### PR TITLE
Use set_registry_token before checking index_image

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -782,6 +782,7 @@ def handle_add_request(
                 bundles=resolved_bundles,
                 binary_image=prebuild_info['binary_image_resolved'],
                 from_index=from_index_resolved,
+                overwrite_from_index_token=overwrite_from_index_token,
                 overwrite_csv=(prebuild_info['distribution_scope'] in ['dev', 'stage']),
             )
         else:

--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -126,7 +126,8 @@ def _add_bundles_missing_in_source(
             '%s bundles have invalid version label and will be deprecated.', len(invalid_bundles)
         )
 
-    is_source_fbc = is_image_fbc(source_from_index)
+    with set_registry_token(overwrite_target_index_token, source_from_index):
+        is_source_fbc = is_image_fbc(source_from_index)
     if is_source_fbc:
         opm_registry_add_fbc(
             base_dir=base_dir,
@@ -134,6 +135,7 @@ def _add_bundles_missing_in_source(
             binary_image=binary_image,
             from_index=source_from_index,
             container_tool='podman',
+            overwrite_from_index_token=overwrite_target_index_token,
         )
     else:
         _opm_index_add(
@@ -215,8 +217,9 @@ def handle_merge_request(
     dockerfile_name = 'index.Dockerfile'
 
     with tempfile.TemporaryDirectory(prefix='iib-') as temp_dir:
-        source_fbc = is_image_fbc(source_from_index_resolved)
-        target_fbc = is_image_fbc(target_index_resolved)
+        with set_registry_token(overwrite_target_index_token, source_from_index):
+            source_fbc = is_image_fbc(source_from_index_resolved)
+            target_fbc = is_image_fbc(target_index_resolved)
 
         # do not remove - logging requested by stakeholders
         if source_fbc:

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -194,7 +194,9 @@ def _serve_cmd_at_port(serve_cmd, cwd, port, max_tries, wait_time):
     raise IIBError(f'Index registry has not been initialized after {max_tries} tries')
 
 
-def _get_or_create_temp_index_db_file(base_dir, from_index=None):
+def _get_or_create_temp_index_db_file(
+    base_dir, from_index=None, overwrite_from_index_token=None, ignore_existing=False
+):
     """
     Get path to temp index.db used for opm registry commands.
 
@@ -203,6 +205,8 @@ def _get_or_create_temp_index_db_file(base_dir, from_index=None):
 
     :param str base_dir: base directory where index.db file will be located.
     :param str from_index: index image, from which we should copy index.
+    :param bool ignore_existing: if set it forces to copy index.db from `from_index`.
+       `from_index` must be set
     :return: Returns path to index.db located in base_dir.
     :rtype: str
     """
@@ -210,7 +214,7 @@ def _get_or_create_temp_index_db_file(base_dir, from_index=None):
 
     index_db_file = os.path.join(base_dir, get_worker_config()['temp_index_db_path'])
 
-    if os.path.exists(index_db_file):
+    if not ignore_existing and os.path.exists(index_db_file):
         log.debug('Temp index.db already exist for %s', from_index)
         return index_db_file
 

--- a/tests/test_workers/test_tasks/test_build_merge_index_image.py
+++ b/tests/test_workers/test_tasks/test_build_merge_index_image.py
@@ -164,7 +164,7 @@ def test_handle_merge_request(
         mock_dep_b.assert_called_once()
         assert mock_bi.call_count == 3
         assert mock_pi.call_count == 3
-    mock_set_registry_token.assert_called_once()
+    mock_set_registry_token.call_count == 2
     assert mock_add_label_to_index.call_count == 2
     mock_uiips.assert_called_once()
 

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -280,6 +280,7 @@ def test_opm_registry_add(
     assert "--enable-alpha" in opm_args
 
 
+@pytest.mark.parametrize('is_fbc', (True, False))
 @pytest.mark.parametrize('from_index', (None, 'some_index:latest'))
 @pytest.mark.parametrize('bundles', (['bundle:1.2', 'bundle:1.3'], []))
 @pytest.mark.parametrize('overwrite_csv', (True, False))
@@ -287,9 +288,13 @@ def test_opm_registry_add(
 @mock.patch('iib.workers.tasks.opm_operations.opm_generate_dockerfile')
 @mock.patch('iib.workers.tasks.opm_operations.opm_migrate')
 @mock.patch('iib.workers.tasks.opm_operations._opm_registry_add')
+@mock.patch('iib.workers.tasks.build._get_index_database')
 @mock.patch('iib.workers.tasks.opm_operations.get_hidden_index_database')
+@mock.patch('iib.workers.tasks.opm_operations.is_image_fbc')
 def test_opm_registry_add_fbc(
+    mock_iifbc,
     mock_ghid,
+    mock_gid,
     mock_ora,
     mock_om,
     mock_ogd,
@@ -297,12 +302,15 @@ def test_opm_registry_add_fbc(
     bundles,
     overwrite_csv,
     container_tool,
+    is_fbc,
     tmpdir,
 ):
     index_db_file = os.path.join(tmpdir, 'database/index.db')
     fbc_dir = os.path.join(tmpdir, 'catalogs')
     mock_ghid.return_value = index_db_file
+    mock_gid.return_value = index_db_file
     mock_om.return_value = fbc_dir
+    mock_iifbc.return_value = is_fbc
 
     opm_operations.opm_registry_add_fbc(
         base_dir=tmpdir,


### PR DESCRIPTION
There was missing _set_registry_token (adding credentials from payload `overwrite_from_index_token`) when accessing image in private registry. 

CLOUDDST-11393