### PR TITLE
Cleanup local manifest lists before creating a new one

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -118,6 +118,18 @@ def _create_and_push_manifest_list(request_id, arches):
     """
     buildah_manifest_cmd = ['buildah', 'manifest']
     output_pull_spec = get_rebuilt_image_pull_spec(request_id)
+
+    try:
+        run_cmd(
+            buildah_manifest_cmd + ['rm', output_pull_spec],
+            exc_msg=f'Failed to remove local manifest list. {output_pull_spec} does not exist',
+        )
+    except IIBError as e:
+        error_msg = str(e)
+        if 'Manifest list not found locally.' not in error_msg:
+            raise IIBError(f'Error removing local manifest list: {error_msg}')
+        log.debug('Manifest list cannot be removed. No manifest list %s found', output_pull_spec)
+
     log.info('Creating the manifest list %s locally', output_pull_spec)
     run_cmd(
         buildah_manifest_cmd + ['create', output_pull_spec],

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -520,6 +520,9 @@ def run_cmd(cmd, params=None, exc_msg=None, strict=True):
                 match = re.match(regex, msg)
                 if match:
                     raise IIBError(f'{exc_msg.rstrip(".")}: {match.groups()[0]}')
+        if set(['buildah', 'manifest', 'rm']) <= set(cmd):
+            if 'image not known' in response.stderr:
+                raise IIBError('Manifest list not found locally.')
 
         raise IIBError(exc_msg)
 


### PR DESCRIPTION
If one of the later steps fails, then in the retry, IIB tries
to recreate an existing manifest list which buildah doesn't allow
This commit resolves that issue by removing the existing local
manifest list before creating a new one.

Refers to CLOUDDST-9014