### PR TITLE
Update Celery to 5.2.2 for Python 3.8

### DIFF
--- a/requirements-py38.txt
+++ b/requirements-py38.txt
@@ -25,9 +25,9 @@ botocore==1.23.23 \
     # via
     #   boto3
     #   s3transfer
-celery==5.2.1 \
-    --hash=sha256:b41a590b49caf8e6498a57db628e580d5f8dc6febda0f42de5d783aed5b7f808 \
-    --hash=sha256:cc63ea6572d558be65297ba6db7a7979e64c0a3d0d61212d6302ef1ca05a0d22
+celery==5.2.2 \
+    --hash=sha256:2844eb040e915398623a43253a8e1016723442ece6b0751a3c416d8a2b34216f \
+    --hash=sha256:5a68a351076cfac4f678fa5ffd898105c28825a2224902da006970005196d061
     # via iib (setup.py)
 certifi==2019.11.28 \
     --hash=sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3 \

--- a/requirements-test-py38.txt
+++ b/requirements-test-py38.txt
@@ -36,9 +36,9 @@ botocore==1.23.23 \
     #   -r requirements-py38.txt
     #   boto3
     #   s3transfer
-celery==5.2.1 \
-    --hash=sha256:b41a590b49caf8e6498a57db628e580d5f8dc6febda0f42de5d783aed5b7f808 \
-    --hash=sha256:cc63ea6572d558be65297ba6db7a7979e64c0a3d0d61212d6302ef1ca05a0d22
+celery==5.2.2 \
+    --hash=sha256:2844eb040e915398623a43253a8e1016723442ece6b0751a3c416d8a2b34216f \
+    --hash=sha256:5a68a351076cfac4f678fa5ffd898105c28825a2224902da006970005196d061
     # via -r requirements-py38.txt
 certifi==2019.11.28 \
     --hash=sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3 \


### PR DESCRIPTION
Update Celery to remediate CVE-2021-23727 (Stored Command Injection security vulnerability). 