### PR TITLE
Add the ability to specify required label values for a bundle

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -19,6 +19,7 @@ class Config(object):
     iib_image_push_template = '{registry}/operator-registry-index:{request_id}'
     iib_log_level = 'INFO'
     iib_poll_api_frequency = 15
+    iib_required_labels = {}
     include = ['iib.workers.tasks.build']
     # The task messages will be acknowledged after the task has been executed,
     # instead of just before
@@ -109,6 +110,9 @@ def validate_celery_config(conf, **kwargs):
 
     if not conf.get('iib_api_url'):
         raise ConfigError('iib_api_url must be set')
+
+    if not isinstance(conf['iib_required_labels'], dict):
+        raise ConfigError('iib_required_labels must be a dictionary')
 
 
 def get_worker_config():

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -39,6 +39,7 @@ def test_validate_celery_config():
             'iib_api_url': 'http://localhost:8080/api/v1/',
             'iib_registry': 'registry',
             'iib_registry_credentials': 'username:password',
+            'iib_required_labels': {},
         }
     )
 
@@ -52,4 +53,15 @@ def test_validate_celery_config_failure(missing_key):
     }
     conf.pop(missing_key)
     with pytest.raises(ConfigError, match=f'{missing_key} must be set'):
+        validate_celery_config(conf)
+
+
+def test_validate_celery_config_iib_required_labels_not_dict():
+    conf = {
+        'iib_api_url': 'http://localhost:8080/api/v1/',
+        'iib_registry': 'registry',
+        'iib_registry_credentials': 'username:password',
+        'iib_required_labels': 123,
+    }
+    with pytest.raises(ConfigError, match='iib_required_labels must be a dictionary'):
         validate_celery_config(conf)


### PR DESCRIPTION
This is configured with the configuration `iib_required_labels`, where each key is an expected label and the value is the expected value of the label.