### PR TITLE
Set GID 0 for cache directory

### DIFF
--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -427,7 +427,7 @@ def verify_cache_insertion_edit_dockerfile(file_list: list) -> None:
     :raises: IIBError when the Dockerfile edit is unsuccessful.
     """
     copied_cache_found = False
-    match_str = f'COPY --chown=1001 cache /tmp/cache'
+    match_str = f'COPY --chown=1001:0 cache /tmp/cache'
     for line in file_list:
         if match_str in line:
             copied_cache_found = True
@@ -447,7 +447,7 @@ def insert_cache_into_dockerfile(dockerfile_path: str) -> None:
 
     file_data = file_data.replace(
         'RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]',
-        'COPY --chown=1001 cache /tmp/cache',
+        'COPY --chown=1001:0 cache /tmp/cache',
     )
 
     with open(dockerfile_path, 'w') as f:

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -587,7 +587,7 @@ def test_insert_cache_into_dockerfile(tmpdir):
     opm_operations.insert_cache_into_dockerfile(generated_dockerfile)
 
     assert generated_dockerfile.read_text('utf-8') == dockerfile_template.format(
-        run_command='COPY --chown=1001 cache /tmp/cache'
+        run_command='COPY --chown=1001:0 cache /tmp/cache'
     )
 
 
@@ -609,7 +609,7 @@ def test_insert_cache_into_dockerfile_no_matching_line(tmpdir):
 
 
 def test_verify_cache_insertion_edit_dockerfile():
-    input_list = ['ADD /configs', 'COPY . .' 'COPY --chown=1001 cache /tmp/cache']
+    input_list = ['ADD /configs', 'COPY . .' 'COPY --chown=1001:0 cache /tmp/cache']
     opm_operations.verify_cache_insertion_edit_dockerfile(input_list)
 
 


### PR DESCRIPTION
Fixing `/tmp/cache/cache: permission denied` caused by incorrect GID

[CLOUDDST-17016]