### PR TITLE
Fix for memcachedKeyLengthError

### DIFF
--- a/iib/workers/dogpile_cache.py
+++ b/iib/workers/dogpile_cache.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import functools
+import hashlib
 
 from dogpile.cache import make_region
 
@@ -48,7 +49,12 @@ def generate_cache_key(fn, *args, **kwargs):
     arguments = '|'.join(
         [str(arg) for arg in args] + [f'{kwarg}={kwargs[kwarg]}' for kwarg in kwargs]
     )
-    return f'{fn}|{arguments}'
+    key_str = f'{fn}|{arguments}'
+    try:
+        key = hashlib.sha256(key_str).hexdigest()
+    except TypeError:
+        key = hashlib.sha256(key_str.encode('utf-8')).hexdigest()
+    return key
 
 
 def create_dogpile_region():

--- a/tests/test_workers/test_dogpile_cache.py
+++ b/tests/test_workers/test_dogpile_cache.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import pytest
+
+from iib.workers.dogpile_cache import generate_cache_key
+
+
+@pytest.mark.parametrize(
+    "args,kwargs",
+    [
+        (['a', 'r', 'g', 's'], {"k": "kwargs"}),
+        (
+            [
+                "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. ",
+                "Aenean commodo ligula eget dolor. Aenean massa. Cum sociis ",
+                "natoque penatibus et magnis dis parturient montes, nascetur ",
+                "ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu",
+                "pretium quis, sem. Nulla consequat massa quis enim. Donec.",
+            ],
+            {"k": "kwargs"},
+        ),
+        (
+            ['a', 'r', 'g', 's'],
+            {
+                "long": """Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+           Aenean commodo ligula eget dolor. Aenean massa. Cum sociis
+           natoque penatibus et magnis dis parturient montes, nascetur""",
+                "kwargs": """ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu,
+           pretium quis, sem. Nulla consequat massa quis enim. Donec.""",
+            },
+        ),
+    ],
+)
+def test_generate_cache_key(args, kwargs):
+    passwd = generate_cache_key('function_name', *args, **kwargs)
+    assert len(passwd) <= 250


### PR DESCRIPTION
memcache client supports keys with length <= 250.
It might happen that function name with all arguments is
longer then this limit. For this case we should create
SHA256 sum to have unique name that will be used to
determine correct cached value.

Error example: https://iib.engineering.redhat.com/api/v1/builds/90240/logs

refers to [CLOUDDST-7479]