### PR TITLE
Replacing Travis tests with GitHub Actions

### DIFF
--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -1,0 +1,42 @@
+---
+name: Run tox
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+        python-version: ["3.8", "3.9"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt install libkrb5-dev -y
+          python -m pip install --upgrade pip
+          pip install --upgrade virtualenv
+          pip install --upgrade tox>4.0.0
+          pip install --pre tox-gh-actions
+      - name: Run static tests with tox
+        run: |
+          tox -m static
+      - name: Run unit tests with tox
+        run: |
+          tox -m test
+      - name: Run documentation build test with tox
+        run: |
+          tox -m docs
+      - name: Run security checks with tox
+        run: |
+          tox -m security

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
----
-language: python
-python:
-  - "3.8"
-  - "3.9"
-install:
-  - pip3 install -U virtualenv pip tox
-script:
-  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,26 @@
 [tox]
+min_version = 4.0
 skip_missing_interpreters = true
 envlist = black,docs,flake8,py38,py39,safety,yamllint,bandit
 downloadcache = {toxworkdir}/_download/
+labels =
+    test = unit_tests
+    static = black, flake8, yamllint
+    security = bandit, safety
+    docs = docs
+
+[gh-actions]
+python =
+    3.8: py38, black, flake8, yamllint, mypy, bandit, safety, docs, unit_tests
+    3.9: py39, black, flake8, yamllint, mypy, bandit, safety, docs, unit_tests
 
 [testenv]
 usedevelop = true
 # 3.8 is the current suppported version
 # 3.9 is the latest version available on RHEL8
 basepython =
-    black: python3.8
-    docs: python3.8
-    flake8: python3.8
     py38: python3.8
     py39: python3.9
-    safety: python3.8
-    yamllint: python3.8
-    bandit: python3.8
-    mypy: python3.8
     migrate-db: python3.8
     pip-compile: python3.9
 setenv =
@@ -71,6 +75,13 @@ description = Python 3.9 unit tests [Mandatory]
 commands =
     {[testenv]pytest_command}
 deps = 
+    -rrequirements-test.txt
+
+[testenv:unit_tests]
+description = Python unit tests [Mandatory]
+commands =
+    {[testenv]pytest_command}
+deps =
     -rrequirements-test.txt
 
 [testenv:safety]

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,7 @@ setenv =
 	IIB_TESTING=true
 pytest_command =
     pytest -vv \
-        --capture=sys\
-        --cov-config .coveragerc --cov=iib --cov-report term \
+        --capture=sys --cov-config .coveragerc --cov=iib --cov-report term \
         --cov-report xml --cov-report html {posargs}
 
 [testenv:black]

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ downloadcache = {toxworkdir}/_download/
 labels =
     test = unit_tests
     static = black, flake8, yamllint
-    security = bandit, safety
+    security = bandit
     docs = docs
 
 [gh-actions]


### PR DESCRIPTION
Due to recent and increasing security issues on Travis CI we should move to GitHub Actions.