### PR TITLE
Increase iib_api_timeout, iib_retry_delay and iib_retry_jitter defaul…

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ The custom configuration options for the Celery workers are listed below:
   [broker_url](https://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url)
   configuration documentation.
 * `iib_api_timeout` - the timeout in seconds for HTTP requests to the REST API. This defaults to
-  `30` seconds.
+  `60` seconds.
 * `iib_api_url` - the URL to the IIB REST API (e.g. `https://iib.domain.local/api/v1/`).
 * `iib_aws_s3_bucket_name` - the name of the AWS S3 bucket used to store artifact files like logs
   and related_bundles if specified. `iib_request_logs_dir` and `iib_request_related_bundles_dir`
@@ -349,8 +349,8 @@ The custom configuration options for the Celery workers are listed below:
   `30s` (30 seconds).
 * `iib_total_attempts` - the total number of attempts to make at trying a function relating to the
   container registry before erroring out. This defaults to `5`. It's also used as the max number of attempts to buildah when receiving HTTP 50X errors.
-* `iib_retry_delay` - the delay in seconds between retry attempts. It's just used for buildah when receiving HTTP 50X errors. This defaults to `4`.
-* `iib_retry_jitter` - the extra seconds to be added on delay between retry attempts. It's just used for buildah when receiving HTTP 50X errors. This defaults to `2`.
+* `iib_retry_delay` - the delay in seconds between retry attempts. It's just used for buildah when receiving HTTP 50X errors. This defaults to `5`.
+* `iib_retry_jitter` - the extra seconds to be added on delay between retry attempts. It's just used for buildah when receiving HTTP 50X errors. This defaults to `5`.
 
 If you wish to configure AWS S3 bucket for storing artifact files, the following **environment variables**
 must be set along with `iib_aws_s3_bucket_name` config variable:

--- a/iib/workers/api_utils.py
+++ b/iib/workers/api_utils.py
@@ -25,7 +25,7 @@ def get_requests_session(auth=False):
             mutual_authentication=requests_kerberos.OPTIONAL
         )
     retry = Retry(
-        total=3, read=3, connect=3, backoff_factor=1, status_forcelist=(500, 502, 503, 504)
+        total=3, read=3, connect=3, backoff_factor=3, status_forcelist=(408, 500, 502, 503, 504)
     )
     adapter = requests.adapters.HTTPAdapter(max_retries=retry)
     session.mount('http://', adapter)

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -14,7 +14,7 @@ class Config(object):
     # Avoid infinite Celery retries when the broker is offline.
     broker_connection_max_retries: int = 10
     iib_aws_s3_bucket_name = None
-    iib_api_timeout = 30
+    iib_api_timeout = 60
     iib_docker_config_template = os.path.join(
         os.path.expanduser('~'), '.docker', 'config.json.template'
     )
@@ -43,8 +43,8 @@ class Config(object):
     iib_dogpile_arguments = {'url': ['127.0.0.1']}
     iib_skopeo_timeout = '300s'
     iib_total_attempts: int = 5
-    iib_retry_delay: int = 4
-    iib_retry_jitter: int = 2
+    iib_retry_delay: int = 5
+    iib_retry_jitter: int = 5
     include = [
         'iib.workers.tasks.build',
         'iib.workers.tasks.build_merge_index_image',

--- a/tests/test_workers/test_api_utils.py
+++ b/tests/test_workers/test_api_utils.py
@@ -15,7 +15,7 @@ def test_get_request(mock_session):
 
     api_utils.get_request(3)
 
-    mock_session.get.assert_called_once_with('http://iib-api:8080/api/v1/builds/3', timeout=30)
+    mock_session.get.assert_called_once_with('http://iib-api:8080/api/v1/builds/3', timeout=60)
 
 
 @mock.patch('iib.workers.api_utils.requests_session')
@@ -52,7 +52,7 @@ def test_set_omps_operator_version(mock_session):
     mock_session.patch.assert_called_once_with(
         'http://iib-api:8080/api/v1/builds/3',
         json={'omps_operator_version': '{"operator": "1.0.0"}'},
-        timeout=30,
+        timeout=60,
     )
 
 
@@ -66,7 +66,7 @@ def test_update_request(mock_session):
     mock_session.patch.assert_called_once_with(
         'http://iib-api:8080/api/v1/builds/3',
         json={'index_image': 'index-image:latest'},
-        timeout=30,
+        timeout=60,
     )
 
 


### PR DESCRIPTION


This will ensure that IIB backs off for a reasonable time before retrying
and will also retry on timeout errors.

Refers to CLOUDDST-14454