### PR TITLE
New attribute 'build_tags' for index_image operations

### DIFF
--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -60,6 +60,7 @@ def _get_rm_args(payload, request, overwrite_from_index):
         payload.get('overwrite_from_index_token'),
         request.distribution_scope,
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
+        payload.get('build_tags', []),
     ]
 
 
@@ -87,6 +88,7 @@ def _get_add_args(payload, request, overwrite_from_index, celery_queue):
         flask.current_app.config['IIB_GREENWAVE_CONFIG'].get(celery_queue),
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
         payload.get('deprecation_list', []),
+        payload.get('build_tags', []),
     ]
 
 
@@ -743,6 +745,7 @@ def merge_index_image():
         payload.get('overwrite_target_index_token'),
         request.distribution_scope,
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
+        payload.get('build_tags', []),
     ]
     safe_args = _get_safe_args(args, payload)
 

--- a/iib/web/migrations/versions/5188702409d9_extra_build_tags.py
+++ b/iib/web/migrations/versions/5188702409d9_extra_build_tags.py
@@ -1,0 +1,54 @@
+"""Added BuildTag and RequestBuildTag.
+
+Revision ID: 5188702409d9
+Revises: e16a8cd2e028
+Create Date: 2021-09-29 12:19:11.632047
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5188702409d9'
+down_revision = 'e16a8cd2e028'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'build_tag',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'request_build_tag',
+        sa.Column('request_id', sa.Integer(), nullable=False),
+        sa.Column('tag_id', sa.Integer(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(['request_id'], ['request.id'],),
+        sa.ForeignKeyConstraint(['tag_id'], ['build_tag.id'],),
+        sa.PrimaryKeyConstraint('request_id', 'tag_id'),
+        sa.UniqueConstraint('request_id', 'tag_id'),
+    )
+    with op.batch_alter_table('request_build_tag', schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f('ix_request_build_tag_request_id'), ['request_id'], unique=False
+        )
+        batch_op.create_index(batch_op.f('ix_request_build_tag_tag_id'), ['tag_id'], unique=False)
+
+    with op.batch_alter_table('request_create_empty_index', schema=None) as batch_op:
+        batch_op.alter_column('from_index_id', existing_type=sa.INTEGER(), nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table('request_create_empty_index', schema=None) as batch_op:
+        batch_op.alter_column('from_index_id', existing_type=sa.INTEGER(), nullable=False)
+
+    with op.batch_alter_table('request_build_tag', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_request_build_tag_tag_id'))
+        batch_op.drop_index(batch_op.f('ix_request_build_tag_request_id'))
+
+    op.drop_table('request_build_tag')
+    op.drop_table('build_tag')

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -775,6 +775,13 @@ components:
                 type: string
               example:
                 - prometheus-operator
+            build_tags:
+              description: >
+                Extra tags applied to intermediate index image
+              type: array
+              items:
+                type: string
+              example: ["v4.5-10-08-2021"]
     AddRequest:
       type: object
       properties:
@@ -847,6 +854,13 @@ components:
               This will determine what level of protection the addition will have.
           type: string
           example: 'prod'
+        build_tags:
+          description: >
+              Extra tags applied to intermediate index image
+          type: array
+          items:
+            type: string
+          example: ["v4.5-10-08-2021"]
       required:
         - bundles
     AddResponse:
@@ -899,6 +913,13 @@ components:
                 This will determine what level of protection the removal will have.
           type: string
           example: 'prod'
+        build_tags:
+          description: >
+              Extra tags applied to intermediate index image
+          type: array
+          items:
+            type: string
+          example: ["v4.5-10-08-2021"]
       required:
         - from_index
         - operators
@@ -1020,6 +1041,13 @@ components:
               This will determine what level of protection the addition will have.
           type: string
           example: 'prod'
+        build_tags:
+          description: >
+              Extra tags applied to intermediate index image
+          type: array
+          items:
+            type: string
+          example: ["v4.5-10-08-2021"]
       required:
         - source_from_index
     MergeIndexImageResponse:
@@ -1087,6 +1115,13 @@ components:
             type: string
           example:
             version: 'v4.6'
+        build_tags:
+          description: >
+              Extra tags applied to intermediate index image
+          type: array
+          items:
+            type: string
+          example: ["v4.5-10-08-2021"]
       required:
         - from_index
     ResponseCreateEmptyIndex:
@@ -1123,6 +1158,13 @@ components:
             request_type:
               type: string
               example: "create-empty-index"
+            build_tags:
+              description: >
+                Extra tags applied to intermediate index image
+              type: array
+              items:
+                type: string
+              example: ["v4.5-10-08-2021"]
     RequestUpdate:
       type: object
       properties:

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -106,54 +106,69 @@ def _cleanup():
 
 
 @retry(exceptions=IIBError, tries=get_worker_config().iib_total_attempts, logger=log)
-def _create_and_push_manifest_list(request_id, arches):
+def _create_and_push_manifest_list(request_id, arches, build_tags):
     """
     Create and push the manifest list to the configured registry.
 
     :param int request_id: the ID of the IIB build request
     :param iter arches: an iterable of arches to create the manifest list for
