### PR TITLE
Revert "Adding ability to update binary image of index image from the Add bundle command

### DIFF
--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -66,7 +66,7 @@ def _get_add_args(payload, request_id, overwrite_from_index, celery_queue):
     :param str celery_queue: name of celery queue
     """
     return [
-        payload.get('bundles', []),
+        payload['bundles'],
         payload['binary_image'],
         request_id,
         payload.get('from_index'),

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -803,23 +803,12 @@ class RequestAdd(Request, RequestIndexImageMixin):
         request_kwargs = deepcopy(kwargs)
 
         bundles = request_kwargs.get('bundles', [])
-        if not isinstance(bundles, list) or any(
-            not item or not isinstance(item, str) for item in bundles
+        if (
+            not isinstance(bundles, list)
+            or len(bundles) == 0
+            or any(not item or not isinstance(item, str) for item in bundles)
         ):
-            raise ValidationError(
-                '"bundles" should be either an empty array or an array of non-empty strings'
-            )
-
-        # Check if no bundles `from_index and `binary_image` are specified
-        # if no bundles and and no from index then a empty index will be created
-        # if no binary image and just a from_index then we are not updating anything and it would
-        # be a no-op
-        if not request_kwargs.get('bundles') and (
-            not request_kwargs.get('from_index') or not request_kwargs.get('binary_image')
-        ):
-            raise ValidationError(
-                '"from_index" and "binary_image" must be specified if no bundles are specified'
-            )
+            raise ValidationError(f'"bundles" should be a non-empty array of strings')
 
         for param in ('cnr_token', 'organization'):
             if param not in request_kwargs:
@@ -837,7 +826,8 @@ class RequestAdd(Request, RequestIndexImageMixin):
 
         cls._from_json(
             request_kwargs,
-            additional_optional_params=['from_index', 'organization', 'bundles'],
+            additional_required_params=['bundles'],
+            additional_optional_params=['from_index', 'organization'],
             batch=batch,
         )
 

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -370,14 +370,13 @@ def _opm_index_add(
     """
     # The bundles are not resolved since these are stable tags, and references
     # to a bundle image using a digest fails when using the opm command.
-    bundle_str = ','.join(bundles) or "''"
     cmd = [
         'opm',
         'index',
         'add',
         '--generate',
         '--bundles',
-        bundle_str,
+        ','.join(bundles),
         '--binary-image',
         binary_image,
     ]

--- a/tests/test_web/test_api_v1.py
+++ b/tests/test_web/test_api_v1.py
@@ -230,6 +230,15 @@ def test_get_build_logs_not_configured(client, db, minimal_request_add):
         ),
         (
             {
+                'bundles': [],
+                'from_index': 'pull:spec',
+                'binary_image': 'binary:img',
+                'add_arches': ['s390x'],
+            },
+            '"bundles" should be a non-empty array of strings',
+        ),
+        (
+            {
                 'bundles': ['some:thing'],
                 'from_index': 32,
                 'binary_image': 'binary:image',
@@ -362,20 +371,12 @@ def test_rm_operators_overwrite_not_allowed(mock_smfsc, client, db):
     'data, error_msg',
     (
         (
+            {'from_index': 'pull:spec', 'binary_image': 'binary:image', 'add_arches': ['s390x']},
+            '"bundles" should be a non-empty array of strings',
+        ),
+        (
             {'bundles': ['some:thing'], 'from_index': 'pull:spec', 'add_arches': ['s390x']},
             'Missing required parameter(s): binary_image',
-        ),
-        (
-            {'from_index': 'pull:spec', 'add_arches': ['s390x']},
-            '"from_index" and "binary_image" must be specified if no bundles are specified',
-        ),
-        (
-            {'add_arches': ['s390x'], 'binary_image': 'binary:image'},
-            '"from_index" and "binary_image" must be specified if no bundles are specified',
-        ),
-        (
-            {'add_arches': ['s390x']},
-            '"from_index" and "binary_image" must be specified if no bundles are specified',
         ),
         (
             {
@@ -460,30 +461,18 @@ def test_add_bundle_from_index_and_add_arches_missing(mock_smfsc, db, auth_env, 
     mock_smfsc.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    ('overwrite_from_index', 'bundles', 'from_index'),
-    (
-        (False, ['some:thing'], None),
-        (False, [], 'some:thing'),
-        (True, ['some:thing'], 'some:thing'),
-        (True, [], 'some:thing'),
-    ),
-)
+@pytest.mark.parametrize('overwrite_from_index', (False, True))
 @mock.patch('iib.web.api_v1.handle_add_request')
 @mock.patch('iib.web.api_v1.messaging.send_message_for_state_change')
-def test_add_bundle_success(
-    mock_smfsc, mock_har, overwrite_from_index, db, auth_env, client, bundles, from_index,
-):
+def test_add_bundle_success(mock_smfsc, mock_har, overwrite_from_index, db, auth_env, client):
     data = {
+        'bundles': ['some:thing'],
         'binary_image': 'binary:image',
         'add_arches': ['s390x'],
         'organization': 'org',
         'cnr_token': 'token',
         'overwrite_from_index': overwrite_from_index,
-        'from_index': from_index,
     }
-    if bundles:
-        data['bundles'] = bundles
 
     response_json = {
         'arches': [],
@@ -492,8 +481,8 @@ def test_add_bundle_success(
         'binary_image': 'binary:image',
         'binary_image_resolved': None,
         'bundle_mapping': {},
-        'bundles': bundles,
-        'from_index': from_index,
+        'bundles': ['some:thing'],
+        'from_index': None,
         'from_index_resolved': None,
         'id': 1,
         'index_image': None,


### PR DESCRIPTION
This reverts commit d2f44775b899a31329d7a50da0ca562c9e0c1cca.

OPM does not like the parameter `--bundles ''`. It fails with:
```
time="2020-09-11T12:57:51-04:00" level=error msg="permissive mode disabled" bundles="['']" error="error resolving name : object required"
Error: error resolving name : object required
```