### PR TITLE
Fix _opm_index_add map overwrite_from_index_token [CLOUDDST-5026]

### DIFF
--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -109,7 +109,10 @@ def _add_bundles_missing_in_source(
         )
 
     _opm_index_add(
-        base_dir, missing_bundle_paths, binary_image, overwrite_target_index_token,
+        base_dir,
+        missing_bundle_paths,
+        binary_image,
+        overwrite_from_index_token=overwrite_target_index_token,
     )
     _add_label_to_index(
         'com.redhat.index.delivery.version', ocp_version, base_dir, 'index.Dockerfile'

--- a/tests/test_workers/test_tasks/test_build_merge_index_image.py
+++ b/tests/test_workers/test_tasks/test_build_merge_index_image.py
@@ -262,7 +262,7 @@ def test_add_bundles_missing_in_source(
             'quay.io/bundle2@sha256:456132',
         ],
         'binary-image:4.5',
-        None,
+        overwrite_from_index_token=None,
     )
     assert mock_gil.call_count == 5
     assert mock_aolti.call_count == 2
@@ -441,7 +441,7 @@ def test_add_bundles_missing_in_source_none_missing(
         'some_dir',
         ['quay.io/bundle3@sha256:123456', 'quay.io/bundle4@sha256:123456'],
         'binary-image:4.5',
-        None,
+        overwrite_from_index_token=None,
     )
     assert mock_gil.call_count == 4
     assert mock_aolti.call_count == 2


### PR DESCRIPTION
* return  `source_from_index` paramater to `_opm_index_add` function