+    :param build_tags: list of extra tag to use for intermediate index image
     :return: the pull specification of the manifest list
     :rtype: str
     :raises IIBError: if creating or pushing the manifest list fails
     """
     buildah_manifest_cmd = ['buildah', 'manifest']
-    output_pull_spec = get_rebuilt_image_pull_spec(request_id)
+    output_pull_specs = [get_rebuilt_image_pull_spec(request_id)]
+    _tags = [request_id]
+    if build_tags:
+        _tags += build_tags
+    conf = get_worker_config()
+    for tag in _tags:
+        for output_pull_spec in output_pull_specs:
+            output_pull_spec = conf['iib_image_push_template'].format(
+                registry=conf['iib_registry'], request_id=tag
+            )
+            try:
+                run_cmd(
+                    buildah_manifest_cmd + ['rm', output_pull_spec],
+                    exc_msg=f'Failed to remove local manifest list. {output_pull_spec} does not exist',
+                )
+            except IIBError as e:
+                error_msg = str(e)
+                if 'Manifest list not found locally.' not in error_msg:
+                    raise IIBError(f'Error removing local manifest list: {error_msg}')
+                log.debug('Manifest list cannot be removed. No manifest list %s found', output_pull_spec)
+            log.info('Creating the manifest list %s locally', output_pull_spec)
+            run_cmd(
+                buildah_manifest_cmd + ['create', output_pull_spec],
+                exc_msg=f'Failed to create the manifest list locally: {output_pull_spec}',
+            )
+            for arch in sorted(arches):
+                arch_pull_spec = _get_external_arch_pull_spec(
+                    request_id, arch, include_transport=True
+                )
+                log.debug(
+                    'Adding the manifest %s to the manifest list %s',
+                    arch_pull_spec,
+                    output_pull_spec,
+                )
+                run_cmd(
+                    buildah_manifest_cmd + ['add', output_pull_spec, arch_pull_spec],
+                    exc_msg=(
+                        f'Failed to add {arch_pull_spec} to the'
+                        f' local manifest list: {output_pull_spec}'
+                    ),
+                )
 
-    try:
-        run_cmd(
-            buildah_manifest_cmd + ['rm', output_pull_spec],
-            exc_msg=f'Failed to remove local manifest list. {output_pull_spec} does not exist',
-        )
-    except IIBError as e:
-        error_msg = str(e)
-        if 'Manifest list not found locally.' not in error_msg:
-            raise IIBError(f'Error removing local manifest list: {error_msg}')
-        log.debug('Manifest list cannot be removed. No manifest list %s found', output_pull_spec)
+            log.debug('Pushing manifest list %s', output_pull_spec)
+            run_cmd(
+                buildah_manifest_cmd
+                + ['push', '--all', output_pull_spec, f'docker://{output_pull_spec}'],
+                exc_msg=f'Failed to push the manifest list to {output_pull_spec}',
+            )
 
-    log.info('Creating the manifest list %s locally', output_pull_spec)
-    run_cmd(
-        buildah_manifest_cmd + ['create', output_pull_spec],
-        exc_msg=f'Failed to create the manifest list locally: {output_pull_spec}',
-    )
-    for arch in sorted(arches):
-        arch_pull_spec = _get_external_arch_pull_spec(request_id, arch, include_transport=True)
-        log.debug(
-            'Adding the manifest %s to the manifest list %s', arch_pull_spec, output_pull_spec
-        )
-        run_cmd(
-            buildah_manifest_cmd + ['add', output_pull_spec, arch_pull_spec],
-            exc_msg=(
-                f'Failed to add {arch_pull_spec} to the' f' local manifest list: {output_pull_spec}'
-            ),
-        )
-
-    log.debug('Pushing manifest list %s', output_pull_spec)
-    run_cmd(
-        buildah_manifest_cmd + ['push', '--all', output_pull_spec, f'docker://{output_pull_spec}'],
-        exc_msg=f'Failed to push the manifest list to {output_pull_spec}',
-    )
-
-    return output_pull_spec
+    # return 1st item as it holds production tag
+    return output_pull_specs[0]
 
 
 def _update_index_image_pull_spec(
@@ -800,6 +815,7 @@ def handle_add_request(
     greenwave_config=None,
     binary_image_config=None,
     deprecation_list=None,
+    build_tags=None,
 ):
     """
     Coordinate the the work needed to build the index image with the input bundles.
