### PR TITLE
Using get_image_label instead of skopeo_inspect for is_image_fbc

### DIFF
--- a/iib/workers/tasks/fbc_utils.py
+++ b/iib/workers/tasks/fbc_utils.py
@@ -23,11 +23,9 @@ def is_image_fbc(image):
     :return: True if image is FBC type, False otherwise (SQLite)
     :rtype: bool
     """
-    from iib.workers.tasks.utils import skopeo_inspect
+    from iib.workers.tasks.utils import get_image_label
 
-    skopeo_output = skopeo_inspect(f'docker://{image}')
-    fbc_image_label = 'operators.operatorframework.io.index.configs.v1'
-    return fbc_image_label in skopeo_output['Labels']
+    return bool(get_image_label(image, 'operators.operatorframework.io.index.configs.v1'))
 
 
 def get_catalog_dir(from_index, base_dir):

--- a/tests/test_workers/test_tasks/test_fbc_utils.py
+++ b/tests/test_workers/test_tasks/test_fbc_utils.py
@@ -10,145 +10,84 @@ from iib.workers.tasks.fbc_utils import is_image_fbc
     "skopeo_output,is_fbc",
     [
         (
-            {
-                'Name': 'Example name',
-                'Digest': 'sha256:643091113cd923cdd73121039b3a21768112c9e327fc25341b08d23ac8920c55',
-                'RepoTags': [
-                    'apitestnew',
-                    'apitest4.5',
-                    'apitest4.6original',
-                    'apitestoriginal',
-                    'addremove',
-                    'v4.5',
-                    'v4.6',
-                    'v4.7',
-                    'v4.8',
-                    'apitest4.6',
-                    'apitest',
-                ],
-                'Created': '2021-08-31T11:05:14.326184587Z',
-                'DockerVersion': '',
-                'Labels': {
-                    'License': 'GPLv2+',
-                    'architecture': 'x86_64',
-                    'build-date': '2021-07-29T18:07:48.204636',
-                    'com.redhat.build-host': 'cpt-1002.osbs.prod.upshift.rdu2.redhat.com',
-                    'com.redhat.component': 'operator-registry-container',
-                    'com.redhat.index.delivery.distribution_scope': 'prod',
-                    'com.redhat.index.delivery.version': 'v4.6',
-                    'description': 'This is a component.',
-                    'distribution-scope': 'public',
-                    'io.buildah.version': '1.21.4',
-                    'io.k8s.description': 'This is a component',
-                    'io.k8s.display-name': 'OpenShift Operator Registry',
-                    'name': 'openshift/ose-operator-registry',
-                    'operators.operatorframework.io.index.database.v1': '/database/index.db',
-                    'release': '202107291702.p0.git.d13e51c',
-                    'vcs-ref': '62919c6e7ff78a96172e807f284eb67570cd45f9',
-                    'vcs-type': 'git',
-                    'vendor': 'Red Hat, Inc.',
-                    'version': 'v4.6.0',
+                {
+                    "created": "2021-11-10T13:56:39.522635487Z",
+                    "author": "Bazel",
+                    "architecture": "amd64",
+                    "os": "linux",
+                    "config": {
+                        "User": "0",
+                        "Env": [
+                            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox",
+                            "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
+                        ],
+                        "Entrypoint": [
+                            "/bin/opm"
+                        ],
+                        "Cmd": [
+                            "serve",
+                            "/configs"
+                        ],
+                        "WorkingDir": "/",
+                        "Labels": {
+                            "io.buildah.version": "1.23.1",
+                        }
+                    },
+                    "rootfs": {
+                        "type": "layers",
+                        "diff_ids": [
+                            "sha256:c0d270ab7e0db0fa1db41d15b679a7b77ffbb9db62790095c7aee41444435933",
+                        ]
+                    },
+                    "history": [
+                        {
+                            "created": "1970-01-01T00:00:00Z",
+                            "created_by": "bazel build ...",
+                            "author": "Bazel"
+                        },
+                    ]
                 },
-                'Architecture': 'amd64',
-                'Os': 'linux',
-                'Layers': [
-                    'sha256:6586c25e081b96e64d917ef7c6c626c2c33e8939eb54ba3c50381e0ea8c01f40',
-                    'sha256:a0a58a27cc5fb235bb3626f0b714fb2906bc3bf2fbd33d0df6d681152e647f36',
-                    'sha256:6838f999ac51f9eb20f77097761a7b9a040f9b59d9bb924d888aacdd2f964475',
-                    'sha256:23925e4bf332cd36ea5bfc837ff2f8be929c72c82c912a177f88b2aef8aaad05',
-                    'sha256:141a9db3f4083b78f4e887d6f8d5e87aa19d579fbb27c551aab06bca7b9553f6',
-                    'sha256:e99a404321fe4cb0e9f5d7f6ae75b1b7476412a81d709855c9de7fdeed4be47f',
-                ],
-                'Env': [
-                    '__doozer=merge',
-                    'BUILD_RELEASE=202107291702.p0.git.d13e51c',
-                    'BUILD_VERSION=v4.6.0',
-                    'OS_GIT_MAJOR=4',
-                    'OS_GIT_MINOR=6',
-                    'OS_GIT_PATCH=0',
-                    'OS_GIT_TREE_STATE=clean',
-                    'OS_GIT_VERSION=4.6.0-202107291702.p0.git.d13e51c-d13e51c',
-                    'SOURCE_GIT_TREE_STATE=clean',
-                    'OS_GIT_COMMIT=d13e51c',
-                    'SOURCE_DATE_EPOCH=1624562969',
-                    'SOURCE_GIT_COMMIT=d13e51ceec5f7379de64aabce2c0befc094a3e7b',
-                    'SOURCE_GIT_TAG=v1.14.3-36-gd13e51ce',
-                    'SOURCE_GIT_URL=https://github.com/operator-framework/operator-registry',
-                    'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-                    'container=oci',
-                ],
-            },
-            False,
+                False
         ),
         (
-            {
-                'Name': 'Example name',
-                'Digest': 'sha256:643091113cd923cdd73121039b3a21768112c9e327fc25341b08d23ac8920c55',
-                'RepoTags': [
-                    'apitestnew',
-                    'apitest4.5',
-                    'apitest4.6original',
-                    'apitestoriginal',
-                    'addremove',
-                    'v4.5',
-                    'v4.6',
-                    'v4.7',
-                    'v4.8',
-                    'apitest4.6',
-                    'apitest',
-                ],
-                'Created': '2021-08-31T11:05:14.326184587Z',
-                'DockerVersion': '',
-                'Labels': {
-                    'License': 'GPLv2+',
-                    'architecture': 'x86_64',
-                    'build-date': '2021-07-29T18:07:48.204636',
-                    'com.redhat.build-host': 'cpt-1002.osbs.prod.upshift.rdu2.redhat.com',
-                    'com.redhat.component': 'operator-registry-container',
-                    'com.redhat.index.delivery.distribution_scope': 'prod',
-                    'com.redhat.index.delivery.version': 'v4.6',
-                    'description': 'This is a component.',
-                    'distribution-scope': 'public',
-                    'io.buildah.version': '1.21.4',
-                    'io.k8s.description': 'This is a component',
-                    'io.k8s.display-name': 'OpenShift Operator Registry',
-                    'name': 'openshift/ose-operator-registry',
-                    "operators.operatorframework.io.index.configs.v1": "/configs",
-                    'release': '202107291702.p0.git.d13e51c',
-                    'vcs-ref': '62919c6e7ff78a96172e807f284eb67570cd45f9',
-                    'vcs-type': 'git',
-                    'vendor': 'Red Hat, Inc.',
-                    'version': 'v4.6.0',
+                {
+                    "created": "2021-11-10T13:56:39.522635487Z",
+                    "author": "Bazel",
+                    "architecture": "amd64",
+                    "os": "linux",
+                    "config": {
+                        "User": "0",
+                        "Env": [
+                            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox",
+                            "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
+                        ],
+                        "Entrypoint": [
+                            "/bin/opm"
+                        ],
+                        "Cmd": [
+                            "serve",
+                            "/configs"
+                        ],
+                        "WorkingDir": "/",
+                        "Labels": {
+                            "io.buildah.version": "1.23.1",
+                            "operators.operatorframework.io.index.configs.v1": "/configs"
+                        }
+                    },
+                    "rootfs": {
+                        "type": "layers",
+                        "diff_ids": [
+                            "sha256:c0d270ab7e0db0fa1db41d15b679a7b77ffbb9db62790095c7aee41444435933",
+                        ]
+                    },
+                    "history": [
+                        {
+                            "created": "1970-01-01T00:00:00Z",
+                            "created_by": "bazel build ...",
+                            "author": "Bazel"
+                        },
+                    ]
                 },
-                'Architecture': 'amd64',
-                'Os': 'linux',
-                'Layers': [
-                    'sha256:6586c25e081b96e64d917ef7c6c626c2c33e8939eb54ba3c50381e0ea8c01f40',
-                    'sha256:a0a58a27cc5fb235bb3626f0b714fb2906bc3bf2fbd33d0df6d681152e647f36',
-                    'sha256:6838f999ac51f9eb20f77097761a7b9a040f9b59d9bb924d888aacdd2f964475',
-                    'sha256:23925e4bf332cd36ea5bfc837ff2f8be929c72c82c912a177f88b2aef8aaad05',
-                    'sha256:141a9db3f4083b78f4e887d6f8d5e87aa19d579fbb27c551aab06bca7b9553f6',
-                    'sha256:e99a404321fe4cb0e9f5d7f6ae75b1b7476412a81d709855c9de7fdeed4be47f',
-                ],
-                'Env': [
-                    '__doozer=merge',
-                    'BUILD_RELEASE=202107291702.p0.git.d13e51c',
-                    'BUILD_VERSION=v4.6.0',
-                    'OS_GIT_MAJOR=4',
-                    'OS_GIT_MINOR=6',
-                    'OS_GIT_PATCH=0',
-                    'OS_GIT_TREE_STATE=clean',
-                    'OS_GIT_VERSION=4.6.0-202107291702.p0.git.d13e51c-d13e51c',
-                    'SOURCE_GIT_TREE_STATE=clean',
-                    'OS_GIT_COMMIT=d13e51c',
-                    'SOURCE_DATE_EPOCH=1624562969',
-                    'SOURCE_GIT_COMMIT=d13e51ceec5f7379de64aabce2c0befc094a3e7b',
-                    'SOURCE_GIT_TAG=v1.14.3-36-gd13e51ce',
-                    'SOURCE_GIT_URL=https://github.com/operator-framework/operator-registry',
-                    'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-                    'container=oci',
-                ],
-            },
             True,
         ),
     ],


### PR DESCRIPTION
- supports logging
- better caching - since we might call get labels multiple times