### PR TITLE
Retry buildah if incorrect arch created

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,9 @@ The custom configuration options for the Celery workers are listed below:
 * `iib_retry_jitter` - the extra seconds to be added on delay between retry attempts. It's just used for buildah when receiving HTTP 50X errors. This defaults to `5`.
 * `iib_retry_multiplier` - the constant in the `2^x * multiplier` formula, where x stands for attempt number. Formula is used to calculate the
   seconds to be added on delay between retry attempts. It's just used for buildah when receiving HTTP 50X errors. This defaults to `5`.
+* `iib_supported_archs` - the architectures supported by IIB. IIB can build index images for these
+  architectures. The dictionary has mapping of arch aliases with formal names like
+  `{"arm64": "aarch64"}`
 
 
 If you wish to configure AWS S3 bucket for storing artifact files, the following **environment variables**

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -61,6 +61,12 @@ class Config(object):
     iib_retry_delay: int = 10
     iib_retry_jitter: int = 10
     iib_retry_multiplier: int = 5
+    iib_supported_archs: dict = {
+        "amd64": "x86_64",
+        "arm64": "aarch64",
+        "s390x": "s390x",
+        "ppc64le": "ppc64le",
+    }
     include: List[str] = [
         'iib.workers.tasks.build',
         'iib.workers.tasks.build_merge_index_image',

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -548,7 +548,7 @@ def get_image_labels(pull_spec: str) -> Dict[str, str]:
     :return: the dictionary of the labels on the image
     :rtype: dict
     """
-    if pull_spec.startswith('docker://'):
+    if pull_spec.startswith('docker://') or pull_spec.startswith('containers-storage'):
         full_pull_spec = pull_spec
     else:
         full_pull_spec = f'docker://{pull_spec}'


### PR DESCRIPTION
buildah bud builds an index image with incorrect arch sometimes, in order to work around that inspect the image built and rebuild the image if the arch is incorrect.
Refers to CLOUDDST-18481