### PR TITLE
Replace retry with retry package and set back-off interval for skopeo_inspect

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,6 +10,7 @@ python-memcached
 psycopg2-binary
 recommonmark
 requests
+retry
 ruamel.yaml
 # https://github.com/sphinx-doc/sphinx/issues/2796
 sphinx!=3.0.2

--- a/iib/workers/tasks/legacy.py
+++ b/iib/workers/tasks/legacy.py
@@ -12,7 +12,8 @@ import ruamel.yaml
 from iib.exceptions import IIBError
 from iib.workers.api_utils import set_request_state, set_omps_operator_version
 from iib.workers.config import get_worker_config
-from iib.workers.tasks.utils import get_image_labels, retry, run_cmd
+from iib.workers.tasks.utils import get_image_labels, run_cmd
+from retry import retry
 
 log = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ def get_legacy_support_packages(bundles, request_id, ocp_version, force_backport
     return packages
 
 
-@retry(attempts=2, wait_on=IIBError, logger=log)
+@retry(exceptions=IIBError, tries=2, logger=log)
 def _opm_index_export(rebuilt_index_image, package, temp_dir):
     """
     Export the package that needs to be backported.
@@ -114,7 +115,7 @@ def _opm_index_export(rebuilt_index_image, package, temp_dir):
     )
 
 
-@retry(attempts=3, wait_on=IIBError, logger=log)
+@retry(exceptions=IIBError, tries=3, logger=log)
 def _push_package_manifest(package_dir, cnr_token, organization):
     """
     Push ``manifests.zip`` file created for an exported package to OMPS.

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -15,4 +15,5 @@ python-memcached
 python-qpid-proton
 requests
 requests-kerberos
+retry
 ruamel.yaml

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -304,8 +304,8 @@ psycopg2-binary==2.8.4 \
     # via -r requirements-test.in
 py==1.10.0 \
     --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \
-    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a
-    # via pytest
+    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
+    # via pytest, retry
 pycparser==2.19 \
     --hash=sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3
     # via cffi
@@ -356,6 +356,10 @@ requests==2.22.0 \
     # via
     #   -r requirements-test.in
     #   requests-kerberos
+retry==0.9.2 \
+    --hash=sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606 \
+    --hash=sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4 \
+    # via -r requirements-test.in
 ruamel.yaml.clib==0.2.0 \
     --hash=sha256:1e77424825caba5553bbade750cec2277ef130647d685c2b38f68bc03453bac6 \
     --hash=sha256:392b7c371312abf27fb549ec2d5e0092f7ef6e6c9f767bfb13e83cb903aca0fd \

--- a/requirements.txt
+++ b/requirements.txt
@@ -228,6 +228,10 @@ psycopg2-binary==2.8.4 \
     --hash=sha256:eac8a3499754790187bb00574ab980df13e754777d346f85e0ff6df929bcd964 \
     --hash=sha256:eaed1c65f461a959284649e37b5051224f4db6ebdc84e40b5e65f2986f101a08
     # via iib (setup.py)
+py==1.10.0 \
+    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \
+    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a \
+    # via retry
 pycparser==2.19 \
     --hash=sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3
     # via cffi
@@ -264,6 +268,10 @@ requests==2.22.0 \
     # via
     #   iib (setup.py)
     #   requests-kerberos
+retry==0.9.2 \
+    --hash=sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606 \
+    --hash=sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4 \
+    # via iib (setup.py)
 ruamel.yaml.clib==0.2.0 \
     --hash=sha256:1e77424825caba5553bbade750cec2277ef130647d685c2b38f68bc03453bac6 \
     --hash=sha256:392b7c371312abf27fb549ec2d5e0092f7ef6e6c9f767bfb13e83cb903aca0fd \

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'python-qpid-proton',
         'requests',
         'requests-kerberos',
+        'retry',
         'ruamel.yaml',
     ],
     classifiers=[

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -192,20 +192,6 @@ def test_set_container_image_null(mock_remove):
     mock_remove.assert_not_called()
 
 
-def test_retry():
-    mock_func = mock.Mock()
-
-    @utils.retry(attempts=3, wait_on=IIBError)
-    def _func_to_retry():
-        mock_func()
-        raise IIBError('Some error')
-
-    with pytest.raises(IIBError, match='Some error'):
-        _func_to_retry()
-
-    assert mock_func.call_count == 3
-
-
 @mock.patch('iib.workers.tasks.utils.subprocess.run')
 def test_run_cmd(mock_sub_run):
     mock_rv = mock.Mock()


### PR DESCRIPTION
Replace custom retry with retry package and setting back-off interval for skopeo_inspect

- replaced internal retry with retry package
- set back-off interval for skopeo_inspect with delay between retry 5, 10, 20, 40, 80 seconds

This change removes exception log message `'The maximum number of attempts (%s) have failed'` from logs.
Original (IIBError) exception is still raised.
And it changes retry message from `'Exception %r raised from %r.  Retrying now' `to `'%s, retrying in %s seconds...'`

refers to [CLOUDDST-6436]