### PR TITLE
Pretty print (log) of RequestConfig classes

### DIFF
--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -195,6 +195,14 @@ class RequestConfig:
         identify the appropriate ``binary_image`` to use.
     """
 
+    # these attrs should not be printed out
+    _secret_attrs = [
+        'cnr_token',
+        'overwrite_from_index_token',
+        'overwrite_target_index_token',
+        'registry_auths',
+    ]
+
     _attrs = ["_binary_image", "distribution_scope", "binary_image_config"]
     __slots__ = _attrs
 
@@ -217,6 +225,14 @@ class RequestConfig:
         ]:
             return True
         return False
+
+    def __repr__(self):
+        # this is used to print() and log any instance of this class in dictionary format
+        attrs = {x: getattr(self, x) for x in self.__slots__}
+        for attr in self._secret_attrs:
+            if attrs.get(attr) is not None:
+                attrs[attr] = '*****'
+        return str(attrs)
 
     def binary_image(self, index_info, distribution_scope):
         """Get binary image based on self configuration, index image info and distribution scope."""


### PR DESCRIPTION
- print() or log can be used to display any RequestConfig class and its children

It removes unclear logging 
```
Prepare request for build with parameters <iib.workers.tasks.utils.RequestConfigCreateIndexImage object at 0x7efd5561dee0>
```
And replaces it with correct information
```
 Prepare request for build with parameters {'_binary_image': None, 'distribution_scope': None, 'binary_image_config': {'stage': {'v4.5': 'registry.redhat.io/openshift4/ose-operator-registry:v4.5', 'v4.6': 'registry.redhat.io/openshift4/ose-operator-registry:v4.6', 'v4.7': 'registry.redhat.io/openshift4/ose-operator-registry:v4.7', 'v4.8': 'registry.redhat.io/openshift4/ose-operator-registry:v4.8', 'v4.9': 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry:v4.9', 'v4.10': 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry:v4.9', 'v4.11': 'registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-operator-registry:v4.9'}}, 'overwrite_from_index_token': None, 'from_index': 'quay.io/jlipovsk/fbc-image:fbc', 'add_arches': None, 'bundles': None, 'operators': None}
```

And this is how it looks with overwrite_from_index_token set:
```
Prepare request for build with parameters {'_binary_image': 'registry.redhat.io/openshift4/ose-operator-registry:v4.9', 'distribution_scope': None, 'binary_image_config': {}, 'overwrite_from_index_token': '*****', 'from_index': 'quay.io/jlipovsk/pfbc:latest', 'add_arches': ['amd64'], 'bundles': ['registry-proxy.engineering.redhat.com/rh-osbs/lgallett-bundle:v1.0-9'], 'operators': None}
```

