### PR TITLE
Stop relying on github opm releases

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,3 +1,21 @@
+FROM centos:8 AS builder
+
+RUN dnf -y install \
+    --setopt=deltarpm=0 \
+    --setopt=install_weak_deps=false \
+    --setopt=tsflags=nodocs \
+    git \
+    golang \
+    make \
+    && dnf clean all
+
+ENV OPM_SRC="/src"
+ENV OPM_TAG="v1.12.8"
+
+RUN git clone https://github.com/operator-framework/operator-registry $OPM_SRC && \
+    (cd $OPM_SRC && git checkout $OPM_TAG && make build) && \
+    cp $OPM_SRC/bin/opm /usr/bin/opm
+
 FROM centos:8
 LABEL maintainer="Red Hat - EXD"
 
@@ -17,8 +35,8 @@ RUN dnf -y install \
     python3-pip \
     skopeo \
     && dnf clean all
-ADD https://github.com/operator-framework/operator-registry/releases/download/v1.12.7/linux-amd64-opm /usr/bin/opm
-RUN chmod +x /usr/bin/opm
+
+COPY --from=builder /usr/bin/opm /usr/bin/opm
 ADD https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64 /usr/bin/manifest-tool
 RUN chmod +x /usr/bin/manifest-tool
 COPY . .


### PR DESCRIPTION
The opm developers have requested that IIB no longer use the opm binary
found in the releases page of the project. For development purposes, IIB
now builds its own binary of opm from source.

* CLOUDBLD-1109

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>