### PR TITLE
Don't perform index image verification when overwrite_from_index is False

### DIFF
--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -17,7 +17,6 @@ from iib.workers.tasks.build import (
     _push_image,
     _update_index_image_build_state,
     _update_index_image_pull_spec,
-    _verify_index_image,
 )
 from iib.workers.tasks.celery import app
 from iib.workers.tasks.utils import request_logger, run_cmd, set_registry_token
@@ -266,15 +265,6 @@ def handle_merge_request(
             _build_image(temp_dir, 'index.Dockerfile', request_id, arch)
             _push_image(request_id, arch)
 
-    _verify_index_image(
-        prebuild_info['source_from_index_resolved'], source_from_index, overwrite_target_index_token
-    )
-
-    if target_index:
-        _verify_index_image(
-            prebuild_info['target_index_resolved'], target_index, overwrite_target_index_token
-        )
-
     output_pull_spec = _create_and_push_manifest_list(request_id, prebuild_info['arches'])
     _update_index_image_pull_spec(
         output_pull_spec,
@@ -283,6 +273,7 @@ def handle_merge_request(
         target_index,
         overwrite_target_index,
         overwrite_target_index_token,
+        prebuild_info['target_index_resolved'],
     )
     set_request_state(
         request_id, 'complete', 'The index image was successfully cleaned and updated.'

--- a/tests/test_workers/test_tasks/test_build_merge_index_image.py
+++ b/tests/test_workers/test_tasks/test_build_merge_index_image.py
@@ -15,7 +15,7 @@ from iib.workers.tasks import build_merge_index_image
     ),
 )
 @mock.patch('iib.workers.tasks.build_merge_index_image._update_index_image_pull_spec')
-@mock.patch('iib.workers.tasks.build_merge_index_image._verify_index_image')
+@mock.patch('iib.workers.tasks.build._verify_index_image')
 @mock.patch('iib.workers.tasks.build_merge_index_image._create_and_push_manifest_list')
 @mock.patch('iib.workers.tasks.build_merge_index_image._push_image')
 @mock.patch('iib.workers.tasks.build_merge_index_image._build_image')
@@ -84,10 +84,9 @@ def test_handle_merge_request(
     mock_uiibs.assert_called_once_with(1, prebuild_info)
     if target_index:
         assert mock_gpb.call_count == 2
-        assert mock_vii.call_count == 2
     else:
         assert mock_gpb.call_count == 1
-        assert mock_vii.call_count == 1
+    mock_vii.assert_not_called()
     mock_abmis.assert_called_once()
     mock_gbfdl.assert_called_once()
     mock_geaps.assert_called_once()
@@ -99,7 +98,7 @@ def test_handle_merge_request(
 
 
 @mock.patch('iib.workers.tasks.build_merge_index_image._update_index_image_pull_spec')
-@mock.patch('iib.workers.tasks.build_merge_index_image._verify_index_image')
+@mock.patch('iib.workers.tasks.build._verify_index_image')
 @mock.patch('iib.workers.tasks.build_merge_index_image._create_and_push_manifest_list')
 @mock.patch('iib.workers.tasks.build_merge_index_image._push_image')
 @mock.patch('iib.workers.tasks.build_merge_index_image._build_image')
@@ -168,7 +167,7 @@ def test_handle_merge_request_no_deprecate(
     assert mock_dep_b.call_count == 0
     assert mock_bi.call_count == 2
     assert mock_pi.call_count == 2
-    assert mock_vii.call_count == 2
+    mock_vii.assert_not_called()
     mock_capml.assert_called_once()
     mock_uiips.assert_called_once()
 


### PR DESCRIPTION
There is no risk of data loss when IIB doesn't overwrite the original index image. Thus, to prevent unnecessary failures, this check is disabled when overwrite_from_index is False.

More info in CLOUDDST-2783