@@ -833,6 +849,7 @@ def handle_add_request(
         ``binary_image`` to use.
     :param list deprecation_list: list of deprecated bundles for the target index image. Defaults
         to ``None``.
+    :param list build_tags: List of tags which will be applied to intermediate index images.
     :raises IIBError: if the index image build fails.
     """
     _cleanup()
@@ -989,7 +1006,7 @@ def handle_add_request(
         )
 
     set_request_state(request_id, 'in_progress', 'Creating the manifest list')
-    output_pull_spec = _create_and_push_manifest_list(request_id, arches)
+    output_pull_spec = _create_and_push_manifest_list(request_id, arches, build_tags)
 
     _update_index_image_pull_spec(
         output_pull_spec,
@@ -1018,6 +1035,7 @@ def handle_rm_request(
     overwrite_from_index_token=None,
     distribution_scope=None,
     binary_image_config=None,
+    build_tags=None,
 ):
     """
     Coordinate the work needed to remove the input operators and rebuild the index image.
@@ -1040,6 +1058,7 @@ def handle_rm_request(
         ``None``.
     :param dict binary_image_config: the dict of config required to identify the appropriate
         ``binary_image`` to use.
+    :param list build_tags: List of tags which will be applied to intermediate index images.
     :raises IIBError: if the index image build fails.
     """
     _cleanup()
@@ -1092,7 +1111,7 @@ def handle_rm_request(
             _push_image(request_id, arch)
 
     set_request_state(request_id, 'in_progress', 'Creating the manifest list')
-    output_pull_spec = _create_and_push_manifest_list(request_id, arches)
+    output_pull_spec = _create_and_push_manifest_list(request_id, arches, build_tags)
 
     _update_index_image_pull_spec(
         output_pull_spec,

--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -153,6 +153,7 @@ def handle_merge_request(
     overwrite_target_index_token=None,
     distribution_scope=None,
     binary_image_config=None,
+    build_tags=None,
 ):
     """
     Coordinate the work needed to merge old (N) index image with new (N+1) index image.
@@ -172,6 +173,7 @@ def handle_merge_request(
         The format of the token must be in the format "user:password".
     :param str distribution_scope: the scope for distribution of the index image, defaults to
         ``None``.
+    :param build_tags: list of extra tag to use for intermetdiate index image
     :raises IIBError: if the index image merge fails.
     """
     _cleanup()
@@ -278,7 +280,9 @@ def handle_merge_request(
             file_mode=(stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP),
         )
 
-    output_pull_spec = _create_and_push_manifest_list(request_id, prebuild_info['arches'])
+    output_pull_spec = _create_and_push_manifest_list(
+        request_id, prebuild_info['arches'], build_tags
+    )
     _update_index_image_pull_spec(
         output_pull_spec,
         request_id,

--- a/iib/workers/tasks/build_regenerate_bundle.py
+++ b/iib/workers/tasks/build_regenerate_bundle.py
@@ -119,7 +119,7 @@ def handle_regenerate_bundle_request(
                 _push_image(request_id, arch)
 
     set_request_state(request_id, 'in_progress', 'Creating the manifest list')
-    output_pull_spec = _create_and_push_manifest_list(request_id, arches)
+    output_pull_spec = _create_and_push_manifest_list(request_id, arches, [])
 
     conf = get_worker_config()
     if conf['iib_index_image_output_registry']:

--- a/tests/test_web/test_models.py
+++ b/tests/test_web/test_models.py
@@ -21,6 +21,25 @@ def test_request_add_architecture(db, minimal_request):
     assert len(minimal_request.architectures) == 2
 
 
+def test_request_add_tag(db, minimal_request):
+    binary_image = models.Image(pull_specification='quay.io/add/binary-image:latest2')
+    db.session.add(binary_image)
+    batch = models.Batch()
+    db.session.add(batch)
+    request = models.RequestAdd(batch=batch, binary_image=binary_image)
+    db.session.add(request)
+    db.session.commit()
+    minimal_request.add_build_tag('build-tag1')
+
+    minimal_request.add_build_tag('build-tag1')
+    minimal_request.add_build_tag('build-tag1')
+    minimal_request.add_build_tag('build-tag2')
+    db.session.commit()
+    assert len(minimal_request.build_tags) == 2
+    assert minimal_request.build_tags[0].name == 'build-tag1'
+    assert minimal_request.build_tags[1].name == 'build-tag2'
+
+
 def test_request_add_state(db, minimal_request):
     minimal_request.add_state('in_progress', 'Starting things up')
     minimal_request.add_state('complete', 'All done!')

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -63,7 +63,8 @@ def test_create_and_push_manifest_list(mock_open, mock_run_cmd, mock_td, tmp_pat
         None,
         None,
         None,
-        None
+        None,
+        None,
     ]
 
     output = []
@@ -118,7 +119,10 @@ def test_create_and_push_manifest_list(mock_open, mock_run_cmd, mock_td, tmp_pat
             ],
             exc_msg='Failed to push the manifest list to registry:8443/iib-build:3',
         ),
-        mock.call(['buildah', 'manifest', 'rm', 'registry:8443/iib-build:extra_build_tag1'], exc_msg='Failed to remove local manifest list. registry:8443/iib-build:extra_build_tag1 does not exist'),
+        mock.call(
+            ['buildah', 'manifest', 'rm', 'registry:8443/iib-build:extra_build_tag1'],
+            exc_msg='Failed to remove local manifest list. registry:8443/iib-build:extra_build_tag1 does not exist',
+        ),
         mock.call(
             ['buildah', 'manifest', 'create', 'registry:8443/iib-build:extra_build_tag1'],
             exc_msg='Failed to create the manifest list locally: '

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -121,7 +121,8 @@ def test_create_and_push_manifest_list(mock_open, mock_run_cmd, mock_td, tmp_pat
         ),
         mock.call(
             ['buildah', 'manifest', 'rm', 'registry:8443/iib-build:extra_build_tag1'],
-            exc_msg='Failed to remove local manifest list. registry:8443/iib-build:extra_build_tag1 does not exist',
+            exc_msg='Failed to remove local manifest list. '
+            'registry:8443/iib-build:extra_build_tag1 does not exist',
         ),
         mock.call(
             ['buildah', 'manifest', 'create', 'registry:8443/iib-build:extra_build_tag1'],

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -50,7 +50,8 @@ def test_cleanup(mock_rdc, mock_run_cmd):
 
 @mock.patch('iib.workers.tasks.build.tempfile.TemporaryDirectory')
 @mock.patch('iib.workers.tasks.build.run_cmd')
-def test_create_and_push_manifest_list(mock_run_cmd, mock_td, tmp_path):
+@mock.patch('iib.workers.tasks.build.open')
+def test_create_and_push_manifest_list(mock_open, mock_run_cmd, mock_td, tmp_path):
     mock_td.return_value.__enter__.return_value = tmp_path
     mock_run_cmd.side_effect = [
         IIBError('Manifest list not found locally.'),
@@ -58,9 +59,16 @@ def test_create_and_push_manifest_list(mock_run_cmd, mock_td, tmp_path):
         None,
         None,
         None,
+        None,
+        None,
+        None,
+        None,
+        None
     ]
 
-    build._create_and_push_manifest_list(3, {'amd64', 's390x'})
+    output = []
+    mock_open().__enter__().write.side_effect = lambda x: output.append(x)
+    build._create_and_push_manifest_list(3, {'amd64', 's390x'}, ['extra_build_tag1'])
 
     expected_calls = [
         mock.call(
@@ -110,6 +118,49 @@ def test_create_and_push_manifest_list(mock_run_cmd, mock_td, tmp_path):
             ],
             exc_msg='Failed to push the manifest list to registry:8443/iib-build:3',
         ),
+        mock.call(['buildah', 'manifest', 'rm', 'registry:8443/iib-build:extra_build_tag1'], exc_msg='Failed to remove local manifest list. registry:8443/iib-build:extra_build_tag1 does not exist'),
+        mock.call(
+            ['buildah', 'manifest', 'create', 'registry:8443/iib-build:extra_build_tag1'],
+            exc_msg='Failed to create the manifest list locally: '
+            'registry:8443/iib-build:extra_build_tag1',
+        ),
+        mock.call(
+            [
+                'buildah',
+                'manifest',
+                'add',
+                'registry:8443/iib-build:extra_build_tag1',
+                'docker://registry:8443/iib-build:3-amd64',
+            ],
+            exc_msg=(
+                'Failed to add docker://registry:8443/iib-build:3-amd64'
+                ' to the local manifest list: registry:8443/iib-build:extra_build_tag1'
+            ),
+        ),
+        mock.call(
+            [
+                'buildah',
+                'manifest',
+                'add',
+                'registry:8443/iib-build:extra_build_tag1',
+                'docker://registry:8443/iib-build:3-s390x',
+            ],
+            exc_msg=(
+                'Failed to add docker://registry:8443/iib-build:3-s390x'
+                ' to the local manifest list: registry:8443/iib-build:extra_build_tag1'
+            ),
+        ),
+        mock.call(
+            [
+                'buildah',
+                'manifest',
+                'push',
+                '--all',
+                'registry:8443/iib-build:extra_build_tag1',
+                'docker://registry:8443/iib-build:extra_build_tag1',
+            ],
+            exc_msg='Failed to push the manifest list to registry:8443/iib-build:extra_build_tag1',
+        ),
     ]
     assert mock_run_cmd.call_args_list == expected_calls
 
@@ -122,7 +173,7 @@ def test_create_and_push_manifest_list_failure_to_rm_manifest_list(mock_run_cmd,
 
     error_msg = 'Error removing local manifest list: Different error never seen before!'
     with pytest.raises(IIBError, match=error_msg):
-        build._create_and_push_manifest_list(3, {'amd64', 's390x'})
+        build._create_and_push_manifest_list(3, {'amd64', 's390x'}, [])
 
 
 @pytest.mark.parametrize(
@@ -558,6 +609,7 @@ def test_handle_add_request(
         greenwave_config,
         binary_image_config=binary_image_config,
         deprecation_list=deprecation_list,
+        build_tags=["extra_tag1", "extra_tag2"],
     )
 
     mock_sir.assert_called_once()

--- a/tests/test_workers/test_tasks/test_build_merge_index_image.py
+++ b/tests/test_workers/test_tasks/test_build_merge_index_image.py
@@ -19,7 +19,6 @@ from iib.workers.tasks.utils import RequestConfigMerge
 )
 @mock.patch('iib.workers.tasks.build_merge_index_image._update_index_image_pull_spec')
 @mock.patch('iib.workers.tasks.build._verify_index_image')
-@mock.patch('iib.workers.tasks.build_merge_index_image._create_and_push_manifest_list')
 @mock.patch('iib.workers.tasks.build_merge_index_image._push_image')
 @mock.patch('iib.workers.tasks.build_merge_index_image._build_image')
 @mock.patch('iib.workers.tasks.build_merge_index_image.deprecate_bundles')
@@ -36,9 +35,11 @@ from iib.workers.tasks.utils import RequestConfigMerge
 @mock.patch('iib.workers.tasks.build_merge_index_image._cleanup')
 @mock.patch('iib.workers.tasks.build_merge_index_image._add_label_to_index')
 @mock.patch('iib.workers.tasks.build_merge_index_image.set_registry_token')
+@mock.patch('subprocess.run')
 @mock.patch('iib.workers.tasks.build_merge_index_image.is_image_dc')
 def test_handle_merge_request(
     mock_iidc,
+    mock_run,
     mock_set_registry_token,
     mock_add_label_to_index,
     mock_cleanup,
@@ -52,13 +53,13 @@ def test_handle_merge_request(
     mock_dep_b,
     mock_bi,
     mock_pi,
-    mock_capml,
     mock_vii,
     mock_uiips,
     target_index,
     target_index_resolved,
     binary_image,
 ):
+    mock_run.return_value.returncode = 0
     prebuild_info = {
         'arches': {'amd64', 'other_arch'},
         'binary_image': binary_image,
@@ -118,7 +119,6 @@ def test_handle_merge_request(
     mock_set_registry_token.assert_called_once()
     assert mock_bi.call_count == 2
     assert mock_pi.call_count == 2
-    mock_capml.assert_called_once_with(1, {'amd64', 'other_arch'})
     assert mock_add_label_to_index.call_count == 2
     mock_uiips.assert_called_once()
 
@@ -210,7 +210,7 @@ def test_handle_merge_request_no_deprecate(
     assert mock_pi.call_count == 2
     assert mock_add_label_to_index.call_count == 2
     mock_vii.assert_not_called()
-    mock_capml.assert_called_once_with(1, {'amd64', 'other_arch'})
+    mock_capml.assert_called_once_with(1, {'amd64', 'other_arch'}, None)
     mock_uiips.assert_called_once()
 
 

--- a/tests/test_workers/test_tasks/test_build_regenerate_bundle.py
+++ b/tests/test_workers/test_tasks/test_build_regenerate_bundle.py
@@ -120,7 +120,7 @@ def test_handle_regenerate_bundle_request(
         ]
     )
 
-    mock_capml.assert_called_once_with(request_id, list(arches))
+    mock_capml.assert_called_once_with(request_id, list(arches), [])
 
     assert mock_ur.call_count == 2
     mock_ur.assert_has_calls(


### PR DESCRIPTION
For index image operations, it's now possible to set build_tags
attribute to apply extra tags for intermediate index image