### PR TITLE
Set correlation_id, not message_id, on messages

### DIFF
--- a/iib/web/messaging.py
+++ b/iib/web/messaging.py
@@ -243,7 +243,7 @@ def json_to_envelope(address, content, properties=None):
     :rtype: Envelope
     """
     message = proton.Message(body=json.dumps(content), properties=properties)
-    message.id = str(uuid.uuid4())
+    message.correlation_id = str(uuid.uuid4())
     message.content_type = 'application/json'
     message.durable = current_app.config['IIB_MESSAGING_DURABLE']
     return Envelope(address, message)
@@ -280,7 +280,9 @@ def send_messages(envelopes):
                 address_to_sender[envelope.address] = connection.create_sender(envelope.address)
 
             current_app.logger.info(
-                'Sending message %s to %s', envelope.message.id, envelope.address
+                'Sending message %s (correlation-id) to %s',
+                envelope.message.correlation_id,
+                envelope.address,
             )
             address_to_sender[envelope.address].send(
                 envelope.message, timeout=conf['IIB_MESSAGING_TIMEOUT']

--- a/tests/test_web/test_messaging.py
+++ b/tests/test_web/test_messaging.py
@@ -170,8 +170,9 @@ def test_json_to_envelope(mock_current_app, durable):
     envelope = messaging.json_to_envelope(address, content)
 
     assert envelope.address == address
-    # Verify that the ID is a UUID
-    assert len(envelope.message.id) == 36
+    # Verify that the Correlation ID is a UUID
+    assert len(envelope.message.correlation_id) == 36
+    assert envelope.message.id is None
     assert envelope.message.body == '{"han": "solo"}'
     assert envelope.message.content_type == 'application/json'
     assert envelope.message.durable is durable


### PR DESCRIPTION
The ActiveMQ broker will set a message ID automatically if one is not
set. This is actually preferred as it allows custom configuration in the
broker to be leveraged to created a meaningful message ID.

For tracking purposes, it is encouraged to set a correlation_id to allow
tracking of the message throughout the system.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>