### PR TITLE
Fixing yamllint warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+---
 name: Build images and push to quay.io
 
 on:

--- a/.github/workflows/build_on_tag.api.yml
+++ b/.github/workflows/build_on_tag.api.yml
@@ -1,3 +1,4 @@
+---
 name: Build IIB-API image and push to quay.io
 
 on:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -6,3 +6,8 @@ rules:
   line-length:
     max: 100
     level: warning
+
+  truthy:
+    # disable checking keys for truthy values (removes warning for "on" section in github workflows)
+    # https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy
+    check-keys: false

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -843,8 +843,8 @@ components:
         force_backport:
           type: boolean
           description: >
-            (deprecated) If True, always backport packages to the legacy app registry via OMPS. Requires
-            cnr_token and organization to be set if True.
+            (deprecated) If True, always backport packages to the legacy app registry via OMPS.
+            Requires cnr_token and organization to be set if True.
           default: false
         from_index:
           type: string
@@ -986,8 +986,8 @@ components:
             expiration:
               type: string
               description: >-
-                UTC timestamp in ISO format that indicates when the related bundles for the request are
-                considered to be expired and will be removed.
+                UTC timestamp in ISO format that indicates when the related bundles for the request
+                are considered to be expired and will be removed.
           example:
             url: https://iib.domain.local/api/v1/builds/1/related_bundles
             expiration: '2019-09-19T19:35:15.722265Z'


### PR DESCRIPTION
- added `---` at top of yaml files
- wrap lines longer then 100
- disabled truthy check for keys -> removes false positive on github workflow files