### PR TITLE
Static Application Security Testing

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: /tests,/docker,/htmlcov,/.pytest-cache,/.git*,__pycache__,/.tox,.eggs,*.egg,/env*,/iib-data,/venv*,/.vscode,/.pyre

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters = true
-envlist = black,docs,flake8,py36,py38,safety36,safety38,yamllint
+envlist = black,docs,flake8,py36,py38,safety36,safety38,yamllint,bandit
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
@@ -16,6 +16,7 @@ basepython =
     safety36: python3.6
     safety38: python3.8
     yamllint: python3.8
+    bandit: python3.8
 setenv =
 	IIB_TESTING=true
 pytest_command =
@@ -86,6 +87,15 @@ deps =
     safety
 commands =
     safety check -r requirements-py38.txt
+
+[testenv:bandit]
+description = static application security testing [Mandatory]
+skip_install = true
+deps =
+    bandit
+commands =
+    bandit -ll -r .
+
 
 [flake8]
 ignore = D100,D104,D105,W503


### PR DESCRIPTION
# Static Application Security Testing

This PR includes `bandit` on `tox.ini` file to perform SAST in our CI

## Implementation details
* The new file `.bandit` contains the main configuration for it. In our case we're just excluding some unwanted directories.
* Among the excluded directories we have `/tests` and `/docker` since:
  - The main goal of SAST is to scan the application, not its tests or Dockerfile(s).
  - The `/tests` dir contains many functions with  `assert` keys and other stuff that get incorrectly caught by `bandit` as vulnerabilities thus even the [project's main page](https://github.com/PyCQA/bandit#per-project-command-line-args) suggests to not scan the tests directory.
* The `bandit` scan was set to just trigger failures for severity **Medium or higher**
* There are no tests skipped nor any additional plugins besides the defaults which comes with `bandit` from `pip`

## Notes
1. The following "problems" were caught by `bandit` and we need to discuss whether they should be just ignored or treated:

```
Test results:
>> Issue: [B102:exec_used] Use of exec detected.
   Severity: Medium   Confidence: High
   Location: ./iib/workers/config.py:171:12
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b102_exec_used.html
170	        with open(prod_config_file_path, mode='rb') as config_file:
171	            exec(compile(config_file.read(), prod_config_file_path, 'exec'), _user_config)
172	

--------------------------------------------------
>> Issue: [B103:set_bad_file_permissions] Chmod setting a permissive mask 0o775 on file (log_file_path).
   Severity: Medium   Confidence: High
   Location: ./iib/workers/tasks/utils.py:700:12
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b103_set_bad_file_permissions.html
699	            request_log_handler.setFormatter(log_formatter)
700	            os.chmod(log_file_path, 0o775)

```
  
Refers to CLOUDDST-10707