### PR TITLE
Overwrite from_index before the OMPS push [CLOUDDST-114]

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -162,7 +162,7 @@ def _update_index_image_pull_spec(
     """
     conf = get_worker_config()
     if from_index and overwrite_from_index:
-        output_message = f'Ovewriting the index image {from_index} with {output_pull_spec}'
+        output_message = f'Overwriting the index image {from_index} with {output_pull_spec}'
         log.info(output_message)
         index_image = from_index
         exc_msg = f'Failed to overwrite the input from_index container image of {index_image}'


### PR DESCRIPTION
Earlier if overwrite_from_index option was specified,
the index image would be overridden after the OMPS push.
Fix this as overriding should happen before and
the OMPS push should get the latest pull spec of the index image.
Also so that the OMPS push can be ignored if index override
raised any errors