### PR TITLE
bundle_replacements should only be a dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 /iib_data/
 /ca-bundle.crt
 compose-files/docker/
+
+# other files
+**/.DS_Store

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -1189,7 +1189,7 @@ class RequestRegenerateBundle(Request):
     @property
     def bundle_replacements(self):
         """Return the Python representation of the JSON bundle_replacements."""
-        return json.loads(self._bundle_replacements) if self._bundle_replacements else None
+        return json.loads(self._bundle_replacements) if self._bundle_replacements else {}
 
     @bundle_replacements.setter
     def bundle_replacements(self, bundle_replacements):
@@ -1201,9 +1201,7 @@ class RequestRegenerateBundle(Request):
         :param dict bundle_replacements: the dictionary of the bundle_replacements or ``None``
         """
         self._bundle_replacements = (
-            json.dumps(bundle_replacements, sort_keys=True)
-            if bundle_replacements is not None
-            else None
+            json.dumps(bundle_replacements, sort_keys=True) if bundle_replacements else None
         )
 
     @classmethod
@@ -1224,8 +1222,8 @@ class RequestRegenerateBundle(Request):
             optional_params={'bundle_replacements', 'organization', 'registry_auths'},
         )
         # Validate bundle_replacements is correctly provided
-        bundle_replacements = request_kwargs.get('bundle_replacements', None)
-        if bundle_replacements is not None:
+        bundle_replacements = request_kwargs.get('bundle_replacements', {})
+        if bundle_replacements:
             if not isinstance(bundle_replacements, dict):
                 raise ValidationError('The value of "bundle_replacements" must be a JSON object')
 
@@ -1281,6 +1279,7 @@ class RequestRegenerateBundle(Request):
             self.from_bundle_image_resolved, 'pull_specification', None
         )
         rv['organization'] = self.organization
+        rv['bundle_replacements'] = self.bundle_replacements
         if (
             current_app.config['IIB_REQUEST_RELATED_BUNDLES_DIR']
             or current_app.config['IIB_AWS_S3_BUCKET_NAME']

--- a/iib/workers/tasks/build_regenerate_bundle.py
+++ b/iib/workers/tasks/build_regenerate_bundle.py
@@ -55,7 +55,7 @@ def handle_regenerate_bundle_request(
     organization: str,
     request_id: int,
     registry_auths: Optional[Dict[str, Any]] = None,
-    bundle_replacements: Optional[Dict[str, str]] = None,
+    bundle_replacements: Optional[Dict[str, str]] = {},
 ) -> None:
     """
     Coordinate the work needed to regenerate the operator bundle image.

--- a/tests/test_web/test_api_v1.py
+++ b/tests/test_web/test_api_v1.py
@@ -1153,6 +1153,7 @@ def test_patch_request_regenerate_bundle_success(
         'batch': 1,
         'batch_annotations': None,
         'bundle_image': 'bundle:image',
+        'bundle_replacements': {},
         'from_bundle_image': minimal_request_regenerate_bundle.from_bundle_image.pull_specification,
         'from_bundle_image_resolved': 'from-bundle-image:resolved',
         'id': minimal_request_regenerate_bundle.id,
@@ -1337,7 +1338,10 @@ def test_not_found(client):
 @mock.patch('iib.web.api_v1.handle_regenerate_bundle_request')
 @mock.patch('iib.web.api_v1.messaging.send_message_for_state_change')
 def test_regenerate_bundle_success(mock_smfsc, mock_hrbr, db, auth_env, client):
-    data = {'from_bundle_image': 'registry.example.com/bundle-image:latest'}
+    data = {
+        'from_bundle_image': 'registry.example.com/bundle-image:latest',
+        'bundle_replacements': {'foo': 'bar'},
+    }
 
     # Assume a timestamp to simplify tests
     _timestamp = '2020-02-12T17:03:00Z'
@@ -1348,6 +1352,7 @@ def test_regenerate_bundle_success(mock_smfsc, mock_hrbr, db, auth_env, client):
         'batch': 1,
         'batch_annotations': None,
         'bundle_image': None,
+        'bundle_replacements': {'foo': 'bar'},
         'from_bundle_image': 'registry.example.com/bundle-image:latest',
         'from_bundle_image_resolved': None,
         'logs': {
@@ -1486,7 +1491,10 @@ def test_regenerate_bundle_batch_success(
                 'registry_auths': {'auths': {'registry2.example.com': {'auth': 'dummy_auth'}}},
                 'bundle_replacements': {'foo': 'bar:baz'},
             },
-            {'from_bundle_image': 'registry.example.com/bundle-image2:latest'},
+            {
+                'from_bundle_image': 'registry.example.com/bundle-image2:latest',
+                'bundle_replacements': None,
+            },
         ]
     }
     if annotations:

--- a/tests/test_web/test_models.py
+++ b/tests/test_web/test_models.py
@@ -205,3 +205,4 @@ def test_request_logs_and_related_bundles_in_response(
     rv = minimal_request_regenerate_bundle.to_json(verbose=True)
     assert rv['logs']['url'] == 'some-url-for-data'
     assert rv['related_bundles']['url'] == 'some-url-for-data'
+    assert rv['bundle_replacements'] == {}


### PR DESCRIPTION
If it is not configured, it should be set as an empty dictionary instead of None.

Signed-off-by: arewm <arewm@users.noreply.github.com>