### PR TITLE
Add organizations and request types to the batch state change messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,9 @@ the non-verbose format like in the `/builds` API endpoint. The message has the f
 the application properties: `batch`, `id`, `state`, and `user`.
 
 The batch state change message body is a JSON object with the following keys: `annotations`,
-`batch`, `requests`, `request_ids`, `state`, and `user`. The `requests` value is an array of JSON
-objects with the keys `id`, `organization`, and `type`. The message has the following keys set in
-the application properties: `batch`, `state`, and `user`.
+`batch`, `requests`, `state`, and `user`. The `requests` value is an array of JSON objects with the
+keys `id`, `organization`, and `type`. The message has the following keys set in the application
+properties: `batch`, `state`, and `user`.
 
 ## Gating Bundle Images
 

--- a/README.md
+++ b/README.md
@@ -277,9 +277,10 @@ The build request state change message body is the JSON representation of the bu
 the non-verbose format like in the `/builds` API endpoint. The message has the following keys set in
 the application properties: `batch`, `id`, `state`, and `user`.
 
-The batch state change message body is a JSON object with the following keys: `batch`,
-`annotations`, `request_ids`, `state`, and `user`. The message has the following keys set in the
-application properties: `batch`, `state`, and `user`.
+The batch state change message body is a JSON object with the following keys: `annotations`,
+`batch`, `requests`, `request_ids`, `state`, and `user`. The `requests` value is an array of JSON
+objects with the keys `id`, `organization`, and `type`. The message has the following keys set in
+the application properties: `batch`, `state`, and `user`.
 
 ## Gating Bundle Images
 

--- a/iib/web/messaging.py
+++ b/iib/web/messaging.py
@@ -160,6 +160,14 @@ def _get_batch_state_change_envelope(batch, new_batch=False):
         content = {
             'batch': batch.id,
             'annotations': batch.annotations,
+            'requests': [
+                {
+                    'id': request.id,
+                    'organization': getattr(request, 'organization', None),
+                    'type': request.type_name,
+                }
+                for request in batch.requests
+            ],
             'request_ids': sorted(batch.request_ids),
             'state': batch_state,
             'user': batch_username,

--- a/iib/web/messaging.py
+++ b/iib/web/messaging.py
@@ -168,7 +168,6 @@ def _get_batch_state_change_envelope(batch, new_batch=False):
                 }
                 for request in batch.requests
             ],
-            'request_ids': sorted(batch.request_ids),
             'state': batch_state,
             'user': batch_username,
         }

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -476,18 +476,6 @@ class Batch(db.Model):
             return 'complete'
 
     @property
-    def request_ids(self):
-        """
-        Get the IDs of the requests in the batch.
-
-        :return: the set of requests IDs
-        :rtype: set
-        """
-        return {
-            result.id for result in db.session.query(Request.id).filter(Request.batch == self).all()
-        }
-
-    @property
     def request_states(self):
         """
         Get the states of all the requests in the batch.

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -386,6 +386,16 @@ class Request(db.Model):
         """
         return {'arches', 'state', 'state_reason'}
 
+    @property
+    def type_name(self):
+        """
+        Get the request's type as a string.
+
+        :return: the request's type
+        :rtype: str
+        """
+        return RequestTypeMapping.pretty(self.type)
+
 
 class Batch(db.Model):
     """A batch associated with one or more requests."""
@@ -393,7 +403,9 @@ class Batch(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     _annotations = db.Column('annotations', db.Text, nullable=True)
 
-    requests = db.relationship('Request', foreign_keys=[Request.batch_id], back_populates='batch')
+    requests = db.relationship(
+        'Request', foreign_keys=[Request.batch_id], back_populates='batch', order_by='Request.id'
+    )
 
     @property
     def annotations(self):

--- a/tests/test_web/test_messaging.py
+++ b/tests/test_web/test_messaging.py
@@ -56,7 +56,6 @@ def test_get_batch_state_change_envelope(
         assert json.loads(envelope.message.body) == {
             'annotations': annotations,
             'batch': 1,
-            'request_ids': [1, 2, 3],
             'requests': [
                 {'id': 1, 'organization': 'mos-eisley-marketplace', 'type': 'add'},
                 {'id': 2, 'organization': None, 'type': 'rm'},

--- a/tests/test_web/test_models.py
+++ b/tests/test_web/test_models.py
@@ -93,20 +93,6 @@ def test_batch_state(last_request_state, db):
     assert request.batch.state == last_request_state
 
 
-def test_batch_request_ids(db):
-    binary_image = models.Image(pull_specification='quay.io/add/binary-image:latest')
-    db.session.add(binary_image)
-    batch = models.Batch()
-    db.session.add(batch)
-    for i in range(3):
-        request = models.RequestAdd(batch=batch, binary_image=binary_image)
-        db.session.add(request)
-
-    db.session.commit()
-
-    assert request.batch.request_ids == {1, 2, 3}
-
-
 def test_batch_request_states(db):
     binary_image = models.Image(pull_specification='quay.io/add/binary-image:latest')
     db.session.add(binary_image)


### PR DESCRIPTION
This also removes the obsolete `request_ids` array in the batch state change messages.