### PR TITLE
Use podman container-tool when merging indexes

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -462,6 +462,7 @@ def _opm_index_add(
     from_index=None,
     overwrite_from_index_token=None,
     overwrite_csv=False,
+    container_tool=None,
 ):
     """
     Add the input bundles to an operator index.
@@ -480,6 +481,7 @@ def _opm_index_add(
         ``overwrite_from_index``. The format of the token must be in the format "user:password".
     :param bool overwrite_csv: a boolean determining if a bundle will be replaced if the CSV
         already exists.
+    :param str container_tool: the container tool to be used to operate on the index image
     :raises IIBError: if the ``opm index add`` command fails.
     """
     # The bundles are not resolved since these are stable tags, and references
@@ -495,6 +497,9 @@ def _opm_index_add(
         '--binary-image',
         binary_image,
     ]
+    if container_tool:
+        cmd.append('--container-tool')
+        cmd.append(container_tool)
 
     log.info('Generating the database file with the following bundle(s): %s', ', '.join(bundles))
     if from_index:

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -200,11 +200,18 @@ def test_get_image_label(mock_si, label, expected):
 @pytest.mark.parametrize('from_index', (None, 'some_index:latest'))
 @pytest.mark.parametrize('bundles', (['bundle:1.2', 'bundle:1.3'], []))
 @pytest.mark.parametrize('overwrite_csv', (True, False))
+@pytest.mark.parametrize('container_tool', (None, 'podwoman'))
 @mock.patch('iib.workers.tasks.build.set_registry_token')
 @mock.patch('iib.workers.tasks.build.run_cmd')
-def test_opm_index_add(mock_run_cmd, mock_srt, from_index, bundles, overwrite_csv):
+def test_opm_index_add(mock_run_cmd, mock_srt, from_index, bundles, overwrite_csv, container_tool):
     build._opm_index_add(
-        '/tmp/somedir', bundles, 'binary-image:latest', from_index, 'user:pass', overwrite_csv
+        '/tmp/somedir',
+        bundles,
+        'binary-image:latest',
+        from_index,
+        'user:pass',
+        overwrite_csv,
+        container_tool=container_tool,
     )
 
     mock_run_cmd.assert_called_once()
@@ -223,6 +230,11 @@ def test_opm_index_add(mock_run_cmd, mock_srt, from_index, bundles, overwrite_cs
         assert '--overwrite-latest' in opm_args
     else:
         assert '--overwrite-latest' not in opm_args
+    if container_tool:
+        assert '--container-tool' in opm_args
+        assert container_tool in opm_args
+    else:
+        assert '--container-tool' not in opm_args
 
     mock_srt.assert_called_once_with('user:pass', from_index)
 


### PR DESCRIPTION
opm has a built-in mechanism for interacting with container image. This
is the default. However, when adding large amount of bundle image to an
index image, opm's built-in mechanism does not handle availability
hiccups in the registry hosting the bundle images:
https://bugzilla.redhat.com/show_bug.cgi?id=1937097

In fact, we have not been able to run a merge index operation
successfully when adding a couple of hundred bundle images to the index.
Some of the indexes managed by IIB have double this amount.

By setting container-tool to podman when adding images during a merge
operation, we drastically improve the resiliency of this operation.

* CLOUDBLD-4658

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>