### PR TITLE
Remove unused dcm binary file from dev env.

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -30,8 +30,6 @@ ADD https://github.com/fullstorydev/grpcurl/releases/download/v1.8.5/grpcurl_1.8
 RUN cd /usr/bin && tar -xf /src/grpcurl_1.8.5_linux_x86_64.tar.gz grpcurl && rm -f /src/grpcurl_1.8.5_linux_x86_64.tar.gz
 ADD https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/operator-sdk_linux_amd64 /usr/bin/operator-sdk
 RUN chmod +x /usr/bin/operator-sdk
-ADD https://github.com/release-engineering/dcm/releases/download/v0.1.1/dcm_linux_amd64 /usr/bin/dcm
-RUN chmod +x /usr/bin/dcm
 
 RUN update-alternatives --set python3 $(which python3.8)
 


### PR DESCRIPTION
dcm is no longer used for File-Based Catalog. 
We do not have to add it to worker image.