### PR TITLE
Add Declarative Config Migrator to worker Dockerfile

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -70,6 +70,8 @@ RUN cd /usr/bin && tar -xf /src/grpcurl_1.7.0_linux_x86_64.tar.gz grpcurl && rm 
 RUN chmod +x /usr/bin/manifest-tool
 ADD https://github.com/operator-framework/operator-sdk/releases/download/v1.9.0/operator-sdk_linux_amd64 /usr/bin/operator-sdk
 RUN chmod +x /usr/bin/operator-sdk
+ADD https://github.com/release-engineering/dcm/releases/download/v0.1.1/dcm_linux_amd64 /usr/bin/dcm
+RUN chmod +x /usr/bin/dcm
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' /etc/containers/storage.conf


### PR DESCRIPTION
To support declarative config in IIB we have to install DCM binary which is used by workers.

refers to [CLOUDDST-8699]