### PR TITLE
Add support for substitutes-for

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -44,7 +44,6 @@ FROM centos:8
 LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src
-# Install podman 1.7.0 from Fedora 30 as a workaround for
 # https://bugzilla.redhat.com/show_bug.cgi?id=1801874
 RUN dnf -y install \
     --setopt=deltarpm=0 \

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -26,7 +26,7 @@ RUN dnf -y install \
     && dnf clean all
 
 ENV OPM_SRC="/src"
-ENV OPM_TAG="v1.16.1"
+ENV OPM_TAG="v1.17.0"
 
 RUN git clone https://github.com/operator-framework/operator-registry $OPM_SRC && \
     (cd $OPM_SRC && git checkout $OPM_TAG && make build) && \

--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -309,7 +309,9 @@ def add_bundles():
     if not isinstance(payload, dict):
         raise ValidationError('The input data must be a JSON object')
 
-    if 'bundles' in payload and payload['bundles']:
+    # Only run `_get_unique_bundles` if it is a list. If it's not, `from_json`
+    # will raise an error to the user.
+    if payload.get('bundles') and isinstance(payload['bundles'], list):
         payload['bundles'] = _get_unique_bundles(payload['bundles'])
 
     request = RequestAdd.from_json(payload)

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -503,6 +503,9 @@ def _opm_index_add(
         'opm',
         'index',
         'add',
+        # This enables substitutes-for functionality for rebuilds. See
+        # https://github.com/operator-framework/enhancements/blob/master/enhancements/substitutes-for.md
+        '--enable-alpha',
         '--generate',
         '--bundles',
         bundle_str,

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -235,6 +235,7 @@ def test_opm_index_add(mock_run_cmd, mock_srt, from_index, bundles, overwrite_cs
         assert container_tool in opm_args
     else:
         assert '--container-tool' not in opm_args
+    assert "--enable-alpha" in opm_args
 
     mock_srt.assert_called_once_with('user:pass', from_index)
 


### PR DESCRIPTION
In opm 1.17.0, the substitutes-for functionality was added:
https://github.com/operator-framework/enhancements/blob/master/enhancements/substitutes-for.md

This adds support for this. Note that the "--enable-alpha" flag
just enables this new functionality and nothing else.

In addition, I added a few small commits that fixed issues I encountered when spinning up docker-compose. I can split them out in a separate PR if you'd like.