### PR TITLE
Add IIB_BINARY_IMAGE_CONFIG to IIB and make binary_image param optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ The custom configuration options for the REST API are listed below:
 
 * `IIB_ADDITIONAL_LOGGERS` - a list of Python loggers that should have the same log level that is
   set for `IIB_LOG_LEVEL`. This defaults to `[]`.
+* `IIB_BINARY_IMAGE_CONFIG` - the mapping, `dict(<str>: dict(<str>:<str>))`, of distribution scope
+  to another dictionary mapping ocp_version label to a binary image pull specification.
+  This is useful in setting up customized binary image for different index image images thus
+  reducing complexity for the end user. This defaults to `{}`.
 * `IIB_FORCE_OVERWRITE_FROM_INDEX` - a boolean that determines if privileged users should be forced
   to have `overwrite_from_index` set to `True`. This defaults to `False`.
 * `IIB_GREENWAVE_CONFIG` - the mapping, `dict(<str>: dict(<str>:<str>))`, of celery task queues to

--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -50,13 +50,14 @@ def _get_rm_args(payload, request, overwrite_from_index):
     """
     return [
         payload['operators'],
-        payload['binary_image'],
         request.id,
         payload['from_index'],
+        payload.get('binary_image'),
         payload.get('add_arches'),
         overwrite_from_index,
         payload.get('overwrite_from_index_token'),
         request.distribution_scope,
+        flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
     ]
 
 
@@ -71,8 +72,8 @@ def _get_add_args(payload, request, overwrite_from_index, celery_queue):
     """
     return [
         payload.get('bundles', []),
-        payload['binary_image'],
         request.id,
+        payload.get('binary_image'),
         payload.get('from_index'),
         payload.get('add_arches'),
         payload.get('cnr_token'),
@@ -82,6 +83,7 @@ def _get_add_args(payload, request, overwrite_from_index, celery_queue):
         payload.get('overwrite_from_index_token'),
         request.distribution_scope,
         flask.current_app.config['IIB_GREENWAVE_CONFIG'].get(celery_queue),
+        flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
     ]
 
 
@@ -371,6 +373,7 @@ def patch_request(request_id):
             )
 
     image_keys = (
+        'binary_image',
         'binary_image_resolved',
         'bundle_image',
         'from_bundle_image_resolved',
@@ -654,14 +657,15 @@ def merge_index_image():
     overwrite_target_index = payload.get('overwrite_target_index', False)
     celery_queue = _get_user_queue(serial=overwrite_target_index)
     args = [
-        payload['binary_image'],
         payload['source_from_index'],
         payload.get('deprecation_list', []),
         request.id,
+        payload.get('binary_image'),
         payload.get('target_index'),
         overwrite_target_index,
         payload.get('overwrite_target_index_token'),
         payload.get('distribution_scope'),
+        flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
     ]
     safe_args = _get_safe_args(args, payload)
 

--- a/iib/web/app.py
+++ b/iib/web/app.py
@@ -81,6 +81,31 @@ def validate_api_config(config):
                     f'{queue_name} in "IIB_GREENWAVE_CONFIG"'
                 )
 
+    if config['IIB_BINARY_IMAGE_CONFIG']:
+        if not isinstance(config['IIB_BINARY_IMAGE_CONFIG'], dict):
+            raise ConfigError(
+                'IIB_BINARY_IMAGE_CONFIG must be a dict mapping distribution_scope to '
+                'another dict mapping ocp_version to binary_image'
+            )
+        for distribution_scope, value_dict in config['IIB_BINARY_IMAGE_CONFIG'].items():
+            if not isinstance(distribution_scope, str) or distribution_scope not in (
+                'dev',
+                'stage',
+                'prod',
+            ):
+                raise ConfigError(
+                    'distribution_scope values must be one of the following'
+                    ' "prod", "stage" or "dev" strings.'
+                )
+            if not isinstance(value_dict, dict):
+                raise ConfigError(
+                    'Value for distribution_scope keys must be a dict mapping'
+                    ' ocp_version to binary_image'
+                )
+            for ocp_version, binary_image_value in value_dict.items():
+                if not isinstance(ocp_version, str) or not isinstance(binary_image_value, str):
+                    raise ConfigError('All ocp_version and binary_image values must be strings.')
+
 
 # See app factory pattern:
 #   http://flask.pocoo.org/docs/0.12/patterns/appfactories/

--- a/iib/web/config.py
+++ b/iib/web/config.py
@@ -10,6 +10,7 @@ class Config(object):
 
     # Additional loggers to set to the level defined in IIB_LOG_LEVEL
     IIB_ADDITIONAL_LOGGERS = []
+    IIB_BINARY_IMAGE_CONFIG = {}
     IIB_FORCE_OVERWRITE_FROM_INDEX = False
     IIB_GREENWAVE_CONFIG = {}
     IIB_LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s %(module)s.%(funcName)s %(message)s'

