### PR TITLE
IIB 6.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.7.0
+- Add bundle_replacements parameter to regenerate_bundle API and worker
+- Bump mako version
+- Increase iib_api_timeout to 120 seconds
+- Fix RM request private registry bug
+
 ## 6.6.1
 - Add recursive-related-bundles endpoint 
 - Adding ability to create single-active-consumer queues

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='iib',
-    version='6.6.1',
+    version='6.7.0',
     long_description=__doc__,
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,


### PR DESCRIPTION
- Add bundle_replacements parameter to regenerate_bundle API and worker
- Bump mako version
- Increase iib_api_timeout to 120 seconds
- Fix RM request private registry bug