### PR TITLE
Fix flake8, yamlint and docs tests for release v5.0.0

### DIFF
--- a/.github/workflows/build_on_tag.api.yml
+++ b/.github/workflows/build_on_tag.api.yml
@@ -1,6 +1,6 @@
 name: Build IIB-API image and push to quay.io
 
-on:  
+on:
   push:
     tags:
       - '*'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 celery
+boto3
 dogpile.cache
 flask
 flask-login

--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -120,7 +120,7 @@ def _get_artifact_file_from_s3_bucket(
     s3_key_prefix, s3_file_name, request_id, request_temp_data_expiration_date, s3_bucket_name
 ):
     """
-    Helper function to get artifact file from S3 bucket.
+    It's a helper function to get artifact file from S3 bucket.
 
     :param str s3_key_prefix: the logical location of the file in the S3 bucket
     :param str s3_file_name: the name of the file in S3 bucket

--- a/tests/test_web/test_s3_utils.py
+++ b/tests/test_web/test_s3_utils.py
@@ -13,10 +13,10 @@ def test_get_object_from_s3_bucket(mock_boto3):
     my_mock.meta.client.get_object.return_value = {
         'ResponseMetadata': {
             'RequestId': 'CK2VG4V5ZQXAAM5B',
-            'HostId': 'q4Wp/tsvjnl/eBeN0dHvHYi6xUl9U149BdN6IAXjaFJnnQX+mLjg8hM4xAfgijfDo3fugYSEpPA=',
+            'HostId': 'q4Wp/tsvjnl/eBeN0dHvHYi6xUl9U149BdN6IAXjaFJnnQX+=',
             'HTTPStatusCode': 200,
             'HTTPHeaders': {
-                'x-amz-id-2': 'q4Wp/tsvjnl/eBeN0dHvHYi6xUl9U149BdN6IAXjaFJnnQX+mLjg8hM4xAfgijfDo3fugYSEpPA=',
+                'x-amz-id-2': 'q4Wp/tsvjnl/eBeN0dHvHYi6xUl9U149BdN6IAXjaFJnnQX+=',
                 'x-amz-request-id': 'CK2VG4V5ZQXAAM5B',
                 'date': 'Sun, 05 Dec 2021 03:35:14 GMT',
                 'last-modified': 'Sun, 05 Dec 2021 03:29:26 GMT',

--- a/tests/test_workers/test_s3_utils.py
+++ b/tests/test_workers/test_s3_utils.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import os
 import re
 from unittest import mock
 


### PR DESCRIPTION
# Fixes for release v5.0.0

This PR fixes the `tox` tests for `flake8`, `docs` and `yamlint`

No functionality is changed.

Please take a look and if it's good to you merge it before #346 