### PR TITLE
Prevent failures when deprecation list contains duplicated bundles

### DIFF
--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -833,6 +833,11 @@ class RequestIndexImageMixin:
                 )
             request_kwargs['distribution_scope'] = distribution_scope
 
+        # Prevent duplicated items in "deprecation_list"
+        deprecation_list = request_kwargs.pop('deprecation_list', None)
+        if deprecation_list:
+            request_kwargs['deprecation_list'] = list(set(deprecation_list))
+
         # Verify the user is authorized to use overwrite_from_index
         # current_user.is_authenticated is only ever False when auth is disabled
         if current_user.is_authenticated:


### PR DESCRIPTION
This PR implements the bugfix for CLOUDDST-9728 by eliminating duplicated bundles on deprecation list which causes DB failures like:

```ERROR:  duplicate key value violates unique constraint "request_add_bundle_deprecation_constraint"```