### PR TITLE
Fixing deprecation of operator in FBC image

### DIFF
--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -1088,7 +1088,7 @@ def get_all_index_images_info(
     return infos
 
 
-def get_image_label(pull_spec: str, label: str) -> Optional[str]:
+def get_image_label(pull_spec: str, label: str) -> str:
     """
     Get a specific label from the container image.
 
@@ -1098,7 +1098,7 @@ def get_image_label(pull_spec: str, label: str) -> Optional[str]:
     :rtype: str
     """
     log.debug('Getting the label of %s from %s', label, pull_spec)
-    return get_image_labels(pull_spec).get(label)
+    return get_image_labels(pull_spec).get(label, '')
 
 
 def verify_labels(bundles: List[str]) -> None:

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -795,7 +795,7 @@ def test_get_image_arches_not_manifest_list(mock_si):
         utils.get_image_arches('image:latest')
 
 
-@pytest.mark.parametrize('label, expected', (('some_label', 'value'), ('not_there', None)))
+@pytest.mark.parametrize('label, expected', (('some_label', 'value'), ('not_there', '')))
 @mock.patch('iib.workers.tasks.utils.skopeo_inspect')
 def test_get_image_label(mock_si, label, expected):
     mock_si.return_value = {'config': {'Labels': {'some_label': 'value'}}}


### PR DESCRIPTION
For correct behavior we have to remove all `deprecation_bundles` directories from FBC that may contain opted-in packages before overwriting catalogs (catalog from db and catalog from index). Otherwise already deprecated package is still served.