### PR TITLE
Add a log statement before calling get_legacy_support_packages

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -536,6 +536,7 @@ def handle_add_request(
     """
     _verify_labels(bundles)
 
+    log.info('Checking if interacting with the legacy app registry is required')
     legacy_support_packages = get_legacy_support_packages(bundles)
     if legacy_support_packages:
         validate_legacy_params_and_config(legacy_support_packages, bundles, cnr_token, organization)

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -112,7 +112,7 @@ def run_cmd(cmd, params=None, exc_msg=None):
     if response.returncode != 0:
         log.error('The command "%s" failed with: %s', ' '.join(cmd), response.stderr)
         if cmd[0] == 'opm':
-            # Caputre the fatal error
+            # Capture the fatal error
             regex = r'^(?:.+level=fatal .*error=")(.+)(?:")$'
             # Start from the last log message since that is often where the failure occurs
             for msg in reversed(response.stderr.splitlines()):


### PR DESCRIPTION
This makes it clear what is going on in the logs. Without this
log message, it can appear that the Celery task was not started
and froze if the connection to the container registry with the
bundles is slow.