### PR TITLE
Store the operator to bundle mapping

### DIFF
--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -7,7 +7,7 @@ from werkzeug.exceptions import Unauthorized
 
 from iib.exceptions import ValidationError
 from iib.web import db
-from iib.web.models import Architecture, Image, Request, RequestState, RequestStateMapping
+from iib.web.models import Architecture, Image, Operator, Request, RequestState, RequestStateMapping
 from iib.web.utils import pagination_metadata, str_to_bool
 from iib.workers.tasks.build import handle_add_request, handle_rm_request
 from iib.workers.tasks.general import failed_request_callback
@@ -133,6 +133,7 @@ def patch_request(request_id):
     valid_keys = {
         'arches',
         'binary_image_resolved',
+        'bundle_mapping',
         'from_index_resolved',
         'index_image',
         'state',
@@ -147,6 +148,13 @@ def patch_request(request_id):
     for key, value in payload.items():
         if key == 'arches':
             Architecture.validate_architecture_json(value)
+        elif key == 'bundle_mapping':
+            exc_msg = f'The "{key}" key must be an object with the values as lists of strings'
+            if not isinstance(value, dict):
+                raise ValidationError(exc_msg)
+            for v in value.values():
+                if not isinstance(v, list) or any(not isinstance(s, str) for s in v):
+                    raise ValidationError(exc_msg)
         elif not value or not isinstance(value, str):
             raise ValidationError(f'The value for "{key}" must be a non-empty string')
 
@@ -177,6 +185,12 @@ def patch_request(request_id):
 
     for arch in payload.get('arches', []):
         request.add_architecture(arch)
+
+    for operator, bundles in payload.get('bundle_mapping', {}).items():
+        operator_img = Operator.get_or_create(operator)
+        for bundle in bundles:
+            bundle_img = Image.get_or_create(bundle)
+            bundle_img.operator = operator_img
 
     db.session.commit()
 

--- a/iib/web/migrations/versions/274ba38408e8_initial_migration.py
+++ b/iib/web/migrations/versions/274ba38408e8_initial_migration.py
@@ -26,7 +26,9 @@ def upgrade():
     op.create_table(
         'image',
         sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('operator_id', sa.Integer(), nullable=True),
         sa.Column('pull_specification', sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(['operator_id'], ['operator.id']),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('pull_specification'),
     )

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -17,7 +17,7 @@ from iib.workers.tasks.legacy import (
     opm_index_export,
     validate_legacy_params_and_config,
 )
-from iib.workers.tasks.utils import run_cmd, skopeo_inspect
+from iib.workers.tasks.utils import get_image_labels, run_cmd, skopeo_inspect
 
 
 __all__ = ['handle_add_request', 'opm_index_add', 'handle_rm_request', 'opm_index_rm']
@@ -416,22 +416,6 @@ def _verify_index_image(resolved_prebuild_from_index, unresolved_from_index):
             'The supplied from_index image changed during the IIB request.'
             ' Please resubmit the request.'
         )
-
-
-def get_image_labels(pull_spec):
-    """
-    Get the labels from the image.
-
-    :param list<str> labels: the labels to get
-    :return: the dictionary of the labels on the image
-    :rtype: dict
-    """
-    if pull_spec.startswith('docker://'):
-        full_pull_spec = pull_spec
-    else:
-        full_pull_spec = f'docker://{pull_spec}'
-    log.debug('Getting the labels from %s', full_pull_spec)
-    return skopeo_inspect(full_pull_spec).get('Labels', {})
 
 
 def get_image_label(pull_spec, label):

--- a/iib/workers/tasks/legacy.py
+++ b/iib/workers/tasks/legacy.py
@@ -11,7 +11,7 @@ from iib.exceptions import IIBError
 from iib.workers.api_utils import set_request_state
 from iib.workers.config import get_worker_config
 
-from iib.workers.tasks.utils import run_cmd, skopeo_inspect
+from iib.workers.tasks.utils import get_image_labels, run_cmd
 
 log = logging.getLogger(__name__)
 
@@ -38,9 +38,9 @@ def get_legacy_support_packages(bundles):
     """
     packages = set()
     for bundle in bundles:
-        skopeo_out = skopeo_inspect(f'docker://{bundle}')
-        if skopeo_out['Labels'].get('com.redhat.delivery.backport', False):
-            packages.add(skopeo_out['Labels']['operators.operatorframework.io.bundle.package.v1'])
+        labels = get_image_labels(bundle)
+        if labels.get('com.redhat.delivery.backport', False):
+            packages.add(labels['operators.operatorframework.io.bundle.package.v1'])
 
     return packages
 

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -11,6 +11,22 @@ from iib.workers.config import get_worker_config
 log = logging.getLogger(__name__)
 
 
+def get_image_labels(pull_spec):
+    """
+    Get the labels from the image.
+
+    :param list<str> labels: the labels to get
+    :return: the dictionary of the labels on the image
+    :rtype: dict
+    """
+    if pull_spec.startswith('docker://'):
+        full_pull_spec = pull_spec
+    else:
+        full_pull_spec = f'docker://{pull_spec}'
+    log.debug('Getting the labels from %s', full_pull_spec)
+    return skopeo_inspect(full_pull_spec).get('Labels', {})
+
+
 def skopeo_inspect(*args, use_creds=False):
     """
     Wrap the ``skopeo inspect`` command.

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -121,15 +121,8 @@ def test_get_image_arches_not_manifest_list(mock_si):
         build._get_image_arches('image:latest')
 
 
-@mock.patch('iib.workers.tasks.build.skopeo_inspect')
-def test_get_image_labels(mock_si):
-    skopeo_rv = {'Labels': {'some_label': 'value'}}
-    mock_si.return_value = skopeo_rv
-    assert build.get_image_labels('some-image:latest') == skopeo_rv['Labels']
-
-
 @pytest.mark.parametrize('label, expected', (('some_label', 'value'), ('not_there', None)))
-@mock.patch('iib.workers.tasks.build.skopeo_inspect')
+@mock.patch('iib.workers.tasks.utils.skopeo_inspect')
 def test_get_image_label(mock_si, label, expected):
     mock_si.return_value = {'Labels': {'some_label': 'value'}}
     assert build.get_image_label('some-image:latest', label) == expected

--- a/tests/test_workers/test_tasks/test_legacy.py
+++ b/tests/test_workers/test_tasks/test_legacy.py
@@ -7,7 +7,7 @@ from iib.exceptions import IIBError
 from iib.workers.tasks import legacy
 
 
-@mock.patch('iib.workers.tasks.legacy.skopeo_inspect')
+@mock.patch('iib.workers.tasks.utils.skopeo_inspect')
 def test_get_legacy_support_packages(mock_skopeo_inspect):
     mock_skopeo_inspect.return_value = {
         'Labels': {

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import logging
+from unittest import mock
+
+import pytest
+
+from iib.exceptions import IIBError
+from iib.workers.tasks import utils
+
+
+@mock.patch('iib.workers.tasks.utils.skopeo_inspect')
+def test_get_image_labels(mock_si):
+    skopeo_rv = {'Labels': {'some_label': 'value'}}
+    mock_si.return_value = skopeo_rv
+    assert utils.get_image_labels('some-image:latest') == skopeo_rv['Labels']
+
+
+@mock.patch('iib.workers.tasks.utils.subprocess.run')
+def test_run_cmd(mock_sub_run):
+    mock_rv = mock.Mock()
+    mock_rv.returncode = 0
+    mock_sub_run.return_value = mock_rv
+
+    utils.run_cmd(['echo', 'hello world'], {'cwd': '/some/path'})
+
+    mock_sub_run.assert_called_once()
+
+
+@pytest.mark.parametrize('exc_msg', (None, 'Houston, we have a problem!'))
+@mock.patch('iib.workers.tasks.utils.subprocess.run')
+def test_run_cmd_failed(mock_sub_run, caplog, exc_msg):
+    # When running tests that involve Flask before this test, the iib.workers loggers
+    # are disabled. This is an ugly workaround.
+    for logger in ('iib.workers', 'iib.workers.tasks', 'iib.workers.tasks.utils'):
+        logging.getLogger(logger).disabled = False
+
+    mock_rv = mock.Mock()
+    mock_rv.returncode = 1
+    mock_rv.stderr = 'some failure'
+    mock_sub_run.return_value = mock_rv
+
+    expected_exc = exc_msg or 'An unexpected error occurred'
+    with pytest.raises(IIBError, match=expected_exc):
+        utils.run_cmd(['echo', 'iib:iibpassword'], exc_msg=exc_msg)
+
+    mock_sub_run.assert_called_once()
+    # Verify that the password is not logged
+    assert '********' in caplog.text
+    assert 'iib:iibpassword' not in caplog.text
+
+
+@pytest.mark.parametrize('use_creds', (True, False))
+@mock.patch('iib.workers.tasks.utils.run_cmd')
+def test_skopeo_inspect(mock_run_cmd, use_creds):
+    mock_run_cmd.return_value = '{"Name": "some-image"}'
+    image = 'docker://some-image:latest'
+    rv = utils.skopeo_inspect(image, use_creds=use_creds)
+    assert rv == {"Name": "some-image"}
+    skopeo_args = mock_run_cmd.call_args[0][0]
+    expected = ['skopeo', 'inspect', image]
+    if use_creds:
+        expected += ['--creds', 'iib:iibpassword']
+
+    assert skopeo_args == expected


### PR DESCRIPTION
This also renames the "operators" key to "removed_operators" on the GET API endpoint to clarify the difference.