### PR TITLE
Fill in spec.relatedImages when regenerating bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,15 @@ The custom configuration options for the Celery workers are listed below:
 In addition to building operator index images, IIB can also be used to regenerate operator bundle
 images. This is useful for applying modifications to the manifests embedded in the bundle image.
 IIB uses the [operator-manifest](https://github.com/containerbuildsystem/operator-manifest) library
-to assist in these modifications. Currently, IIB will pin any container image pull specification
-to its corresponding digest. See the different
+to assist in these modifications.
+
+Currently, IIB will not perform any modifications on a ClusterServiceVersion file if
+[spec.relatedImages](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/operators/index#olm-enabling-operator-for-restricted-network_osdk-generating-csvs)
+is set.
+
+If it's not set, IIB will pin any container image pull specification and set
+[spec.relatedImages](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.3/html-single/operators/index#olm-enabling-operator-for-restricted-network_osdk-generating-csvs).
+See the different
 [pull specifications](https://github.com/containerbuildsystem/operator-manifest#pull-specifications)
 to which this process applies to.
 

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -773,5 +773,7 @@ def _adjust_operator_manifests(manifests_path):
 
     # Apply modifications to the operator bundle image metadata
     for operator_csv in operator_manifest.files:
+        csv_file_name = os.path.basename(operator_csv.path)
+        log.info('Pinning the pull specifications on %s', csv_file_name)
         operator_csv.replace_pullspecs_everywhere(replacement_pullspecs)
         operator_csv.dump()


### PR DESCRIPTION
This also keeps IIB from pinning pull specifications when spec.relatedImages is already set. A request will fail if spec.relatedImages and the RELATED_IMAGE_* environment variables are set in any of containers in the ClusterServiceVersion file.

Resolves CLOUDBLD-524.