### PR TITLE
Avoid using broken Sphinx version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,6 @@ flask-sqlalchemy
 psycopg2-binary
 recommonmark
 requests
-sphinx
+# https://github.com/sphinx-doc/sphinx/issues/2796
+sphinx!=3.0.2
 sphinx_rtd_theme


### PR DESCRIPTION
Sphinx 3.0.2 does not work for Flask applications:
https://github.com/sphinx-doc/sphinx/issues/2796

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>