### PR TITLE
Return the OMPS-pushed version when IIB backports a bundle

### DIFF
--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -25,6 +25,7 @@ from iib.web.models import (
     RequestState,
     RequestStateMapping,
     get_request_query_options,
+    RequestTypeMapping,
 )
 from iib.web.utils import pagination_metadata, str_to_bool
 from iib.workers.tasks.build import (
@@ -351,6 +352,17 @@ def patch_request(request_id):
         else:
             request.add_state(new_state, new_state_reason)
             state_updated = True
+
+    if 'omps_operator_version' in payload:
+        # `omps_operator_version` is defined in RequestAdd only
+        if request.type == RequestTypeMapping.add.value:
+            request_add = RequestAdd.query.get(request_id)
+            request_add.omps_operator_version = payload.get('omps_operator_version')
+        else:
+            raise ValidationError(
+                f'Request {request_id} is type of "{RequestTypeMapping.pretty(request.type)}" '
+                f'request and does not support setting "omps_operator_version"'
+            )
 
     image_keys = (
         'binary_image_resolved',

--- a/iib/web/migrations/versions/2ab3d4558cb6_add_omps_operator_version.py
+++ b/iib/web/migrations/versions/2ab3d4558cb6_add_omps_operator_version.py
@@ -1,0 +1,28 @@
+"""Extending RequestAdd for omps_operator_version.
+
+Revision ID: 2ab3d4558cb6
+Revises: 71c998c1c210
+Create Date: 2020-09-01 13:19:32.267607
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2ab3d4558cb6'
+down_revision = '71c998c1c210'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    with op.batch_alter_table('request_add', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('omps_operator_version', sa.String(), nullable=True))
+
+
+def downgrade():
+
+    with op.batch_alter_table('request_add', schema=None) as batch_op:
+        batch_op.drop_column('omps_operator_version')

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -788,6 +788,8 @@ class RequestAdd(Request, RequestIndexImageMixin):
     bundles = db.relationship('Image', secondary=RequestAddBundle.__table__)
     organization = db.Column(db.String, nullable=True)
 
+    omps_operator_version = db.Column(db.String, nullable=True)
+
     __mapper_args__ = {
         'polymorphic_identity': RequestTypeMapping.__members__['add'].value,
     }
@@ -860,6 +862,9 @@ class RequestAdd(Request, RequestIndexImageMixin):
         rv = super().to_json(verbose=verbose)
         rv.update(self.get_common_index_image_json())
         rv['organization'] = self.organization
+        rv['omps_operator_version'] = {}
+        if self.omps_operator_version:
+            rv['omps_operator_version'] = json.loads(self.omps_operator_version)
 
         for bundle in self.bundles:
             if bundle.operator:
@@ -879,7 +884,7 @@ class RequestAdd(Request, RequestIndexImageMixin):
         """
         rv = super().get_mutable_keys()
         rv.update(self.get_index_image_mutable_keys())
-        rv.update({'bundles', 'bundle_mapping'})
+        rv.update({'bundles', 'bundle_mapping', 'omps_operator_version'})
         return rv
 
 

--- a/iib/workers/api_utils.py
+++ b/iib/workers/api_utils.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import json
 import logging
 
 import requests
@@ -86,6 +87,28 @@ def set_request_state(request_id, state, state_reason):
     )
     payload = {'state': state, 'state_reason': state_reason}
     exc_msg = 'Setting the state to "{state}" on request {request_id} failed'
+    return update_request(request_id, payload, exc_msg=exc_msg)
+
+
+def set_omps_operator_version(request_id, omps_operator_version):
+    """
+    Set the set_omps_operator_version of the request using the IIB API.
+
+    :param int request_id: the ID of the IIB request
+    :param dict omps_operator_version: the state to set the IIB request to
+    :return: the updated request
+    :rtype: dict
+    :raise IIBError: if the request to the IIB API fails
+    """
+    omps_operator_version_json = json.dumps(omps_operator_version)
+    log.info(
+        'Setting the omps_operator_version of request %d to "%s"',
+        request_id,
+        omps_operator_version_json,
+    )
+    payload = {'omps_operator_version': omps_operator_version_json}
+    exc_msg = 'Setting the omps_operator_version to "{omps_operator_version}" failed'
+
     return update_request(request_id, payload, exc_msg=exc_msg)
 
 

--- a/tests/test_web/test_api_v1.py
+++ b/tests/test_web/test_api_v1.py
@@ -53,6 +53,7 @@ def test_get_build(app, auth_env, client, db):
             'url': 'http://localhost/api/v1/builds/1/logs',
             'expiration': '2020-02-15T17:03:00Z',
         },
+        'omps_operator_version': {},
         'organization': None,
         'removed_operators': [],
         'request_type': 'add',
