### PR TITLE
Add the concept of batching requests

### DIFF
--- a/iib/web/migrations/versions/56d96595c0f7_add_batches.py
+++ b/iib/web/migrations/versions/56d96595c0f7_add_batches.py
@@ -1,0 +1,71 @@
+"""
+Add batches for requests.
+
+Revision ID: 56d96595c0f7
+Revises: 5d6808c0ce1f
+Create Date: 2020-04-23 15:52:38.614572
+
+"""
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '56d96595c0f7'
+down_revision = '5d6808c0ce1f'
+branch_labels = None
+depends_on = None
+
+log = logging.getLogger('alembic')
+
+request_table = sa.Table(
+    'request',
+    sa.MetaData(),
+    sa.Column('id', sa.Integer(), primary_key=True),
+    sa.Column('batch_id', sa.Integer()),
+)
+
+batch_table = sa.Table('batch', sa.MetaData(), sa.Column('id', sa.Integer(), primary_key=True))
+
+
+def upgrade():
+    op.create_table(
+        'batch', sa.Column('id', sa.Integer(), nullable=False), sa.PrimaryKeyConstraint('id')
+    )
+
+    with op.batch_alter_table('request') as batch_op:
+        batch_op.add_column(sa.Column('batch_id', sa.Integer(), nullable=True))
+        batch_op.create_index(batch_op.f('ix_request_batch_id'), ['batch_id'], unique=False)
+        batch_op.create_foreign_key('request_batch_id_fk', 'batch', ['batch_id'], ['id'])
+
+    connection = op.get_bind()
+    # Iterate through all the existing requests
+    for request in connection.execute(request_table.select()).fetchall():
+        # Create a new batch per request
+        connection.execute(batch_table.insert())
+        # Get the ID of the last created batch
+        new_batch_id = connection.execute(
+            batch_table.select().order_by(batch_table.c.id.desc()).limit(1)
+        ).scalar()
+        # Set the request's batch as the last created batch
+        log.info('Adding request %d to batch %d', request.id, new_batch_id)
+        connection.execute(
+            request_table.update()
+            .where(request_table.c.id == request.id)
+            .values(batch_id=new_batch_id)
+        )
+
+    # Now that the batches are all set on the requests, make the batch value not nullable
+    with op.batch_alter_table('request') as batch_op:
+        batch_op.alter_column('batch_id', existing_type=sa.INTEGER(), nullable=False)
+
+
+def downgrade():
+    with op.batch_alter_table('request') as batch_op:
+        batch_op.drop_constraint('request_batch_id_fk', type_='foreignkey')
+        batch_op.drop_index(batch_op.f('ix_request_batch_id'))
+        batch_op.drop_column('batch_id')
+
+    op.drop_table('batch')

--- a/iib/web/migrations/versions/5d6808c0ce1f_regenerate_bundle_request.py
+++ b/iib/web/migrations/versions/5d6808c0ce1f_regenerate_bundle_request.py
@@ -52,9 +52,9 @@ def downgrade():
     # there are no records of that type in the database since the data loss is
     # irreversible.
     regenerate_bundle_requests = connection.execute(
-        request_table.select(
-            whereclause=request_table.c.type == REQUEST_TYPE_REGENERATE_BUNDLE
-        ).count()
+        sa.select([sa.func.count()])
+        .select_from(request_table)
+        .where(request_table.c.type == REQUEST_TYPE_REGENERATE_BUNDLE)
     ).scalar()
     if regenerate_bundle_requests:
         raise RuntimeError(

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -13,6 +13,13 @@ paths:
     get:
       description: Return all the IIB build requests
       parameters:
+        - name: batch
+          in: query
+          description: The batch to filter the build requests by
+          schema:
+            type: integer
+            example: 23
+            default: null
         - name: page
           in: query
           description: The specific page to view
@@ -348,6 +355,10 @@ components:
           example:
             - amd64
             - s390x
+        batch:
+          type: integer
+          example: 23
+          description: The batch that the request is a part of
         id:
           type: integer
           example: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,9 @@ def minimal_request_add(db):
     """
     binary_image = models.Image(pull_specification='quay.io/add/binary-image:latest')
     db.session.add(binary_image)
-    request = models.RequestAdd(binary_image=binary_image)
+    batch = models.Batch()
+    db.session.add(batch)
+    request = models.RequestAdd(batch=batch, binary_image=binary_image)
     db.session.add(request)
     db.session.commit()
     return request
@@ -137,8 +139,10 @@ def minimal_request_rm(db):
     db.session.add(from_index_image)
     operator = models.Operator(name='operator')
     db.session.add(operator)
+    batch = models.Batch()
+    db.session.add(batch)
     request = models.RequestRm(
-        binary_image=binary_image, from_index=from_index_image, operators=[operator]
+        batch=batch, binary_image=binary_image, from_index=from_index_image, operators=[operator]
     )
     db.session.add(request)
     db.session.commit()
@@ -159,7 +163,9 @@ def minimal_request_regenerate_bundle(db):
     """
     from_bundle_image = models.Image(pull_specification='quay.io/regen-bundle/bundle-image:latest')
     db.session.add(from_bundle_image)
-    request = models.RequestRegenerateBundle(from_bundle_image=from_bundle_image)
+    batch = models.Batch()
+    db.session.add(batch)
+    request = models.RequestRegenerateBundle(batch=batch, from_bundle_image=from_bundle_image)
     db.session.add(request)
     db.session.commit()
     return request


### PR DESCRIPTION
This introduces the concept of batches in the database and REST API. This paves the way for a future change that will allow a user to submit multiple requests at the same time and keep track of them as a batch.

All existing requests will be individually assigned to a new batch as part of the database migration. All new requests will be individually assigned to a new batch.

A separate commit also fixes a deprecation warning in one of the migration scripts.