### PR TITLE
Stop setting content-encoding on AMQP messages

### DIFF
--- a/iib/web/messaging.py
+++ b/iib/web/messaging.py
@@ -244,7 +244,6 @@ def json_to_envelope(address, content, properties=None):
     """
     message = proton.Message(body=json.dumps(content), properties=properties)
     message.id = str(uuid.uuid4())
-    message.content_encoding = 'utf-8'
     message.content_type = 'application/json'
     message.durable = current_app.config['IIB_MESSAGING_DURABLE']
     return Envelope(address, message)

--- a/tests/test_web/test_messaging.py
+++ b/tests/test_web/test_messaging.py
@@ -173,7 +173,6 @@ def test_json_to_envelope(mock_current_app, durable):
     # Verify that the ID is a UUID
     assert len(envelope.message.id) == 36
     assert envelope.message.body == '{"han": "solo"}'
-    assert envelope.message.content_encoding == 'utf-8'
     assert envelope.message.content_type == 'application/json'
     assert envelope.message.durable is durable
 


### PR DESCRIPTION
This was errantly set as the value should be like the
HTTP Content-Encoding header:

* http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-properties
* https://www.iana.org/assignments/http-parameters/http-parameters.xml