### PR TITLE
Adding ability to create single-active-consumer queues - iib web.

### DIFF
--- a/iib/web/app.py
+++ b/iib/web/app.py
@@ -7,6 +7,7 @@ from flask.logging import default_handler
 from flask_login import LoginManager
 from flask_migrate import Migrate
 import kombu.exceptions
+from kombu import Queue
 from werkzeug.exceptions import default_exceptions
 
 from iib.exceptions import ConfigError, IIBError, ValidationError
@@ -38,6 +39,12 @@ def load_config(app):
 
     if config_file and os.path.isfile(config_file):
         app.config.from_pyfile(config_file)
+
+    if app.config['IIB_SAC_QUEUES']:
+        app.config.conf.task_queues = [
+            Queue(qname, queue_arguments={'x-single-active-consumer': True})
+            for qname in app.config['IIB_SAC_QUEUES']
+        ]
 
 
 def validate_api_config(config):

--- a/iib/web/config.py
+++ b/iib/web/config.py
@@ -16,6 +16,7 @@ class Config(object):
     IIB_LOG_FORMAT = '%(asctime)s %(name)s %(levelname)s %(module)s.%(funcName)s %(message)s'
     # This sets the level of the "flask.app" logger, which is accessed from current_app.logger
     IIB_LOG_LEVEL = 'INFO'
+    IIB_SAC_QUEUES = []
     IIB_MAX_PER_PAGE = 20
     IIB_MESSAGING_CA = '/etc/pki/tls/certs/ca-bundle.crt'
     IIB_MESSAGING_CERT = '/etc/iib/messaging.crt'

--- a/tests/test_web/test_app.py
+++ b/tests/test_web/test_app.py
@@ -11,7 +11,7 @@ from iib.exceptions import ConfigError
 @mock.patch('iib.web.app.os.getenv')
 @mock.patch('iib.web.app.os.path.isfile')
 def test_load_config_dev(mock_isfile, mock_getenv):
-    mock_app = mock.Mock()
+    mock_app = mock.MagicMock()
 
     def new_getenv(key, default_value):
         return {'IIB_DEV': 'true'}.get(key, default_value)
@@ -27,7 +27,7 @@ def test_load_config_dev(mock_isfile, mock_getenv):
 @mock.patch('iib.web.app.os.path.isfile')
 def test_load_config_prod(mock_isfile, mock_getenv):
     mock_isfile.return_value = True
-    mock_app = mock.Mock()
+    mock_app = mock.MagicMock()
 
     load_config(mock_app)
 


### PR DESCRIPTION
- add iib_sac_queue in config
- setting 'x-single-active-consumer' as queue_arguments (RabbitMQ)

[CLOUDDST-15267]