### PR TITLE
Make message publishing failures nonfatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ to which this process applies to.
 ## Messaging
 
 IIB has support to send messages to an AMQP 1.0 broker. If configured to do so, IIB will send
-messages when a build request state changes and when a batch state changes.
+messages when a build request state changes and when a batch state changes. Please note that if a
+message can't be sent due to an infrastructure issue, the build request will continue as it is not
+considered a fatal error.
 
 The build request state change message body is the JSON representation of the build request in
 the non-verbose format like in the `/builds` API endpoint. The message has the following keys set in

--- a/iib/web/messaging.py
+++ b/iib/web/messaging.py
@@ -195,6 +195,9 @@ def send_messages(envelopes):
     If the IIB configuration ``IIB_MESSAGING_URLS`` is not set, the message will not be sent and
     an error will be logged.
 
+    If the message(s) can't be sent, the exception will be logged but no exception will be raised
+    since this is not considered a fatal error by the application.
+
     :param list envelopes: a list of ``Envelope`` objects representing the messages to send
     """
     conf = current_app.config
@@ -221,6 +224,8 @@ def send_messages(envelopes):
             address_to_sender[envelope.address].send(
                 envelope.message, timeout=conf['IIB_MESSAGING_TIMEOUT']
             )
+    except:  # noqa: E722
+        current_app.logger.exception('Failed to send one or more messages')
     finally:
         if connection:
             connection.close()

--- a/tests/test_web/test_messaging.py
+++ b/tests/test_web/test_messaging.py
@@ -196,6 +196,18 @@ def test_send_messages(mock_gsd, mock_bc, app):
     mock_connection.close.assert_called_once_with()
 
 
+@mock.patch('iib.web.messaging.BlockingConnection')
+@mock.patch('iib.web.messaging._get_ssl_domain')
+def test_send_messages_nonfatal(mock_gsd, mock_bc, app):
+    mock_bc.side_effect = proton.Timeout
+
+    # Verfies that an infrastructure issue is a nonfatal error. If this raises an exception,
+    # the test will fail.
+    messaging.send_messages(
+        [messaging.Envelope('topic://VirtualTopic.eng.star_wars', '{"han": "solo"}')]
+    )
+
+
 @pytest.mark.parametrize('request_msg_expected', (True, False))
 @pytest.mark.parametrize('batch_msg_expected', (True, False))
 @mock.patch('iib.web.messaging._get_request_state_change_envelope')


### PR DESCRIPTION
This is more relevant when considering the changes in PR #78.