### PR TITLE
Create empty fbc index image

### DIFF
--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -895,6 +895,7 @@ def create_empty_index():
     args = [
         payload['from_index'],
         request.id,
+        payload.get('output_fbc'),
         payload.get('binary_image'),
         payload.get('labels'),
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -798,6 +798,7 @@ class RequestIndexImageMixin:
             'overwrite_from_index_token',
             'distribution_scope',
             'build_tags',
+            'output_fbc',
         } | set(additional_optional_params or [])
 
         validate_request_params(
@@ -1543,6 +1544,7 @@ class RequestCreateEmptyIndex(Request, RequestIndexImageMixin):
         'polymorphic_identity': RequestTypeMapping.__members__['create_empty_index'].value
     }
     build_tags = None
+    output_fbc = False
 
     @property
     def labels(self):
@@ -1576,6 +1578,10 @@ class RequestCreateEmptyIndex(Request, RequestIndexImageMixin):
             or len(request_kwargs.get('from_index')) == 0
         ):
             raise ValidationError('"from_index" must be a non-empty string')
+        if request_kwargs.get('output_fbc') and not isinstance(
+            request_kwargs.get('output_fbc'), bool
+        ):
+            raise ValidationError('"output_fbc" should be boolean')
 
         new_labels = request_kwargs.get('labels')
         if new_labels is not None:

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -1143,6 +1143,11 @@ components:
           items:
             type: string
           example: ["v4.5-10-08-2021"]
+        output_fbc:
+          type: boolean
+          description: Specifies whether output index image should be File-based Catalog
+          example: true
+          default: false
       required:
         - from_index
     ResponseCreateEmptyIndex:

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -19,7 +19,7 @@ class Config(object):
         os.path.expanduser('~'), '.docker', 'config.json.template'
     )
     iib_greenwave_url = None
-    iib_grpc_init_wait_time = 10
+    iib_grpc_init_wait_time = 30
     iib_grpc_max_port_tries = 100
     iib_grpc_max_tries = 5
     iib_grpc_start_port = 50051


### PR DESCRIPTION
In order to create an empty FBC index image,
a new parameter 'output_fbc' is added to create-empty-index
endpoint. When this parameter is specified an empty
index image created will be created using the from_index
image.
Refers to CLOUDDST-8773
