### PR TITLE
Use ubi8 for the API container

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM registry.redhat.io/ubi8/ubi:latest
 LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src
@@ -10,6 +10,8 @@ RUN dnf -y install \
     gcc \
     httpd \
     krb5-devel \
+    libffi-devel \
+    libpq-devel \
     mod_auth_gssapi \
     mod_ssl \
     openssl-devel \
@@ -21,7 +23,7 @@ RUN dnf -y install \
 COPY . .
 COPY ./docker/iib-httpd.conf /etc/httpd/conf/httpd.conf
 
-# default python3-pip version for centos8 python3.6 is 9.0.3 and it can't be updated by dnf
+# default python3-pip version for rhel8 python3.6 is 9.0.3 and it can't be updated by dnf
 # we have to update it by pip to version above 21.0.0
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt --no-deps --require-hashes


### PR DESCRIPTION
CentOS 8 will be EOL on December 31st, 2021[0]
Let's at least move away from it in the API container. The worker
container will require additional work.

[0] https://www.centos.org/centos-linux-eol/

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>