### PR TITLE
Stop managing authentication to the container registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ When installing the dependencies in a production environment, run
 
 To ensure the pinned dependencies are not vulnerable, this project uses
 [safety](https://github.com/pyupio/safety), which runs on every pull-request.
+
+## Registry Authentication
+
+IIB does not handle authentication with container registries directly. If authentication is needed,
+configure the `~/.docker/config.json` for the user running the IIB worker.
+
+During development, you may choose to add a volume entry of `- /root/.docker:/root/.docker:z` on the
+workers in `docker-compose.yml` so that your host's root user's Docker configuration with
+authentication is used by the workers. This is only needed if you are working with private images.
+Please note that the containers will modify this configuration since they authenticate with the
+registry created by docker-compose on startup.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     - >-
       cp /host-ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt &&
       cat /certs/root_ca.crt >> /etc/pki/tls/certs/ca-bundle.crt &&
+      podman login --authfile ~/.docker/config.json -u iib -p iibpassword registry:8443 &&
       pip3 install watchdog[watchmedo] &&
       watchmedo auto-restart -d ./iib/workers -p '*.py' --recursive \
         -- celery -A iib.workers.tasks worker -Q iib --loglevel=info
@@ -83,6 +84,7 @@ services:
       - /etc/pki/tls/certs/ca-bundle.crt:/host-ca-bundle.crt:ro
     depends_on:
       - rabbitmq
+      - registry
 
   iib-worker-amd64:
     build:
@@ -97,6 +99,7 @@ services:
     - >-
       cp /host-ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt &&
       cat /certs/root_ca.crt >> /etc/pki/tls/certs/ca-bundle.crt &&
+      podman login --authfile ~/.docker/config.json -u iib -p iibpassword registry:8443 &&
       pip3 install watchdog[watchmedo] &&
       watchmedo auto-restart -d ./iib/workers -p '*.py' --recursive \
         -- celery -A iib.workers.tasks worker -Q iib_amd64 --loglevel=info
@@ -110,3 +113,4 @@ services:
       - /etc/pki/tls/certs/ca-bundle.crt:/host-ca-bundle.crt:ro
     depends_on:
       - rabbitmq
+      - registry

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -48,7 +48,6 @@ class DevelopmentConfig(Config):
     iib_api_url = 'http://iib-api:8080/api/v1/'
     iib_log_level = 'DEBUG'
     iib_registry = 'registry:8443'
-    iib_registry_credentials = 'iib:iibpassword'
 
 
 class TestingConfig(DevelopmentConfig):
@@ -102,11 +101,6 @@ def validate_celery_config(conf, **kwargs):
     """
     if not conf.get('iib_registry'):
         raise ConfigError('iib_registry must be set to the destination container registry')
-
-    if not conf.get('iib_registry_credentials'):
-        raise ConfigError(
-            'iib_registry_credentials must be set in the format of "username:password"'
-        )
 
     if not conf.get('iib_api_url'):
         raise ConfigError('iib_api_url must be set')

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -70,7 +70,6 @@ def _create_and_push_manifest_list(request_id, arches):
     :rtype: str
     :raises iib.exceptions.IIBError: if creating or pushing the manifest list fails
     """
-    conf = get_worker_config()
     output_pull_spec = get_rebuilt_index_image(request_id)
     log.info('Creating the manifest list %s', output_pull_spec)
     with tempfile.TemporaryDirectory(prefix='iib-') as temp_dir:
@@ -108,18 +107,8 @@ def _create_and_push_manifest_list(request_id, arches):
                 manifest_yaml_f.read(),
             )
 
-        username, password = conf['iib_registry_credentials'].split(':', 1)
         run_cmd(
-            [
-                'manifest-tool',
-                '--username',
-                username,
-                '--password',
-                password,
-                'push',
-                'from-spec',
-                manifest_yaml,
-            ],
+            ['manifest-tool', 'push', 'from-spec', manifest_yaml],
             exc_msg=f'Failed to push the manifest list to {output_pull_spec}',
         )
 
@@ -395,9 +384,8 @@ def _push_arch_image(request_id):
     source = _get_local_pull_spec(request_id)
     destination = _get_external_arch_pull_spec(request_id, include_transport=True)
     log.info('Pushing the index image %s to %s', source, destination)
-    conf = get_worker_config()
     run_cmd(
-        ['podman', 'push', '-q', source, destination, '--creds', conf['iib_registry_credentials']],
+        ['podman', 'push', '-q', source, destination],
         exc_msg=f'Failed to push the index image to {destination} on the arch {_get_arch()}',
     )
 

