### PR TITLE
Avoid failing to create-empty-index when labels are not set

### DIFF
--- a/iib/workers/tasks/build_create_empty_index.py
+++ b/iib/workers/tasks/build_create_empty_index.py
@@ -106,7 +106,8 @@ def handle_create_empty_index_request(
             'com.redhat.index.delivery.distribution_scope': prebuild_info['distribution_scope'],
         }
 
-        iib_labels.update(labels)
+        if labels:
+            iib_labels.update(labels)
         for index_label, value in iib_labels.items():
             _add_label_to_index(index_label, value, temp_dir, 'index.Dockerfile')
 


### PR DESCRIPTION
This commit avoids raising exception on create-empty-index if the parameter "labels" are not set in request.

Since "labels" are not a mandatory parameter the request shouldn't break.

This is a contribution out of any JIRA cards.