### PR TITLE
Add support for podman compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,6 @@ dmypy.json
 # IDE
 .vscode/
 
-# docker-compose volumes
-iib_data/
+# docker-compose volumes and files
+/iib_data/
+/ca-bundle.crt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Set the default composer while allowing user to overwrite via the
+# environment variable IIB_COMPOSE_ENGINE.
+IIB_COMPOSE_ENGINE ?= docker-compose
+
+# Declare non-file targets to avoid potential conflict with files
+# of the same name.
+.PHONY: all up test
+
+# Older versions of podman-compose do not support deleting volumes via -v
+COMPOSER_DOWN_OPTS := -v
+COMPOSER_DOWN_HELP := $(shell ${IIB_COMPOSE_ENGINE} down --help)
+ifeq (,$(findstring volume,$(COMPOSER_DOWN_HELP)))
+	COMPOSER_DOWN_OPTS :=
+endif
+
+all:
+	@echo 'Available make targets:'
+	@echo ''
+	@echo 'down:'
+	@echo '  Destroy the local development instance of IIB. By default, this uses docker-compose.'
+	@echo '  Alternatively, set the IIB_COMPOSE_ENGINE environment variable to "podman-compose".'
+	@echo ''
+	@echo 'up:'
+	@echo '  Run a local development instance of IIB. By default, this uses docker-compose.'
+	@echo '  Alternatively, set the IIB_COMPOSE_ENGINE environment variable to "podman-compose".'
+	@echo ''
+	@echo 'test:'
+	@echo '  Execute unit tests and linters. Use the command "tox" directly for more options.'
+
+up: ca-bundle.crt
+	@echo "Starting the local development instance..."
+	${IIB_COMPOSE_ENGINE} up -d
+
+down:
+	@echo "Destroying the local development instance..."
+	${IIB_COMPOSE_ENGINE} down $(COMPOSER_DOWN_OPTS)
+	@rm -rf iib_data
+
+test:
+	@tox
+
+ca-bundle.crt:
+	@cp -f /etc/pki/tls/certs/ca-bundle.crt .

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ development environment. This will automatically run the following containers:
   IIB to publish AMQP 1.0 messages to the Apache ActiveMQ instance at the destinations
   `topic://VirtualTopic.eng.iib.batch.state` and `topic://VirtualTopic.eng.iib.build.state`.
 
+It's recommended to use the wrapper targets in the `Makefile` for pre-requisites. Simply run `make`
+to view available targets.
+
 The Flask application will automatically reload if there is a change in the codebase. If invalid
 syntax is added in the code, the `iib-api` container may shutdown. The Celery worker will
 automatically restart if there is a change under the `iib/workers` directory.
@@ -97,6 +100,11 @@ sudo docker run localhost:8443/iib-build:1
 
 If your development environment requires accessing a private container registry, please read
 the section titled Registry Authentication.
+
+You may also run the development environment with
+[podman-compose](https://github.com/containers/podman-compose). Use the script from the `devel`
+branch as it has various fixes and new features required to run IIB. Set the environment variable
+`IIB_COMPOSE_ENGINE` to the path of the `podman-compose` script before running the `make` commands.
 
 ## Dependency Management
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - ./:/src:z
       - ./iib_data/worker:/var/lib/containers/storage:z
       - ./docker/registry/certs:/registry-certs:ro,z
-      - /etc/pki/tls/certs/ca-bundle.crt:/host-ca-bundle.crt:ro
+      - ./ca-bundle.crt:/host-ca-bundle.crt:ro
       - request-logs-volume:/var/log/iib/requests:z
     depends_on:
       - rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     privileged: true
     volumes:
       - ./:/src:z
-      - ./iib_data/worker:/var/lib/containers/storage:z
+      - worker_container_storage:/var/lib/containers:z
       - ./docker/registry/certs:/registry-certs:ro,z
       - ./ca-bundle.crt:/host-ca-bundle.crt:ro
       - request-logs-volume:/var/log/iib/requests:z
@@ -114,3 +114,4 @@ services:
 volumes:
   message-broker-volume:
   request-logs-volume:
+  worker_container_storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: iib
       RABBITMQ_DEFAULT_PASS: iib
+      # Avoid port conflict with ActiveMQ broker when using podman-compose.
+      # Even though the port is not exposed, podman-compose's use of a pod
+      # requires the ports to be unique across all containers within the pod.
+      RABBITMQ_NODE_PORT: 5673
     ports:
       # The RabbitMQ management console
       - 8081:15672

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -26,7 +26,9 @@ RUN dnf -y install \
     --setopt=deltarpm=0 \
     --setopt=install_weak_deps=false \
     --setopt=tsflags=nodocs \
+    /etc/containers/storage.conf \
     buildah \
+    fuse-overlayfs \
     gcc \
     krb5-devel \
     https://kojipkgs.fedoraproject.org/packages/podman/1.7.0/3.fc30/x86_64/podman-1.7.0-3.fc30.x86_64.rpm \
@@ -41,6 +43,11 @@ ADD https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-to
 ADD https://github.com/fullstorydev/grpcurl/releases/download/v1.7.0/grpcurl_1.7.0_linux_x86_64.tar.gz /src/grpcurl_1.7.0_linux_x86_64.tar.gz
 RUN cd /usr/bin && tar -xf /src/grpcurl_1.7.0_linux_x86_64.tar.gz grpcurl && rm -f /src/grpcurl_1.7.0_linux_x86_64.tar.gz
 RUN chmod +x /usr/bin/manifest-tool
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' /etc/containers/storage.conf
+COPY docker/libpod.conf /usr/share/containers/libpod.conf
+
 COPY . .
 RUN pip3 install -r requirements.txt --no-deps --require-hashes
 RUN pip3 install . --no-deps

--- a/docker/libpod.conf
+++ b/docker/libpod.conf
@@ -1,0 +1,1 @@
+runtime = "runc"

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -59,7 +59,7 @@ class ProductionConfig(Config):
 class DevelopmentConfig(Config):
     """The development IIB Celery configuration."""
 
-    broker_url = 'amqp://iib:iib@rabbitmq:5672//'
+    broker_url = 'amqp://iib:iib@rabbitmq:5673//'
     iib_api_url = 'http://iib-api:8080/api/v1/'
     iib_log_level = 'DEBUG'
     iib_organization_customizations = {


### PR DESCRIPTION
This is rough draft of what it takes to run IIB with podman.

I managed to make this work on fedora 31 by using my fork of podman-compose on the branch super-duper, https://github.com/lcarva/podman-compose/tree/super-duper. This fork has a few different things that improve the experience drastically (PRs have been created for each commit):

- Add support for `down -v` so volumes are removed.
- Create non-existing binding volumes.

But more importantly, it's based on the devel branch of podman-compose which contains a lot of fixes not found in the rpm distribution.

The changes in this PR are the bare minimum to work with podman-compose. Each commit, hopefully, explain why the change is needed.

If this is something we want to pursue further, we can probably create a `Makefile` to handle the copy of the system ca bundle while starting up the docker/podman-compose.