--- a/iib/workers/tasks/legacy.py
+++ b/iib/workers/tasks/legacy.py
@@ -58,9 +58,6 @@ def opm_index_export(packages, request_id, rebuilt_index_image, cnr_token, organ
         backported packages should be pushed to.
     :raises iib.exceptions.IIBError: if the export of packages fails.
     """
-    # Login into the registry to be able to access private repositories
-    _podman_login()
-
     with tempfile.TemporaryDirectory(prefix='iib-') as temp_dir:
         for package in packages:
             cmd = [
@@ -89,21 +86,6 @@ def opm_index_export(packages, request_id, rebuilt_index_image, cnr_token, organ
             _push_package_manifest(package_dir, cnr_token, organization)
 
     set_request_state(request_id, 'in_progress', 'Back ported packages successfully pushed to OMPS')
-
-
-def _podman_login():
-    """
-    Login into the registry to be able to access private repos.
-
-    :raises iib.exceptions.IIBError: if the login fails
-    """
-    conf = get_worker_config()
-    log.info('Logging in %s using podman', conf['iib_registry'])
-    username, password = conf['iib_registry_credentials'].split(':')
-    run_cmd(
-        ['podman', 'login', '-u', username, '-p', password, conf['iib_registry']],
-        exc_msg=f'Failed to login into the registry {conf["iib_registry"]}',
-    )
 
 
 def _push_package_manifest(package_dir, cnr_token, organization):

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -38,18 +38,16 @@ def test_validate_celery_config():
         {
             'iib_api_url': 'http://localhost:8080/api/v1/',
             'iib_registry': 'registry',
-            'iib_registry_credentials': 'username:password',
             'iib_required_labels': {},
         }
     )
 
 
-@pytest.mark.parametrize('missing_key', ('iib_api_url', 'iib_registry', 'iib_registry_credentials'))
+@pytest.mark.parametrize('missing_key', ('iib_api_url', 'iib_registry'))
 def test_validate_celery_config_failure(missing_key):
     conf = {
         'iib_api_url': 'http://localhost:8080/api/v1/',
         'iib_registry': 'registry',
-        'iib_registry_credentials': 'username:password',
     }
     conf.pop(missing_key)
     with pytest.raises(ConfigError, match=f'{missing_key} must be set'):

--- a/tests/test_workers/test_tasks/test_legacy.py
+++ b/tests/test_workers/test_tasks/test_legacy.py
@@ -21,16 +21,6 @@ def test_get_legacy_support_packages(mock_skopeo_inspect):
     assert packages == {'prometheus'}
 
 
-@mock.patch('iib.workers.tasks.legacy.run_cmd')
-def test_podman_login(mock_run_cmd):
-    legacy._podman_login()
-
-    mock_run_cmd.assert_called_once()
-    build_args = mock_run_cmd.call_args[0][0]
-    assert build_args[0:2] == ['podman', 'login']
-    assert 'iib' and 'iibpassword' in build_args
-
-
 @mock.patch('os.listdir')
 def test_verify_package_info_missing_pkg(mock_listdir):
     mock_listdir.return_value = ['package.yaml']
@@ -74,13 +64,12 @@ def test_push_package_manifest_failure(mock_requests, mock_open):
     mock_requests.assert_called_once()
 
 
-@mock.patch('iib.workers.tasks.legacy._podman_login')
 @mock.patch('iib.workers.tasks.legacy.run_cmd')
 @mock.patch('iib.workers.tasks.legacy._verify_package_info')
 @mock.patch('iib.workers.tasks.legacy._zip_package')
 @mock.patch('iib.workers.tasks.legacy._push_package_manifest')
 @mock.patch('iib.workers.tasks.legacy.set_request_state')
-def test_opm_index_export(mock_srs, mock_ppm, mock_zp, mock_vpi, mock_run_cmd, mock_pl):
+def test_opm_index_export(mock_srs, mock_ppm, mock_zp, mock_vpi, mock_run_cmd):
     packages = ['prometheus']
     legacy.opm_index_export(packages, 3, 'from:index', 'token', 'org')
 
@@ -89,7 +78,6 @@ def test_opm_index_export(mock_srs, mock_ppm, mock_zp, mock_vpi, mock_run_cmd, m
     opm_args = mock_run_cmd.call_args[0][0]
     assert opm_args[0:3] == ['opm', 'index', 'export']
     assert 'prometheus' in opm_args
-    mock_pl.assert_called_once()
     mock_vpi.assert_called_once()
     mock_zp.assert_called_once()
     mock_ppm.assert_called_once()

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -28,7 +28,7 @@ def test_run_cmd(mock_sub_run):
 
 @pytest.mark.parametrize('exc_msg', (None, 'Houston, we have a problem!'))
 @mock.patch('iib.workers.tasks.utils.subprocess.run')
-def test_run_cmd_failed(mock_sub_run, caplog, exc_msg):
+def test_run_cmd_failed(mock_sub_run, exc_msg):
     # When running tests that involve Flask before this test, the iib.workers loggers
     # are disabled. This is an ugly workaround.
     for logger in ('iib.workers', 'iib.workers.tasks', 'iib.workers.tasks.utils'):
@@ -41,24 +41,17 @@ def test_run_cmd_failed(mock_sub_run, caplog, exc_msg):
 
     expected_exc = exc_msg or 'An unexpected error occurred'
     with pytest.raises(IIBError, match=expected_exc):
-        utils.run_cmd(['echo', 'iib:iibpassword'], exc_msg=exc_msg)
+        utils.run_cmd(['echo', 'hello'], exc_msg=exc_msg)
 
     mock_sub_run.assert_called_once()
-    # Verify that the password is not logged
-    assert '********' in caplog.text
-    assert 'iib:iibpassword' not in caplog.text
 
 
-@pytest.mark.parametrize('use_creds', (True, False))
 @mock.patch('iib.workers.tasks.utils.run_cmd')
-def test_skopeo_inspect(mock_run_cmd, use_creds):
+def test_skopeo_inspect(mock_run_cmd):
     mock_run_cmd.return_value = '{"Name": "some-image"}'
     image = 'docker://some-image:latest'
-    rv = utils.skopeo_inspect(image, use_creds=use_creds)
+    rv = utils.skopeo_inspect(image)
     assert rv == {"Name": "some-image"}
     skopeo_args = mock_run_cmd.call_args[0][0]
     expected = ['skopeo', 'inspect', image]
-    if use_creds:
-        expected += ['--creds', 'iib:iibpassword']
-
     assert skopeo_args == expected


### PR DESCRIPTION
The authentication should be handled by configuring ~/.docker/config.json instead.