### PR TITLE
Remove the iib_arch_image_push_template configuration option

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -15,7 +15,6 @@ class Config(object):
     broker_transport_options = {'max_retries': 10}
     iib_api_timeout = 30
     iib_arch = 'amd64'
-    iib_arch_image_push_template = '{registry}/operator-registry-index:{request_id}-{arch}'
     iib_arches = {'amd64'}
     iib_image_push_template = '{registry}/operator-registry-index:{request_id}'
     iib_log_level = 'INFO'

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -182,7 +182,7 @@ def _get_external_arch_pull_spec(request_id, arch=None, include_transport=False)
     :rtype: str
     """
     conf = get_worker_config()
-    pull_spec = conf['iib_arch_image_push_template'].format(
+    pull_spec = (conf["iib_image_push_template"] + '-{arch}').format(
         registry=conf['iib_registry'], request_id=request_id, arch=arch or conf['iib_arch']
     )
     if include_transport:


### PR DESCRIPTION
Instead, just assume the value of iib_image_push_template with a suffix of `f'-{arch}'`.