### PR TITLE
Added YAML file checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
+---
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: python
 python:
   - "3.6"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  # 100 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 100
+    level: warning

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: '3'
 services:
   registry:
@@ -19,7 +20,7 @@ services:
   db:
     image: postgres:9.6
     environment:
-      POSTGRES_USER:  iib
+      POSTGRES_USER: iib
       POSTGRES_PASSWORD: iib
       POSTGRES_DB: iib
       POSTGRES_INITDB_ARGS: "--auth='ident' --auth='trust'"
@@ -38,18 +39,18 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile-api
     command:
-    - /bin/sh
-    - -c
-    - >-
-      mkdir -p /etc/iib &&
-      cp /broker-certs/client.crt /etc/iib/messaging.crt &&
-      cp /broker-certs/client.key /etc/iib/messaging.key &&
-      cp /broker-certs/ca.crt /etc/iib/messaging-ca.crt &&
-      pip3 uninstall -y iib &&
-      python3 setup.py develop --no-deps &&
-      iib wait-for-db &&
-      iib db upgrade &&
-      flask run --reload --host 0.0.0.0 --port 8080
+      - /bin/sh
+      - -c
+      - >-
+        mkdir -p /etc/iib &&
+        cp /broker-certs/client.crt /etc/iib/messaging.crt &&
+        cp /broker-certs/client.key /etc/iib/messaging.key &&
+        cp /broker-certs/ca.crt /etc/iib/messaging-ca.crt &&
+        pip3 uninstall -y iib &&
+        python3 setup.py develop --no-deps &&
+        iib wait-for-db &&
+        iib db upgrade &&
+        flask run --reload --host 0.0.0.0 --port 8080
     environment:
       FLASK_ENV: development
       FLASK_APP: iib/web/wsgi.py
@@ -72,15 +73,16 @@ services:
     # This also adds the self-signed CA that was used to sign the Docker registry's certificate
     # to the trusted CA bundle. This will make podman trust the local Docker registry's certificate.
     command:
-    - /bin/bash
-    - -c
-    - >-
-      cp /host-ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt &&
-      cat /registry-certs/root_ca.crt >> /etc/pki/tls/certs/ca-bundle.crt &&
-      podman login --authfile ~/.docker/config.json.template -u iib -p iibpassword registry:8443 &&
-      pip3 install watchdog[watchmedo] &&
-      watchmedo auto-restart -d ./iib/workers -p '*.py' --recursive \
-        -- celery -A iib.workers.tasks worker --loglevel=info
+      - /bin/bash
+      - -c
+      - >-
+        cp /host-ca-bundle.crt /etc/pki/tls/certs/ca-bundle.crt &&
+        cat /registry-certs/root_ca.crt >> /etc/pki/tls/certs/ca-bundle.crt &&
+        podman login --authfile ~/.docker/config.json.template -u iib \
+        -p iibpassword registry:8443 &&
+        pip3 install watchdog[watchmedo] &&
+        watchmedo auto-restart -d ./iib/workers -p '*.py' --recursive \
+          -- celery -A iib.workers.tasks worker --loglevel=info
     environment:
       IIB_DEV: 'true'
       REQUESTS_CA_BUNDLE: /etc/pki/tls/certs/ca-bundle.crt

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -1,3 +1,4 @@
+---
 openapi: 3.0.2
 info:
   description: |

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters = true
-envlist = black,docs,flake8,py36,py37,safety
+envlist = black,docs,flake8,py36,py37,safety,yamllint
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
@@ -13,6 +13,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     safety: python3.7
+    yamllint: python3.7
 deps =
     -rrequirements-test.txt
 setenv =
@@ -46,6 +47,14 @@ deps =
     flake8-docstrings==1.5.0
 commands =
     flake8
+
+[testenv:yamllint]
+description = YAML checks [Mandatory]
+skip_install = true
+deps =
+    yamllint==1.24.2
+commands =
+    yamllint .
 
 [testenv:py36]
 description = Python 3.6 unit tests [Mandatory]


### PR DESCRIPTION
This check should prevent failed parsing of api_v1.yaml (and other YAML files) which results to unreachable documentation of IIB.

- Added yamllint check to tox