### PR TITLE
Increase the retry delay and retry jitter for building images

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -58,8 +58,8 @@ class Config(object):
     iib_dogpile_arguments: Dict[str, List[str]] = {'url': ['127.0.0.1']}
     iib_skopeo_timeout: str = '300s'
     iib_total_attempts: int = 5
-    iib_retry_delay: int = 5
-    iib_retry_jitter: int = 5
+    iib_retry_delay: int = 10
+    iib_retry_jitter: int = 10
     iib_retry_multiplier: int = 5
     include: List[str] = [
         'iib.workers.tasks.build',


### PR DESCRIPTION
Refers to CLOUDDST-16426

When building the image, the buildah command is frequently failing while pulling the signatures of the binary image. Let's increase the retry delay to increase the chances of pulling the binary images successfully