### PR TITLE
Add mod_wsgi dependency to Dockerfile-api

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -14,6 +14,7 @@ RUN dnf -y install \
     libpq-devel \
     mod_auth_gssapi \
     mod_ssl \
+    python3-mod_wsgi \
     openssl-devel \
     python3-devel \
     python3-pip \


### PR DESCRIPTION
This dependency is required for deployment on Openshift