### PR TITLE
Fix broken regeneration of YAML CSV

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -37,6 +37,11 @@ from iib.workers.tasks.utils import (
 __all__ = ['handle_add_request', 'handle_regenerate_bundle_request', 'handle_rm_request']
 
 yaml = ruamel.yaml.YAML()
+# IMPORTANT: ruamel will introduce a line break if the yaml line is longer than yaml.width.
+# Unfortunately, this causes issues for JSON values nested within a YAML file, e.g.
+# metadata.annotations."alm-examples" in a CSV file.
+# The default value is 80. Set it to a more forgiving higher number to avoid issues
+yaml.width = 200
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
ruamel will introduce a line break if the yaml line is longer than
yaml.width.  Unfortunately, this causes issues for JSON values nested
within a YAML file, e.g.  metadata.annotations."alm-examples" in a CSV
file.  The default value is 80. Set it to a more forgivinng higher
number to avoid issues

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>