### PR TITLE
Using correct binary_image variable for creating empty index as FBC

### DIFF
--- a/iib/workers/tasks/build_create_empty_index.py
+++ b/iib/workers/tasks/build_create_empty_index.py
@@ -112,7 +112,7 @@ def handle_create_empty_index_request(
                 temp_dir=temp_dir,
                 from_index_resolved=from_index_resolved,
                 from_index=from_index,
-                binary_image=binary_image,
+                binary_image=prebuild_info['binary_image'],
                 operators=operators,
             )
         else:


### PR DESCRIPTION
I was getting this error on my local host during testing: 

```
2022-01-20 10:22:32,679 iib.workers.tasks.opm_operations INFO opm_operations.opm_generate_dockerfile Generating Dockerfile with binary image None
2022-01-20 10:22:32,683 iib.workers.tasks.general ERROR general.failed_request_callback An unknown error occurred. See logs for details
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/src/iib/workers/tasks/utils.py", line 705, in wrapper
    return func(*args, **kwargs)
  File "/src/iib/workers/tasks/build_create_empty_index.py", line 110, in handle_create_empty_index_request
    opm_create_empty_fbc(
  File "/src/iib/workers/tasks/opm_operations.py", line 478, in opm_create_empty_fbc
    opm_generate_dockerfile(
  File "/src/iib/workers/tasks/opm_operations.py", line 262, in opm_generate_dockerfile
    run_cmd(cmd, {'cwd': base_dir}, exc_msg='Failed to generate Dockerfile for file-based catalog')
  File "/src/iib/workers/tasks/utils.py", line 640, in run_cmd
    log.debug('Running the command "%s"', ' '.join(cmd))
TypeError: sequence item 6: expected str instance, NoneType found
```

After adding this patch I was able to create empty FBC index.

Refers to CLOUDDST-8773