### PR TITLE
Adding retry and port check when opm serve/opm registry serve is called

### DIFF
--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -190,7 +190,7 @@ def _serve_cmd_at_port(
                 output = ''
 
             if 'api.Registry.ListBundles' in output or 'api.Registry.ListPackages' in output:
-                log.debug('Started the command "%s"', ' '.join(serve_cmd))
+                log.debug('Started the command "%s"; pid: %d', ' '.join(serve_cmd), rpc_proc.pid)
                 log.info('Index registry service has been initialized.')
                 return rpc_proc
 

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -771,7 +771,7 @@ def terminate_process(proc: subprocess.Popen, timeout: int = 5) -> None:
     :param subprocess.Popen proc: process to be terminated
     :param int timeout: number of seconds to wait for terminating process
     """
-    log.debug('Terminating process %s', proc)
+    log.debug('Terminating process %s; pid: %d', proc, proc.pid)
     proc.terminate()
     try:
         # not using proc.wait() because it might cause deadlock when using pipes


### PR DESCRIPTION
This should prevent issue when _get_free_port_for_grpc returned false positive. Port which will be already taken by different service.

- we will try to run opm serve commands directly with port
- if port is taken we will get next port from given range and try that
- repeat this until free port is found

refers [CLOUDDST-16030]