### PR TITLE
Fix skopeo verification of bundle image to retry when mediattype is none

### DIFF
--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -473,6 +473,14 @@ def test_get_resolved_bundles_failure(mock_si):
         utils.get_resolved_bundles(['some_bundle@some_sha'])
 
 
+@mock.patch('iib.workers.tasks.utils.run_cmd')
+def test_rasise_exception_on_none_mediatype_skopeo_inspect(mock_run_cmd):
+    mock_run_cmd.return_value = '{"Name": "some-image"}'
+    image = 'docker://some-image:latest'
+    with pytest.raises(IIBError, match='mediaType not found'):
+        utils.skopeo_inspect(image, '--raw', require_media_type=True)
+
+
 @pytest.mark.parametrize(
     'pull_spec, expected',
     (


### PR DESCRIPTION
Sometimes, skopeo inspect cmd succeeds but returns mediaType as none.
This is to retry the cmd for 3 times when this happens to ensure mediaType is retrieved and the bundle is resolved.

CLOUDDST-4590 