@@ -504,6 +505,7 @@ def test_add_bundle_success(
             'url': 'http://localhost/api/v1/builds/1/logs',
             'expiration': '2020-02-15T17:03:00Z',
         },
+        'omps_operator_version': {},
         'organization': 'org',
         'state_history': [
             {
@@ -847,6 +849,7 @@ def test_patch_request_add_success(mock_smfsc, db, minimal_request_add, worker_a
             'url': 'http://localhost/api/v1/builds/1/logs',
             'expiration': '2020-02-15T17:03:00Z',
         },
+        'omps_operator_version': {},
         'organization': None,
         'removed_operators': [],
         'request_type': 'add',

--- a/tests/test_workers/test_api_utils.py
+++ b/tests/test_workers/test_api_utils.py
@@ -41,7 +41,19 @@ def test_set_request_state(mock_update_request):
     api_utils.set_request_state(3, state, state_reason)
 
     mock_update_request.assert_called_once()
-    mock_update_request.call_args[0][1] == {'state': state, 'state_reason': state_reason}
+    assert mock_update_request.call_args[0][1] == {'state': state, 'state_reason': state_reason}
+
+
+@mock.patch('iib.workers.api_utils.requests_auth_session')
+def test_set_omps_operator_version(mock_session):
+    omps_operator_version = {'operator': '1.0.0'}
+    api_utils.set_omps_operator_version(3, omps_operator_version)
+
+    mock_session.patch.assert_called_once_with(
+        'http://iib-api:8080/api/v1/builds/3',
+        json={'omps_operator_version': '{"operator": "1.0.0"}'},
+        timeout=30,
+    )
 
 
 @mock.patch('iib.workers.api_utils.requests_auth_session')

--- a/tests/test_workers/test_tasks/test_legacy.py
+++ b/tests/test_workers/test_tasks/test_legacy.py
@@ -127,10 +127,38 @@ def test_opm_index_export(mock_run_cmd):
 @mock.patch('iib.workers.tasks.legacy._verify_package_info')
 @mock.patch('iib.workers.tasks.legacy._zip_package')
 @mock.patch('iib.workers.tasks.legacy._push_package_manifest')
+@mock.patch('iib.workers.tasks.legacy.set_omps_operator_version')
 @mock.patch('iib.workers.tasks.legacy.set_request_state')
 @mock.patch('iib.workers.tasks.legacy._opm_index_export')
-def test_export_legacy_packages(mock_oie, mock_srs, mock_ppm, mock_zp, mock_vpi):
-    packages = ['prometheus']
+def test_export_legacy_packages(mock_oie, mock_srs, mock_soov, mock_ppm, mock_zp, mock_vpi):
+
+    mock_ppm.return_value = {
+        'extracted_files': [
+            '1.1.1/backup.crd.yaml',
+            '1.1.1/backupstoragelocation.crd.yaml',
+            '1.1.1/deletebackuprequest.crd.yaml',
+            '1.1.1/downloadrequest.crd.yaml',
+            '1.1.1/mig-operator.v1.1.1.clusterserviceversion.yaml',
+            '1.1.1/migcluster.crd.yaml',
+            '1.1.1/migmigration.crd.yaml',
+            '1.1.1/migplan.crd.yaml',
+            '1.1.1/migrationcontroller.crd.yaml',
+            '1.1.1/migstorage.crd.yaml',
+            '1.1.1/podvolumebackup.crd.yaml',
+            '1.1.1/podvolumerestore.crd.yaml',
+            '1.1.1/resticrepository.crd.yaml',
+            '1.1.1/restore.crd.yaml',
+            '1.1.1/schedule.crd.yaml',
+            '1.1.1/serverstatusrequest.crd.yaml',
+            '1.1.1/volumesnapshotlocation.crd.yaml',
+            'package.yaml',
+        ],
+        'organization': 'redhat-operators-devtest',
+        'repo': 'lgallett-bundle',
+        'version': '37.0.0',
+    }
+
+    packages = {'lgallett-bundle'}
     legacy.export_legacy_packages(packages, 3, 'from:index', 'token', 'org')
 
     mock_oie.assert_called_once()
@@ -138,6 +166,7 @@ def test_export_legacy_packages(mock_oie, mock_srs, mock_ppm, mock_zp, mock_vpi)
     mock_zp.assert_called_once()
     mock_ppm.assert_called_once()
     mock_srs.assert_called_once()
+    mock_soov.assert_called_once_with(3, {'lgallett-bundle': '37.0.0'})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- log response from OMPS API for every successful request
- collecting operator version for all packages
- updated patch_request function to process request with omps_operator_version
- adding propagating of OMPS response to _get_base_dir_and_pkg_name
- adding omps_operator_version to RequestAdd database table model
- added set_omps_operator_version; set the set_omps_operator_version of the request using the IIB API.
- added call of set_omps_operator_version after collecting all versions

For more information refer to [CLOUDDST-2201]