### PR TITLE
Create empty index endpoint does not accept build_tags.

### DIFF
--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -1136,13 +1136,6 @@ components:
             type: string
           example:
             version: 'v4.6'
-        build_tags:
-          description: >
-              Extra tags applied to intermediate index image
-          type: array
-          items:
-            type: string
-          example: ["v4.5-10-08-2021"]
         output_fbc:
           type: boolean
           description: Specifies whether output index image should be File-based Catalog


### PR DESCRIPTION
Removind help text for build_tags since it is not accepted by create-empty-index endpoint