### PR TITLE
Use terminate function to shut down a process instead of kill

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -330,7 +330,7 @@ def _get_present_bundles(from_index, base_dir):
         ['grpcurl', '-plaintext', f'localhost:{port}', 'api.Registry/ListBundles'],
         exc_msg='Failed to get bundle data from index image',
     )
-    rpc_proc.kill()
+    rpc_proc.terminate()
 
     # If no data is returned there are not bundles present
     if not bundles:

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -189,7 +189,7 @@ def _serve_cmd_at_port(serve_cmd, cwd, port, max_tries, wait_time):
                 log.info('Index registry service has been initialized.')
                 return rpc_proc
 
-        rpc_proc.kill()
+        rpc_proc.terminate()
 
     raise IIBError(f'Index registry has not been initialized after {max_tries} tries')
 

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -80,7 +80,7 @@ def add_max_ocp_version_property(resolved_bundles, temp_dir):
         ['grpcurl', '-plaintext', f'localhost:{port}', 'api.Registry/ListBundles'],
         exc_msg='Failed to get bundle data from index image',
     )
-    rpc_proc.kill()
+    rpc_proc.terminate()
 
     # This branch is hit when `bundles` attribute is empty and the index image is empty.
     # Ideally the code should not reach here if the bundles attribute is empty but adding
@@ -1040,5 +1040,5 @@ def grpcurl_get_db_data(from_index, base_dir, endpoint):
         ['grpcurl', '-plaintext', f'localhost:{port}', endpoint],
         exc_msg=f'Failed to get {endpoint} data from index image',
     )
-    rpc_proc.kill()
+    rpc_proc.terminate()
     return result


### PR DESCRIPTION
kill function sends the signal signal.SIGKILL because of which
OPM doesn't cleanup the temp directory after a request causing
memory issues in IIB. Replacing it with terminate function instead
sends signal.SIGTERM signal thus causing OPM to cleanup after the
request.

Refers to CLOUDDST-12129