### PR TITLE
Remove the support of privileged users

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,6 @@ The custom configuration options for the REST API are listed below:
   to another dictionary mapping ocp_version label to a binary image pull specification.
   This is useful in setting up customized binary image for different index image images thus
   reducing complexity for the end user. This defaults to `{}`.
-* `IIB_FORCE_OVERWRITE_FROM_INDEX` - a boolean that determines if privileged users should be forced
-  to have `overwrite_from_index` set to `True`. This defaults to `False`.
 * `IIB_GREENWAVE_CONFIG` - the mapping, `dict(<str>: dict(<str>:<str>))`, of celery task queues to
   another dictionary of [Greenwave](https://docs.pagure.org/greenwave/) query parameters to their
   values. This is useful in setting up customized gating for each queue. This defaults to `{}`. Use
@@ -165,8 +163,6 @@ The custom configuration options for the REST API are listed below:
 * `IIB_LOG_LEVEL` - the Python log level of the REST API (Flask). This defaults to `INFO`.
 * `IIB_MAX_PER_PAGE` - the maximum number of build requests that can be shown on a single page.
   This defaults to `20`.
-* `IIB_PRIVILEGED_USERNAMES` - the list of users that can perform privileged actions such
-  as overwriting the input index image with the built index image. This defaults to `[]`.
 * `IIB_REQUEST_LOGS_DIR` - the directory to load the request specific log files. If `None`, per
   request log files information will not appear in the API response. This defaults to `None`.
 * `IIB_REQUEST_LOGS_DAYS_TO_LIVE` - the amount of days after which per request logs are considered

--- a/iib/web/config.py
+++ b/iib/web/config.py
@@ -11,7 +11,6 @@ class Config(object):
     # Additional loggers to set to the level defined in IIB_LOG_LEVEL
     IIB_ADDITIONAL_LOGGERS = []
     IIB_BINARY_IMAGE_CONFIG = {}
-    IIB_FORCE_OVERWRITE_FROM_INDEX = False
     IIB_GREENWAVE_CONFIG = {}
     IIB_LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s %(module)s.%(funcName)s %(message)s'
     # This sets the level of the "flask.app" logger, which is accessed from current_app.logger
@@ -22,7 +21,6 @@ class Config(object):
     IIB_MESSAGING_DURABLE = True
     IIB_MESSAGING_KEY = '/etc/iib/messaging.key'
     IIB_MESSAGING_TIMEOUT = 30
-    IIB_PRIVILEGED_USERNAMES = []
     IIB_REQUEST_LOGS_DIR = None
     IIB_REQUEST_LOGS_DAYS_TO_LIVE = 3
     IIB_USER_TO_QUEUE = {}
@@ -53,7 +51,6 @@ class TestingConfig(DevelopmentConfig):
     """The testing IIB Flask configuration."""
 
     DEBUG = True
-    IIB_PRIVILEGED_USERNAMES = ['tbrady@DOMAIN.LOCAL']
     IIB_WORKER_USERNAMES = ['worker@DOMAIN.LOCAL']
     # IMPORTANT: don't use in-memory sqlite. Alembic migrations will create a new
     # connection producing a new instance of the database which is deleted immediately

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -776,11 +776,9 @@ class RequestIndexImageMixin:
         # Verify the user is authorized to use overwrite_from_index
         # current_user.is_authenticated is only ever False when auth is disabled
         if current_user.is_authenticated:
-            privileged_users = current_app.config['IIB_PRIVILEGED_USERNAMES']
-            if overwrite and not overwrite_token and current_user.username not in privileged_users:
+            if overwrite and not overwrite_token:
                 raise Forbidden(
-                    'You must be a privileged user to set "overwrite_from_index" without'
-                    ' setting "overwrite_from_index_token"'
+                    'You must set "overwrite_from_index_token" to use "overwrite_from_index"'
                 )
 
         # Validate add_arches are correctly provided

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -742,15 +742,13 @@ components:
           type: boolean
           description: >
             Overwrites the input from_index image with the built index image. This can only be
-            performed by privileged users unless overwrite_from_index_token is also provided.
+            performed when overwrite_from_index_token is provided.
           default: false
         overwrite_from_index_token:
           type: string
           description: >
             The token used for reading and overwriting the input from_index image. This is required
-            for non-privileged users to use overwrite_from_index. It's also useful for dealing with
-            index images that IIB does not have access to. The format of the token is in the format
-            "user:password".
+            to use overwrite_from_index. The format of the token is in the format "user:password".
           example: token
         distribution_scope:
           description: >
@@ -796,14 +794,13 @@ components:
           type: boolean
           description: >
             Overwrites the input from_index image with the built index image. This can only be
-            performed by privileged users unless overwrite_from_index_token is also provided.
+            performed when overwrite_from_index_token is provided.
           default: false
         overwrite_from_index_token:
           type: string
           description: >
-            The token used for overwriting the input from_index image. This is required for
-            non-privileged users to use overwrite_from_index. The format of the token must be in
-            the format "user:password".
+            The token used for reading and overwriting the input from_index image. This is required
+            to use overwrite_from_index. The format of the token is in the format "user:password".
           example: token
         distribution_scope:
           description: >
@@ -902,16 +899,15 @@ components:
           type: boolean
           description: >
             Overwrites the input target_index image with the built index image. This can only
-            be performed by privileged users unless overwrite_target_index_token is also provided.
+            be performed when overwrite_target_index_token is provided.
           default: false
         overwrite_target_index_token:
           type: string
           description: >
             The token used for reading and overwriting the input target_index image. This is
-            required for non-privileged users to use overwrite_target_index. It's also useful for
-            dealing with index images that IIB does not have access to. The format of the token is
-            in the format "user:password". If token is required for accessing the index images,
-            then both of them have to be in the same repository.
+            required to use overwrite_target_index. The format of the token is in the format
+            "user:password". If token is required for accessing the index images, then both of
+            them have to be in the same repository.
           example: token
         distribution_scope:
           description: >

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -456,8 +456,8 @@ def _opm_index_add(
     :param str from_index: the pull specification of the container image containing the index that
         the index image build will be based from.
     :param str overwrite_from_index_token: the token used for overwriting the input
-        ``from_index`` image. This is required for non-privileged users to use
-        ``overwrite_from_index``. The format of the token must be in the format "user:password".
+        ``from_index`` image. This is required to use ``overwrite_from_index``.
+        The format of the token must be in the format "user:password".
     :param bool overwrite_csv: a boolean determining if a bundle will be replaced if the CSV
         already exists.
     :param str container_tool: the container tool to be used to operate on the index image
@@ -513,8 +513,8 @@ def _opm_index_rm(base_dir, operators, binary_image, from_index, overwrite_from_
     :param str from_index: the pull specification of the container image containing the index that
         the index image build will be based from.
     :param str overwrite_from_index_token: the token used for overwriting the input
-        ``from_index`` image. This is required for non-privileged users to use
-        ``overwrite_from_index``. The format of the token must be in the format "user:password".
+        ``from_index`` image. This is required to use ``overwrite_from_index``.
+        The format of the token must be in the format "user:password".
     :raises IIBError: if the ``opm index rm`` command fails.
     """
     cmd = [
@@ -706,8 +706,8 @@ def _verify_index_image(
     :param str resolved_prebuild_from_index: resolved index image before starting the build
     :param str unresolved_from_index: unresolved index image provided as API input
     :param str overwrite_from_index_token: the token used for overwriting the input
-        ``from_index`` image. This is required for non-privileged users to use
-        ``overwrite_from_index``. The format of the token must be in the format "user:password".
+        ``from_index`` image. This is required to use ``overwrite_from_index``.
+        The format of the token must be in the format "user:password".
     :raises IIBError: if the index image has changed since IIB build started.
     """
     with set_registry_token(overwrite_from_index_token, unresolved_from_index):
@@ -759,8 +759,8 @@ def handle_add_request(
     :param bool overwrite_from_index: if True, overwrite the input ``from_index`` with the built
         index image.
     :param str overwrite_from_index_token: the token used for overwriting the input
-        ``from_index`` image. This is required for non-privileged users to use
-        ``overwrite_from_index``. The format of the token must be in the format "user:password".
+        ``from_index`` image. This is required to use ``overwrite_from_index``.
+        The format of the token must be in the format "user:password".
     :param str distribution_scope: the scope for distribution of the index image, defaults to
         ``None``.
     :param dict greenwave_config: the dict of config required to query Greenwave to gate bundles.
@@ -939,8 +939,8 @@ def handle_rm_request(
     :param bool overwrite_from_index: if True, overwrite the input ``from_index`` with the built
         index image.
     :param str overwrite_from_index_token: the token used for overwriting the input
-        ``from_index`` image. This is required for non-privileged users to use
-        ``overwrite_from_index``. The format of the token must be in the format "user:password".
+        ``from_index`` image. This is required to use ``overwrite_from_index``.
+        The format of the token must be in the format "user:password".
     :param str distribution_scope: the scope for distribution of the index image, defaults to
         ``None``.
     :param dict binary_image_config: the dict of config required to identify the appropriate

--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -63,8 +63,8 @@ def _add_bundles_missing_in_source(
     :param str arch: the architecture to build this image for.
     :param str ocp_version: ocp version which will be added as a label to the image.
     :param str overwrite_target_index_token: the token used for overwriting the input
-        ``source_from_index`` image. This is required for non-privileged users to use
-        ``overwrite_target_index``. The format of the token must be in the format "user:password".
+        ``source_from_index`` image. This is required to use ``overwrite_target_index``.
+        The format of the token must be in the format "user:password".
     :return: bundles which were added to the index image.
     :rtype: list
     """
@@ -165,8 +165,8 @@ def handle_merge_request(
     :param bool overwrite_target_index: if True, overwrite the input ``target_index`` with
         the built index image.
     :param str overwrite_target_index_token: the token used for overwriting the input
-        ``target_index`` image. This is required for non-privileged users to use
-        ``overwrite_target_index``. The format of the token must be in the format "user:password".
+        ``target_index`` image. This is required to use ``overwrite_target_index``.
+        The format of the token must be in the format "user:password".
     :param str distribution_scope: the scope for distribution of the index image, defaults to
         ``None``.
     :raises IIBError: if the index image merge fails.

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -167,8 +167,8 @@ def deprecate_bundles(
     :param str binary_image: binary image to be used by the new index image.
     :param str from_index: index image, from which the bundles will be deprecated.
     :param str overwrite_target_index_token: the token used for overwriting the input
-        ``from_index`` image. This is required for non-privileged users to use
-        ``overwrite_target_index``. The format of the token must be in the format "user:password".
+        ``from_index`` image. This is required to use ``overwrite_target_index``.
+        The format of the token must be in the format "user:password".
     :param str container_tool: the container tool to be used to operate on the index image
     """
     cmd = [

--- a/tests/test_web/test_broker_error.py
+++ b/tests/test_web/test_broker_error.py
@@ -26,6 +26,7 @@ def test_catch_add_bundle_failure(mock_smfsc, mock_har, db, auth_env, client):
         'organization': 'org',
         'cnr_token': 'token',
         'overwrite_from_index': True,
+        'overwrite_from_index_token': 'some_token',
     }
 
     rv = client.post('/api/v1/builds/add', json=data, environ_base=auth_env)


### PR DESCRIPTION
For all users, overwriting index image is only allowed when overwrite_from_index/overwrite_target_index is True and overwrite_from_index_token/overwrite_target_index_token is set.