### PR TITLE
Fix Rm request private registry bug

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -1011,6 +1011,7 @@ def handle_rm_request(
                 from_index=from_index_resolved,
                 operators=operators,
                 binary_image=prebuild_info['binary_image'],
+                overwrite_from_index_token=overwrite_from_index_token,
             )
 
         else:

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -550,6 +550,7 @@ def opm_registry_rm_fbc(
     from_index: str,
     operators: List[str],
     binary_image: str,
+    overwrite_from_index_token: Optional[str] = None,
 ) -> None:
     """
     Remove operator/s from a File Based Catalog index image.
@@ -563,10 +564,17 @@ def opm_registry_rm_fbc(
         removed from the output index image.
     :param str binary_image: the pull specification of the container image where the opm binary
         gets copied from. This should point to a digest or stable tag.
+    :param str overwrite_from_index_token: the token used for overwriting the input
+        ``from_index`` image. This is required to use ``overwrite_from_index``.
+        The format of the token must be in the format "user:password".
     """
+    from iib.workers.tasks.utils import set_registry_token
+
     log.info('Removing %s from a FBC Image %s', operators, from_index)
     log.info('Using the existing database from %s', from_index)
-    index_db_path = get_hidden_index_database(from_index=from_index, base_dir=base_dir)
+
+    with set_registry_token(overwrite_from_index_token, from_index, append=True):
+        index_db_path = get_hidden_index_database(from_index=from_index, base_dir=base_dir)
 
     _opm_registry_rm(index_db_path, operators, base_dir)
     fbc_dir = opm_migrate(index_db=index_db_path, base_dir=base_dir)

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -349,7 +349,9 @@ def test_opm_registry_add_fbc(
 @mock.patch('iib.workers.tasks.opm_operations.opm_migrate')
 @mock.patch('iib.workers.tasks.opm_operations._opm_registry_rm')
 @mock.patch('iib.workers.tasks.opm_operations.get_hidden_index_database')
+@mock.patch('iib.workers.tasks.utils.set_registry_token')
 def test_opm_registry_rm_fbc(
+    mock_srt,
     mock_ghid,
     mock_orr,
     mock_om,
@@ -364,10 +366,7 @@ def test_opm_registry_rm_fbc(
     mock_om.return_value = fbc_dir
 
     opm_operations.opm_registry_rm_fbc(
-        tmpdir,
-        from_index,
-        operators,
-        'some:image',
+        tmpdir, from_index, operators, 'some:image', overwrite_from_index_token='some_token'
     )
 
     mock_orr.assert_called_once_with(
@@ -376,6 +375,7 @@ def test_opm_registry_rm_fbc(
         tmpdir,
     )
 
+    mock_srt.assert_called_once_with('some_token', 'some_index:latest', append=True)
     mock_om.assert_called_once_with(index_db=index_db_file, base_dir=tmpdir)
     mock_ogd.assert_called_once_with(
         fbc_dir=fbc_dir,


### PR DESCRIPTION
IIB wasn't using the private registry token to pull the index for fbc images in rm requests

Refers to CLOUDDST-15975