### PR TITLE
Support adding annotations to a batch when using the regenerate-bundle-batch API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ the non-verbose format like in the `/builds` API endpoint. The message has the f
 the application properties: `batch`, `id`, `state`, and `user`.
 
 The batch state change message body is a JSON object with the following keys: `batch`,
-`request_ids`, `state`, and `user`. The message has the following keys set in the application
-properties: `batch`, `state`, and `user`.
+`annotations`, `request_ids`, `state`, and `user`. The message has the following keys set in the
+application properties: `batch`, `state`, and `user`.
 
 ## Gating Bundle Images
 

--- a/iib/web/messaging.py
+++ b/iib/web/messaging.py
@@ -105,6 +105,7 @@ def _get_batch_state_change_envelope(batch, new_batch=False):
         batch_username = getattr(batch.user, 'username', None)
         content = {
             'batch': batch.id,
+            'annotations': batch.annotations,
             'request_ids': sorted(batch.request_ids),
             'state': batch_state,
             'user': batch_username,

--- a/iib/web/migrations/versions/71c998c1c210_batch_annotations.py
+++ b/iib/web/migrations/versions/71c998c1c210_batch_annotations.py
@@ -1,0 +1,26 @@
+"""
+Add batch annotations.
+
+Revision ID: 71c998c1c210
+Revises: 56d96595c0f7
+Create Date: 2020-05-07 18:07:20.123669
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '71c998c1c210'
+down_revision = '56d96595c0f7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('batch') as batch_op:
+        batch_op.add_column(sa.Column('annotations', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('batch') as batch_op:
+        batch_op.drop_column('annotations')

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -309,9 +309,12 @@ paths:
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/RequestRegenerateBundle'
+              type: object
+              properties:
+                build_requests:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/RequestRegenerateBundle'
       security:
         - Kerberos Authentication: []
       responses:

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -311,6 +311,11 @@ paths:
             schema:
               type: object
               properties:
+                annotations:
+                  type: object
+                  description: >
+                    An arbitrary JSON object associated with the batch. This is accessed by the
+                    "batch_annotations" key's value on a build request in the batch.
                 build_requests:
                   type: array
                   items:
@@ -629,6 +634,10 @@ components:
         - $ref: '#/components/schemas/Request'
         - type: object
           properties:
+            batch_annotations:
+              type: object
+              description: >
+                An arbitrary JSON object created by the submitter associated with the batch.
             state_history:
               type: array
               items:

--- a/tests/test_web/test_messaging.py
+++ b/tests/test_web/test_messaging.py
@@ -22,9 +22,11 @@ def test_get_batch_state_change_envelope(
 ):
     minimal_request_add.add_state(request_state, 'For some reason')
     db.session.add(minimal_request_add)
+    batch = minimal_request_add.batch
+    annotations = {'Yoda': 'Do or do not. There is no try.'}
+    batch.annotations = annotations
     db.session.commit()
 
-    batch = minimal_request_add.batch
     envelope = messaging._get_batch_state_change_envelope(batch, new_batch=new_batch)
 
     if envelope_expected:
@@ -38,6 +40,7 @@ def test_get_batch_state_change_envelope(
             'user': None,
         }
         assert json.loads(envelope.message.body) == {
+            'annotations': annotations,
             'batch': 1,
             'request_ids': [1],
             'state': request_state,


### PR DESCRIPTION
The first commit changes the regenerate-bundle-batch API endpoint to accept a JSON object instead of an array.

The second commit adds support for setting annotations on a batch when using the regenerate-bundle-batch API endpoint.

Resolves CLOUDBLD-924