### PR TITLE
Fix not iterable error in regenerate-bundle

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -1026,7 +1026,7 @@ def _adjust_operator_bundle(manifests_path, metadata_path, organization=None):
             replacement_needed = True
 
         # Always resolve the image to make sure it's valid
-        resolved_image = ImageName.parse(_get_resolved_image(pullspec))
+        resolved_image = ImageName.parse(_get_resolved_image(pullspec.to_str()))
 
         if registry_replacements.get(resolved_image.registry):
             replacement_needed = True

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -942,7 +942,7 @@ def test_adjust_operator_bundle(mock_aca, mock_gri, mock_apns, tmpdir):
             'registry.access.company.com/operator/image:v2': (
                 'registry.access.company.com/operator/image@sha256:654321'
             ),
-        }[image.to_str()]
+        }[image]
 
     mock_gri.side_effect = _get_resolved_image
 


### PR DESCRIPTION
This fixes the following error when running a regenerate-bundle build
request:

    TypeError: argument of type 'ImageName' is not iterable

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>