--- a/iib/web/migrations/versions/60f89c046096_make_binary_image_optional.py
+++ b/iib/web/migrations/versions/60f89c046096_make_binary_image_optional.py
@@ -1,0 +1,38 @@
+"""Make binary_image optional.
+
+Revision ID: 60f89c046096
+Revises: 983a81fe5e98
+Create Date: 2020-10-12 15:49:24.523019
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '60f89c046096'
+down_revision = '983a81fe5e98'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('request_add', schema=None) as batch_op:
+        batch_op.alter_column('binary_image_id', existing_type=sa.INTEGER(), nullable=True)
+
+    with op.batch_alter_table('request_merge_index_image', schema=None) as batch_op:
+        batch_op.alter_column('binary_image_id', existing_type=sa.INTEGER(), nullable=True)
+
+    with op.batch_alter_table('request_rm', schema=None) as batch_op:
+        batch_op.alter_column('binary_image_id', existing_type=sa.INTEGER(), nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table('request_rm', schema=None) as batch_op:
+        batch_op.alter_column('binary_image_id', existing_type=sa.INTEGER(), nullable=False)
+
+    with op.batch_alter_table('request_merge_index_image', schema=None) as batch_op:
+        batch_op.alter_column('binary_image_id', existing_type=sa.INTEGER(), nullable=False)
+
+    with op.batch_alter_table('request_add', schema=None) as batch_op:
+        batch_op.alter_column('binary_image_id', existing_type=sa.INTEGER(), nullable=False)

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -700,7 +700,6 @@ components:
             type: string
             example: 'prod'
       required:
-        - binary_image
         - bundles
     RequestRemove:
       type: object
@@ -744,7 +743,6 @@ components:
           type: string
           example: 'prod'
       required:
-        - binary_image
         - from_index
         - operators
     RequestRegenerateBundle:
@@ -814,7 +812,6 @@ components:
           type: string
           example: 'prod'
       required:
-        - binary_image
         - source_from_index
     RequestMergeIndexImageOutput:
       allOf:

--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -175,26 +175,27 @@ def _deprecate_bundles(
 @app.task
 @request_logger
 def handle_merge_request(
-    binary_image,
     source_from_index,
     deprecation_list,
     request_id,
+    binary_image=None,
     target_index=None,
     overwrite_target_index=False,
     overwrite_target_index_token=None,
     distribution_scope=None,
+    binary_image_config=None,
 ):
     """
     Coordinate the work needed to merge old (N) index image with new (N+1) index image.
 
-    :param str binary_image: the pull specification of the container image where the opm binary
-        gets copied from.
     :param str source_from_index: pull specification to be used as the base for building the new
         index image.
     :param str target_index: pull specification of content stage index image for the
         corresponding target index image.
     :param list deprecation_list: list of deprecated bundles for the target index image.
     :param int request_id: the ID of the IIB build request.
+    :param str binary_image: the pull specification of the container image where the opm binary
+        gets copied from.
     :param bool overwrite_target_index: if True, overwrite the input ``target_index`` with
         the built index image.
     :param str overwrite_target_index_token: the token used for overwriting the input
@@ -206,12 +207,13 @@ def handle_merge_request(
     """
     _cleanup()
     prebuild_info = _prepare_request_for_build(
-        binary_image,
         request_id,
+        binary_image,
         overwrite_from_index_token=overwrite_target_index_token,
         source_from_index=source_from_index,
         target_index=target_index,
         distribution_scope=distribution_scope,
+        binary_image_config=binary_image_config,
     )
     _update_index_image_build_state(request_id, prebuild_info)
 
@@ -232,7 +234,7 @@ def handle_merge_request(
             source_index_bundles,
             target_index_bundles,
             temp_dir,
-            binary_image,
+            prebuild_info['binary_image'],
             source_from_index,
             request_id,
             arch,
@@ -255,7 +257,7 @@ def handle_merge_request(
             _deprecate_bundles(
                 deprecate_bundles,
                 temp_dir,
-                binary_image,
+                prebuild_info['binary_image'],
                 intermediate_image_name,
                 overwrite_target_index_token,
             )

--- a/tests/test_web/test_app.py
+++ b/tests/test_web/test_app.py
@@ -92,3 +92,38 @@ def test_load_config_prod(mock_isfile, mock_getenv):
 def test_validate_api_config_failure_greenwave_params(config, error_msg):
     with pytest.raises(ConfigError, match=error_msg):
         validate_api_config(config)
+
+
+@pytest.mark.parametrize(
+    'config, error_msg',
+    (
+        (
+            {'IIB_BINARY_IMAGE_CONFIG': {'tom-brady': {}}, 'IIB_GREENWAVE_CONFIG': {}},
+            (
+                'distribution_scope values must be one of the following'
+                ' "prod", "stage" or "dev" strings.'
+            ),
+        ),
+        (
+            {'IIB_BINARY_IMAGE_CONFIG': {'prod': []}, 'IIB_GREENWAVE_CONFIG': {}},
+            (
+                'Value for distribution_scope keys must be a dict mapping'
+                ' ocp_version to binary_image'
+            ),
+        ),
+        (
+            {'IIB_BINARY_IMAGE_CONFIG': {'prod': {'v4.5': 2}}, 'IIB_GREENWAVE_CONFIG': {}},
+            'All ocp_version and binary_image values must be strings.',
+        ),
+        (
+            {'IIB_BINARY_IMAGE_CONFIG': ['something'], 'IIB_GREENWAVE_CONFIG': {}},
+            (
+                'IIB_BINARY_IMAGE_CONFIG must be a dict mapping distribution_scope to '
+                'another dict mapping ocp_version to binary_image'
+            ),
+        ),
+    ),
+)
+def test_validate_api_config_failure_binary_image_params(config, error_msg):
+    with pytest.raises(ConfigError, match=error_msg):
+        validate_api_config(config)


### PR DESCRIPTION
This commit introduces a new config variable called IIB_BINARY_IMAGE_CONFIG
which when specified, doesn't require the user to specify binary_image param
while submitting requests to IIB.

Refers to CLOUDDST-2761