### PR TITLE
Add the regenerate-bundle-batch API endpoint

### DIFF
--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -450,6 +450,21 @@ class Batch(db.Model):
         )
         return [RequestStateMapping(request.state.state).name for request in requests]
 
+    @property
+    def user(self):
+        """
+        Get the ``User`` object associated with the batch.
+
+        :return: the ``User`` object associated with the batch or ``None``
+        :rtype: User or None
+        """
+        return (
+            db.session.query(User)
+            .options(joinedload(User.requests).load_only())
+            .filter(Request.batch == self)
+            .first()
+        )
+
     @staticmethod
     def validate_batch(batch_id):
         """
@@ -855,8 +870,15 @@ class RequestRegenerateBundle(Request):
     }
 
     @classmethod
-    def from_json(cls, kwargs):
-        """Handle JSON requests for the Regenerate Bundle API endpoint."""
+    def from_json(cls, kwargs, batch=None):
+        """
+        Handle JSON requests for the Regenerate Bundle API endpoint.
+
+        :param dict kwargs: the JSON payload of the request.
+        :param Batch batch: the batch to specify with the request. If one is not specified, one will
+            be created automatically.
+        """
+        batch = batch or Batch()
         request_kwargs = deepcopy(kwargs)
 
         validate_request_params(
@@ -882,7 +904,6 @@ class RequestRegenerateBundle(Request):
             request_kwargs['user'] = current_user
 
         # Add the request to a new batch
-        batch = Batch()
         db.session.add(batch)
         request_kwargs['batch'] = batch
 

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -61,7 +61,7 @@ paths:
                     items:
                       oneOf:
                         - $ref: '#/components/schemas/RequestIndexImage'
-                        - $ref: '#/components/schemas/RequestRegenerateBundle'
+                        - $ref: '#/components/schemas/RequestRegenerateBundleOutput'
                   meta:
                     $ref: '#/components/schemas/Pagination'
         '400':
@@ -270,7 +270,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestRegenerateBundleVerbose'
+              $ref: '#/components/schemas/RequestRegenerateBundle'
       security:
         - Kerberos Authentication: []
       responses:
@@ -491,7 +491,6 @@ components:
         - operators
     RequestRegenerateBundle:
       allOf:
-        - $ref: '#/components/schemas/Request'
         - type: object
           properties:
             from_bundle_image:
@@ -509,6 +508,19 @@ components:
               example: openshift-operators
           required:
             - from_bundle_image
+    RequestRegenerateBundleOutput:
+      allOf:
+        - $ref: '#/components/schemas/Request'
+        - type: object
+          properties:
+            from_bundle_image:
+              type: string
+              description: The pull specification of the original bundle image that was modified.
+              example: 'quay.io/user/openshift-bundle-example-container:v1'
+            organization:
+              type: string
+              description: The name of the organization the bundle was regenerated for.
+              example: openshift-operators
     RequestUpdate:
       type: object
       properties:
@@ -562,7 +574,7 @@ components:
     RequestRegenerateBundleVerbose:
       allOf:
         - $ref: '#/components/schemas/RequestVerbose'
-        - $ref: '#/components/schemas/RequestRegenerateBundle'
+        - $ref: '#/components/schemas/RequestRegenerateBundleOutput'
     StateHistory:
       type: object
       properties:

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -300,6 +300,49 @@ paths:
                   error:
                     type: string
                     example: You must be authenticated to perform this action
+  /builds/regenerate-bundle-batch:
+    post:
+      description: Submit a batch of build requests to regenerate an operator bundle image
+      requestBody:
+        description: The build requests to create
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/RequestRegenerateBundle'
+      security:
+        - Kerberos Authentication: []
+      responses:
+        '201':
+          description: The build requests were initiated
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RequestRegenerateBundleVerbose'
+        '400':
+          description: The input is invalid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: '"organization" must be a string'
+        '401':
+          description: The user is not allowed to submit a build request with this input
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: You must be authenticated to perform this action
 components:
   schemas:
     BundleMapping:

--- a/tests/test_web/test_models.py
+++ b/tests/test_web/test_models.py
@@ -65,6 +65,13 @@ def test_request_type_validation(type_num, is_valid):
             models.Request(type=type_num)
 
 
+def test_batch_user(db, minimal_request_add):
+    minimal_request_add.user = models.User(username='han_solo@SW.COM')
+    db.session.commit()
+
+    assert minimal_request_add.batch.user.username == 'han_solo@SW.COM'
+
+
 @pytest.mark.parametrize('last_request_state', ('in_progress', 'failed', 'complete'))
 def test_batch_state(last_request_state, db):
     binary_image = models.Image(pull_specification='quay.io/add/binary-image:latest')


### PR DESCRIPTION
This allows a user to submit multiple regenerate-bundle requests as part of a single batch.

Additionally, this fixes the OpenAPI spec for regenerate-bundle and changes messaging.py to use the correct logger.