### PR TITLE
Allow IIB to specify a different registry to use for the index image

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ The custom configuration options for the Celery workers are listed below:
 * `iib_api_timeout` - the timeout in seconds for HTTP requests to the REST API. This defaults to
   `30` seconds.
 * `iib_api_url` - the URL to the IIB REST API (e.g. `https://iib.domain.local/api/v1/`).
+* `iib_index_image_output_registry` - if set, that value will replace the value from `iib_registry`
+  in the output `index_image` pull specification. This is useful if you'd like users of IIB to
+  pull from a proxy to a registry instead of the registry directly.
 * `iib_image_push_template` - the Python string template of the push destination for the resulting
   manifest list. The available variables are `registry` and `request_id`. The default value is
   `{registry}/iib-build:{request_id}`.

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -13,6 +13,7 @@ class Config(object):
     broker_transport_options = {'max_retries': 10}
     iib_api_timeout = 30
     iib_image_push_template = '{registry}/iib-build:{request_id}'
+    iib_index_image_output_registry = None
     iib_log_level = 'INFO'
     iib_required_labels = {}
     include = ['iib.workers.tasks.build', 'iib.workers.tasks.general']

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -134,9 +134,22 @@ def _finish_request_post_build(output_pull_spec, request_id, arches):
     :param set arches: the set of arches that were built as part of this request
     :raises IIBError: if the manifest list couldn't be created and pushed
     """
+    conf = get_worker_config()
+    if conf['iib_index_image_output_registry']:
+        index_image = output_pull_spec.replace(
+            conf['iib_registry'], conf['iib_index_image_output_registry'], 1
+        )
+        log.info(
+            'Changed the index_image pull specification from %s to %s',
+            output_pull_spec,
+            index_image,
+        )
+    else:
+        index_image = output_pull_spec
+
     payload = {
         'arches': list(arches),
-        'index_image': output_pull_spec,
+        'index_image': index_image,
         'state': 'complete',
         'state_reason': 'The request completed successfully',
     }


### PR DESCRIPTION
This will allow IIB to use the registry directly, but tell users to use the registry proxy. This makes it so that IIB is not reliant on the registry proxy.