### PR TITLE
[WIP] Non working DEV ENV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   # it exits with status code 0.
   minica:
     image: registry.access.redhat.com/ubi8/go-toolset:latest
+    user: root
     command:
       - /bin/sh
       - -c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,17 +4,15 @@ services:
   # This "service" generates the certificate for the registry. Then,
   # it exits with status code 0.
   minica:
-    image: registry.access.redhat.com/ubi8/go-toolset:latest
-    user: root
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile-minica
     command:
       - /bin/sh
       - -c
       - >-
-        go get github.com/jsha/minica &&
         cd /opt/app-root/certs &&
         /opt/app-root/src/bin/minica --domains registry
-    environment:
-      GOPATH: /opt/app-root/src
     volumes:
       - registry-certs-volume:/opt/app-root/certs:z
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
         cp /broker-certs/client.crt /etc/iib/messaging.crt &&
         cp /broker-certs/client.key /etc/iib/messaging.key &&
         cp /broker-certs/ca.crt /etc/iib/messaging-ca.crt &&
-        pip3 uninstall -y iib &&
+        (pip3 uninstall -y iib || rm -rf /usr/local/lib/python3.8/site-packages/iib/) &&
         python3 setup.py develop --no-deps &&
         iib wait-for-db &&
         iib db upgrade &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
           -p iibpassword registry:8443 &&
         pip3 install watchdog[watchmedo] &&
         watchmedo auto-restart -d ./iib/workers -p '*.py' --recursive \
-          -- celery -A iib.workers.tasks worker --loglevel=info
+          -- celery -A iib.workers.tasks worker --loglevel INFO
     environment:
       IIB_DEV: 'true'
       REGISTRY_AUTH_FILE: '/root/.docker/config.json'

--- a/docker/Dockerfile-minica
+++ b/docker/Dockerfile-minica
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:latest
+LABEL maintainer="Red Hat - EXD"
+
+ENV GOPATH="/opt/app-root/src"
+
+USER root
+
+RUN go get github.com/jsha/minica

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -46,4 +46,4 @@ COPY . .
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements-py38.txt --no-deps --require-hashes
 RUN pip3 install . --no-deps
-CMD ["/bin/celery-3", "-A", "iib.workers.tasks", "worker", "--loglevel=info"]
+CMD ["celery", "-A", "iib.workers.tasks", "worker", "--loglevel=info"]


### PR DESCRIPTION
This is just draft to be transparent what I was trying out to fix dev env. 
Note: Some fixes are temp solution before I found better one. 

**minica** could not write to `/opt/app-root/certs` and I got permission denied - this was solved by running setting `root` as user in docker compose file. The default user is `default` but `/opt/app-root/certs` were mounted for `root:root` with `rwx` for user but `r-x` for group. It might be fixed to add g+w as well - but right now I am not sure how to do it only in docker-compose.

Right now worker does not run because ```Error: authenticating creds for "registry:8443": pinging container registry registry:8443: Get "https://registry:8443/v2/": dial tcp 127.0.0.1:8443: connect: connection refused```

It might be caused by registry because it looks like it have some issues as well
```
time="2022-01-14T12:42:09.300498347Z" level=warning msg="No HTTP secret provided - generated random secret. This may cause problems with uploads if multiple registries are behind a load-balancer. To provide a shared secret, fill in http.secret in the configuration file or set the REGISTRY_HTTP_SECRET environment variable." go.version=go1.11.2 instance.id=d25e099d-1526-4337-a040-33fcbe731d99 service=registry version=v2.7.1 
time="2022-01-14T12:42:09.300610046Z" level=info msg="redis not configured" go.version=go1.11.2 instance.id=d25e099d-1526-4337-a040-33fcbe731d99 service=registry version=v2.7.1 
time="2022-01-14T12:42:09.301645971Z" level=info msg="Starting upload purge in 39m0s" go.version=go1.11.2 instance.id=d25e099d-1526-4337-a040-33fcbe731d99 service=registry version=v2.7.1 
time="2022-01-14T12:42:09.308559295Z" level=info msg="using inmemory blob descriptor cache" go.version=go1.11.2 instance.id=d25e099d-1526-4337-a040-33fcbe731d99 service=registry version=v2.7.1 
time="2022-01-14T12:42:09.309266975Z" level=info msg="listening on [::]:8443, tls" go.version=go1.11.2 instance.id=d25e099d-1526-4337-a040-33fcbe731d99 service=registry version=v2.7.1 
```
I might be wrong but I think there might be some trouble with SELinux inside the container [1].

[1] https://stackoverflow.com/questions/34221220/deploying-own-docker-registry-registry-restarting


