### PR TITLE
Avoid infinite Celery retries when the broker is gone

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -11,6 +11,8 @@ class Config(object):
 
     # When publishing a message, don't continuously retry or else the HTTP connection times out
     broker_transport_options = {'max_retries': 10}
+    # Avoid infinite Celery retries when the broker is offline.
+    broker_connection_max_retries: int = 10
     iib_api_timeout = 30
     iib_docker_config_template = os.path.join(
         os.path.expanduser('~'), '.docker', 'config.json.template'

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -17,6 +17,7 @@ def test_configure_celery_with_classes(mock_isfile):
     assert celery_app.conf.task_default_queue == 'celery'
     configure_celery(celery_app)
     assert celery_app.conf.task_default_queue == 'iib'
+    assert celery_app.conf.broker_connection_max_retries == 10
 
 
 @patch('os.getenv')
@@ -33,6 +34,7 @@ def test_configure_celery_with_classes_and_files(mock_open, mock_isfile, mock_ge
     configure_celery(celery_app)
     assert celery_app.conf.task_default_queue == 'not-iib'
     assert celery_app.conf.timezone == 'America/New_York'
+    assert celery_app.conf.broker_connection_max_retries == 10
 
 
 def test_validate_celery_config():


### PR DESCRIPTION
# Avoid Celery Infinity Retries
This PR prevents infinity Celery retries when the broker (RabbitMQ) is down.

The fix is very simple, just set the `broker_connection_max_retries` to any value different than `None` or `0` and it wouldn't retry forever, [as indicated in the manual](https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-broker_connection_max_retries).  

## Key observations
1. According to the [manual](https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-broker_connection_max_retries) the default value for `broker_connection_max_retries` is `100` *BUT* during my tests it never went up after the 16th attempt (infinite loop in `16/100`).
2. Even if the configuration was set to `100` and working properly it would be a **huge** interval since it doubles the waiting time for each attempt by 2 and would last around 3h considering the arithmetic progression.
3. I set it to `10` which gives us 110s (~2min) attempting to reconnect on RabbitMQ.
4. From ~3h to ~2min is a huge difference IMO :smiley: 

Refers to CLOUDDST-9674