### PR TITLE
Fix sphinx version bug: Pin celery version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-celery
+celery==5.3.0b1
 boto3
 dogpile.cache
 flask
@@ -13,7 +13,7 @@ recommonmark
 requests
 ruamel.yaml
 # https://github.com/sphinx-doc/sphinx/issues/2796
-sphinx==5.3.0
+sphinx>5.3.0
 sphinx_rtd_theme
 tenacity
 typing-extensions


### PR DESCRIPTION
Cause of this error is Celery, which does return a string, instead of List[Nodes]. Sphinx was accepting strings from get_signature_prefix() in version 5.3.0, with a warning that this is going to be deprecated. Newer versions of Sphinx throw an error, if the string is returned from get_signature_prefix().
To confirm that this is caused by celery, I tried to create a minimal example https://github.com/xDaile/Celery_bug (also for the purposes of opening the issue in celery repo).
It seems to be already opened (closed now) issue and PRs related to this.

I also found same issue https://github.com/HEPData/hepdata/issues/594 where they explain that the issue was fixed by https://github.com/celery/celery/pull/7978.

There will be condition that if we will use sphinx > 5.2.7, we need celery with some newer version (5.3.0b1, should work now).