### PR TITLE
Add support for Python3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: python
 python:
   - "3.8"
+  - "3.9"
 install:
   - pip3 install -U virtualenv pip tox
 script:

--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -659,7 +659,10 @@ def regenerate_bundle():
     error_callback = failed_request_callback.s(request.id)
     try:
         handle_regenerate_bundle_request.apply_async(
-            args=args, link_error=error_callback, argsrepr=repr(safe_args), queue=_get_user_queue(),
+            args=args,
+            link_error=error_callback,
+            argsrepr=repr(safe_args),
+            queue=_get_user_queue(),
         )
     except kombu.exceptions.OperationalError:
         handle_broker_error(request)

--- a/iib/web/migrations/versions/04dd7532d9c5_polymorphic_requests.py
+++ b/iib/web/migrations/versions/04dd7532d9c5_polymorphic_requests.py
@@ -125,7 +125,10 @@ def upgrade():
         sa.UniqueConstraint('request_add_id', 'image_id'),
     )
     op.create_index(
-        op.f('ix_request_add_bundle_image_id'), 'request_add_bundle', ['image_id'], unique=False,
+        op.f('ix_request_add_bundle_image_id'),
+        'request_add_bundle',
+        ['image_id'],
+        unique=False,
     )
     op.create_index(
         op.f('ix_request_add_bundle_request_add_id'),
@@ -277,19 +280,34 @@ def downgrade():
         batch_op.add_column(sa.Column('from_index_id', sa.INTEGER(), nullable=True))
         batch_op.add_column(sa.Column('binary_image_resolved_id', sa.INTEGER(), nullable=True))
         batch_op.create_foreign_key(
-            'request_from_index_resolved_id_fkey', 'image', ['from_index_resolved_id'], ['id'],
+            'request_from_index_resolved_id_fkey',
+            'image',
+            ['from_index_resolved_id'],
+            ['id'],
         )
         batch_op.create_foreign_key(
-            'request_index_image_id_fkey', 'image', ['index_image_id'], ['id'],
+            'request_index_image_id_fkey',
+            'image',
+            ['index_image_id'],
+            ['id'],
         )
         batch_op.create_foreign_key(
-            'request_binary_image_resolved_id_fkey', 'image', ['binary_image_resolved_id'], ['id'],
+            'request_binary_image_resolved_id_fkey',
+            'image',
+            ['binary_image_resolved_id'],
+            ['id'],
         )
         batch_op.create_foreign_key(
-            'request_binary_image_id_fkey', 'image', ['binary_image_id'], ['id'],
+            'request_binary_image_id_fkey',
+            'image',
+            ['binary_image_id'],
+            ['id'],
         )
         batch_op.create_foreign_key(
-            'request_from_index_id_fkey', 'image', ['from_index_id'], ['id'],
+            'request_from_index_id_fkey',
+            'image',
+            ['from_index_id'],
+            ['id'],
         )
 
     op.create_table(
@@ -302,10 +320,16 @@ def downgrade():
         sa.UniqueConstraint('request_id', 'operator_id'),
     )
     op.create_index(
-        'ix_request_operator_request_id', 'request_operator', ['request_id'], unique=False,
+        'ix_request_operator_request_id',
+        'request_operator',
+        ['request_id'],
+        unique=False,
     )
     op.create_index(
-        'ix_request_operator_operator_id', 'request_operator', ['operator_id'], unique=False,
+        'ix_request_operator_operator_id',
+        'request_operator',
+        ['operator_id'],
+        unique=False,
     )
 
     op.create_table(

--- a/iib/web/migrations/versions/274ba38408e8_initial_migration.py
+++ b/iib/web/migrations/versions/274ba38408e8_initial_migration.py
@@ -60,7 +60,9 @@ def upgrade():
         # naming convention used by Postgreql. This will allow us to drop them
         # in a future migration.
         sa.ForeignKeyConstraint(
-            ['binary_image_id'], ['image.id'], name='request_binary_image_id_fkey',
+            ['binary_image_id'],
+            ['image.id'],
+            name='request_binary_image_id_fkey',
         ),
         sa.ForeignKeyConstraint(
             ['binary_image_resolved_id'],
@@ -68,10 +70,14 @@ def upgrade():
             name='request_binary_image_resolved_id_fkey',
         ),
         sa.ForeignKeyConstraint(
-            ['from_index_id'], ['image.id'], name='request_from_index_id_fkey',
+            ['from_index_id'],
+            ['image.id'],
+            name='request_from_index_id_fkey',
         ),
         sa.ForeignKeyConstraint(
-            ['from_index_resolved_id'], ['image.id'], name='request_from_index_resolved_id_fkey',
+            ['from_index_resolved_id'],
+            ['image.id'],
+            name='request_from_index_resolved_id_fkey',
         ),
         sa.ForeignKeyConstraint(
             ['index_image_id'], ['image.id'], name='request_index_image_id_fkey'

--- a/iib/web/migrations/versions/4c9db41195ec_add_merge_index_image_api_endpoint.py
+++ b/iib/web/migrations/versions/4c9db41195ec_add_merge_index_image_api_endpoint.py
@@ -27,14 +27,38 @@ def upgrade():
         sa.Column('source_from_index_resolved_id', sa.Integer(), nullable=True),
         sa.Column('target_index_id', sa.Integer(), nullable=True),
         sa.Column('target_index_resolved_id', sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(['binary_image_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['binary_image_resolved_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['id'], ['request.id'],),
-        sa.ForeignKeyConstraint(['index_image_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['source_from_index_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['source_from_index_resolved_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['target_index_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['target_index_resolved_id'], ['image.id'],),
+        sa.ForeignKeyConstraint(
+            ['binary_image_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['binary_image_resolved_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['id'],
+            ['request.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['index_image_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['source_from_index_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['source_from_index_resolved_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['target_index_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['target_index_resolved_id'],
+            ['image.id'],
+        ),
         sa.PrimaryKeyConstraint('id'),
     )
 
@@ -42,8 +66,14 @@ def upgrade():
         'bundle_deprecation',
         sa.Column('merge_index_image_id', sa.Integer(), autoincrement=False, nullable=False),
         sa.Column('bundle_id', sa.Integer(), autoincrement=False, nullable=False),
-        sa.ForeignKeyConstraint(['bundle_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['merge_index_image_id'], ['request_merge_index_image.id'],),
+        sa.ForeignKeyConstraint(
+            ['bundle_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['merge_index_image_id'],
+            ['request_merge_index_image.id'],
+        ),
         sa.PrimaryKeyConstraint('merge_index_image_id', 'bundle_id'),
         sa.UniqueConstraint(
             'merge_index_image_id', 'bundle_id', name='merge_index_bundle_constraint'

--- a/iib/web/migrations/versions/5188702409d9_extra_build_tags.py
+++ b/iib/web/migrations/versions/5188702409d9_extra_build_tags.py
@@ -27,8 +27,14 @@ def upgrade():
         'request_build_tag',
         sa.Column('request_id', sa.Integer(), nullable=False),
         sa.Column('tag_id', sa.Integer(), autoincrement=False, nullable=False),
-        sa.ForeignKeyConstraint(['request_id'], ['request.id'],),
-        sa.ForeignKeyConstraint(['tag_id'], ['build_tag.id'],),
+        sa.ForeignKeyConstraint(
+            ['request_id'],
+            ['request.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['tag_id'],
+            ['build_tag.id'],
+        ),
         sa.PrimaryKeyConstraint('request_id', 'tag_id'),
         sa.UniqueConstraint('request_id', 'tag_id'),
     )

--- a/iib/web/migrations/versions/e16a8cd2e028_add_create_empty_index.py
+++ b/iib/web/migrations/versions/e16a8cd2e028_add_create_empty_index.py
@@ -28,13 +28,34 @@ def upgrade():
         sa.Column('index_image_id', sa.Integer(), nullable=True),
         sa.Column('index_image_resolved_id', sa.Integer(), nullable=True),
         sa.Column('distribution_scope', sa.String(), nullable=True),
-        sa.ForeignKeyConstraint(['binary_image_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['binary_image_resolved_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['from_index_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['from_index_resolved_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['id'], ['request.id'],),
-        sa.ForeignKeyConstraint(['index_image_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['index_image_resolved_id'], ['image.id'],),
+        sa.ForeignKeyConstraint(
+            ['binary_image_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['binary_image_resolved_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['from_index_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['from_index_resolved_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['id'],
+            ['request.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['index_image_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['index_image_resolved_id'],
+            ['image.id'],
+        ),
         sa.PrimaryKeyConstraint('id'),
     )
 

--- a/iib/web/migrations/versions/eec630370e68_support_deprecation_list_in_add_request_.py
+++ b/iib/web/migrations/versions/eec630370e68_support_deprecation_list_in_add_request_.py
@@ -21,8 +21,14 @@ def upgrade():
         'request_add_bundle_deprecation',
         sa.Column('request_add_id', sa.Integer(), autoincrement=False, nullable=False),
         sa.Column('bundle_id', sa.Integer(), autoincrement=False, nullable=False),
-        sa.ForeignKeyConstraint(['bundle_id'], ['image.id'],),
-        sa.ForeignKeyConstraint(['request_add_id'], ['request_add.id'],),
+        sa.ForeignKeyConstraint(
+            ['bundle_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['request_add_id'],
+            ['request_add.id'],
+        ),
         sa.PrimaryKeyConstraint('request_add_id', 'bundle_id'),
         sa.UniqueConstraint(
             'request_add_id', 'bundle_id', name='request_add_bundle_deprecation_constraint'

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -1077,7 +1077,9 @@ class RequestRm(Request, RequestIndexImageMixin):
             raise ValidationError(f'"operators" should be a non-empty array of strings')
 
         cls._from_json(
-            request_kwargs, additional_required_params=['operators', 'from_index'], batch=batch,
+            request_kwargs,
+            additional_required_params=['operators', 'from_index'],
+            batch=batch,
         )
 
         request_kwargs['operators'] = [Operator.get_or_create(name=item) for item in operators]

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -281,7 +281,9 @@ def deprecate_bundles_fbc(bundles, base_dir, binary_image, from_index):
     index_db_file = _get_or_create_temp_index_db_file(base_dir=base_dir, from_index=from_index)
 
     opm_registry_deprecatetruncate(
-        base_dir=base_dir, index_db=index_db_file, bundles=bundles,
+        base_dir=base_dir,
+        index_db=index_db_file,
+        bundles=bundles,
     )
 
     fbc_dir = opm_migrate(index_db_file, base_dir)
@@ -387,7 +389,11 @@ def opm_generate_dockerfile(fbc_dir, base_dir, index_db, binary_image, dockerfil
 
 @retry(exceptions=IIBError, tries=2, logger=log)
 def _opm_registry_add(
-    base_dir, index_db, bundles, overwrite_csv=False, container_tool=None,
+    base_dir,
+    index_db,
+    bundles,
+    overwrite_csv=False,
+    container_tool=None,
 ):
     """
     Add the input bundles to an operator index database.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 100
 skip-string-normalization = true
-target-version = ['py38']
+target-version = ['py38', 'py39']

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     entry_points={'console_scripts': ['iib=iib.web.manage:cli']},
     license="GPLv3+",

--- a/tests/test_web/test_broker_error.py
+++ b/tests/test_web/test_broker_error.py
@@ -67,7 +67,13 @@ def test_catch_remove_operator_failure(mock_smfsc, mock_rm, db, auth_env, client
 @mock.patch('iib.web.api_v1.messaging.send_message_for_state_change')
 @mock.patch('iib.web.api_v1.messaging.send_messages_for_new_batch_of_requests')
 def test_catch_regenerate_bundle_batch_failure(
-    mock_smfnbor, mock_smfsc, mock_hrbr, app, auth_env, client, db,
+    mock_smfnbor,
+    mock_smfsc,
+    mock_hrbr,
+    app,
+    auth_env,
+    client,
+    db,
 ):
     mock_hrbr.apply_async.side_effect = OperationalError
 

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -1183,21 +1183,24 @@ def test_add_label_to_index(tmpdir):
 
 
 def test_get_missing_bundles_no_match():
-    assert build._get_missing_bundles(
-        [
-            {
-                'packageName': 'bundle1',
-                'version': 'v1.0',
-                'bundlePath': 'quay.io/pkg/pkg1@sha256:987654',
-            },
-            {
-                'packageName': 'bundle2',
-                'version': 'v2.0',
-                'bundlePath': 'quay.io/pkg/pkg2@sha256:111111',
-            },
-        ],
-        ['quay.io/ns/repo@sha256:123456'],
-    ) == ['quay.io/ns/repo@sha256:123456']
+    assert (
+        build._get_missing_bundles(
+            [
+                {
+                    'packageName': 'bundle1',
+                    'version': 'v1.0',
+                    'bundlePath': 'quay.io/pkg/pkg1@sha256:987654',
+                },
+                {
+                    'packageName': 'bundle2',
+                    'version': 'v2.0',
+                    'bundlePath': 'quay.io/pkg/pkg2@sha256:111111',
+                },
+            ],
+            ['quay.io/ns/repo@sha256:123456'],
+        )
+        == ['quay.io/ns/repo@sha256:123456']
+    )
 
 
 def test_get_missing_bundles_match_hash():
@@ -1245,7 +1248,9 @@ def test_get_present_bundles(moc_osfi, mock_run_cmd, tmpdir):
 @mock.patch('iib.workers.tasks.build.run_cmd')
 @mock.patch('iib.workers.tasks.build.opm_serve_from_index')
 def test_get_no_present_bundles(
-    moc_osfi, mock_run_cmd, tmpdir,
+    moc_osfi,
+    mock_run_cmd,
+    tmpdir,
 ):
 
     rpc_mock = mock.MagicMock()

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -162,7 +162,9 @@ def test_serve_cmd_at_port_delayed_initialize(
 @mock.patch('iib.workers.tasks.opm_operations.shutil.rmtree')
 @mock.patch('iib.workers.tasks.utils.run_cmd')
 def test_opm_migrate(
-    mock_run_cmd, moch_srmtree, tmpdir,
+    mock_run_cmd,
+    moch_srmtree,
+    tmpdir,
 ):
     index_db_file = os.path.join(tmpdir, 'database/index.db')
 
@@ -214,7 +216,10 @@ def test_opm_generate_dockerfile_no_dockerfile(mock_run_cmd, tmpdir, set_index_d
 
     with pytest.raises(IIBError, match=f"Cannot find generated Dockerfile at {df_path}"):
         opm_operations.opm_generate_dockerfile(
-            fbc_dir, tmpdir, index_db_file, "some:image",
+            fbc_dir,
+            tmpdir,
+            index_db_file,
+            "some:image",
         )
 
     mock_run_cmd.assert_called_once_with(
@@ -345,7 +350,12 @@ def test_opm_registry_add_fbc(
 @mock.patch('iib.workers.tasks.opm_operations._opm_registry_rm')
 @mock.patch('iib.workers.tasks.opm_operations.get_hidden_index_database')
 def test_opm_registry_rm_fbc(
-    mock_ghid, mock_orr, mock_om, mock_ogd, tmpdir, operators,
+    mock_ghid,
+    mock_orr,
+    mock_om,
+    mock_ogd,
+    tmpdir,
+    operators,
 ):
     from_index = 'some_index:latest'
     index_db_file = os.path.join(tmpdir, 'database/index.db')
@@ -354,11 +364,16 @@ def test_opm_registry_rm_fbc(
     mock_om.return_value = fbc_dir
 
     opm_operations.opm_registry_rm_fbc(
-        tmpdir, from_index, operators, 'some:image',
+        tmpdir,
+        from_index,
+        operators,
+        'some:image',
     )
 
     mock_orr.assert_called_once_with(
-        index_db_file, operators, tmpdir,
+        index_db_file,
+        operators,
+        tmpdir,
     )
 
     mock_om.assert_called_once_with(index_db=index_db_file, base_dir=tmpdir)
@@ -375,7 +390,9 @@ def test_opm_registry_rm_fbc(
 def test_opm_registry_rm(mock_run_cmd):
     packages = ['abc-operator', 'xyz-operator']
     opm_operations._opm_registry_rm(
-        '/tmp/somedir/some.db', packages, '/tmp/somedir',
+        '/tmp/somedir/some.db',
+        packages,
+        '/tmp/somedir',
     )
 
     mock_run_cmd.assert_called_once()
@@ -462,7 +479,9 @@ def test_opm_registry_deprecatetruncate(mock_run_cmd, bundles):
     ]
 
     opm_operations.opm_registry_deprecatetruncate(
-        base_dir='/tmp', index_db=index_db_file, bundles=bundles,
+        base_dir='/tmp',
+        index_db=index_db_file,
+        bundles=bundles,
     )
 
     mock_run_cmd.assert_called_once_with(
@@ -477,7 +496,13 @@ def test_opm_registry_deprecatetruncate(mock_run_cmd, bundles):
 @mock.patch('iib.workers.tasks.opm_operations.opm_registry_deprecatetruncate')
 @mock.patch('iib.workers.tasks.opm_operations._get_or_create_temp_index_db_file')
 def test_deprecate_bundles_fbc(
-    mock_gtidf, mock_ord, mock_om, mock_ogd, from_index, bundles, tmpdir,
+    mock_gtidf,
+    mock_ord,
+    mock_om,
+    mock_ogd,
+    from_index,
+    bundles,
+    tmpdir,
 ):
     index_db_file = os.path.join(tmpdir, 'database/index.db')
     fbc_dir = os.path.join(tmpdir, 'catalogs')
@@ -485,7 +510,10 @@ def test_deprecate_bundles_fbc(
     mock_om.return_value = fbc_dir
 
     opm_operations.deprecate_bundles_fbc(
-        bundles=bundles, base_dir=tmpdir, binary_image="some:image", from_index=from_index,
+        bundles=bundles,
+        base_dir=tmpdir,
+        binary_image="some:image",
+        from_index=from_index,
     )
 
     mock_ord.assert_called_once_with(base_dir=tmpdir, index_db=index_db_file, bundles=bundles)

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -1073,7 +1073,11 @@ def test_get_binary_image_config_no_config_val():
 
 
 @pytest.mark.parametrize(
-    'endpoint', ("api.Registry/ListPackages", "api.Registry/ListBundles",),
+    'endpoint',
+    (
+        "api.Registry/ListPackages",
+        "api.Registry/ListBundles",
+    ),
 )
 @mock.patch('iib.workers.tasks.utils.run_cmd')
 @mock.patch('iib.workers.tasks.utils.opm_serve_from_index')

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ pytest_command =
 description = black checks [Mandatory]
 skip_install = true
 deps =
-    black==19.10b0
+    black==21.4b0
 commands =
     black --check --diff iib tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,18 @@
 [tox]
 skip_missing_interpreters = true
-envlist = black,docs,flake8,py38,safety,yamllint,bandit
+envlist = black,docs,flake8,py38,py39,safety,yamllint,bandit
 downloadcache = {toxworkdir}/_download/
 
 [testenv]
 usedevelop = true
 # 3.8 is the current suppported version
+# 3.9 is the latest version available on RHEL8
 basepython =
     black: python3.8
     docs: python3.8
     flake8: python3.8
     py38: python3.8
+    py39: python3.9
     safety: python3.8
     yamllint: python3.8
     bandit: python3.8
@@ -57,6 +59,13 @@ commands =
 
 [testenv:py38]
 description = Python 3.8 unit tests [Mandatory]
+commands =
+    {[testenv]pytest_command}
+deps = 
+    -rrequirements-test.txt
+
+[testenv:py39]
+description = Python 3.9 unit tests [Mandatory]
 commands =
     {[testenv]pytest_command}
 deps = 


### PR DESCRIPTION
# Add support for Python 3.9

This PR is a subsequent implementation of #355 and should be only merged **after** it.

It includes the support for Python3.9 as well as keep Python3.8 as default for IIB.

## Black update issues
The code-formatter `black` just support Python 3.9 from version [21.4b0](https://pypi.org/project/black/21.4b0/) and above. 

However, after upgrading `black` from `19.10b0` to `21.4b0` it complained about the formatting in our code, thus I had to let it reformat a series of files to be compliant with its new exigencies.

Finally `black` was updated and `py39` is fully supported.

## Changes
The following files were changed to support Python 3.9:
  * `.travis.yml`
  * `pyproject.toml`
  * `setup.py`
  * `tox.ini`
  
**All other files were just reformatted to be compliant with the new `black` constraints.**

## Observations
* This PR doesn't change any functionality on IIB, just reformat files and allow the use of Python 3.9
* The latest version of Python is 3.10 however this version is not supported on RHEL8 and RHEL9 beta uses 3.9 as default, thus the inclusion of 3.9 instead of 3.10


Refers to CLOUDDST-11351