### PR TITLE
Retry update_request with back-off factor  on failure

### DIFF
--- a/tests/test_workers/test_api_utils.py
+++ b/tests/test_workers/test_api_utils.py
@@ -6,6 +6,9 @@ import pytest
 
 from iib.exceptions import IIBError
 from iib.workers import api_utils
+from iib.workers.config import get_worker_config
+
+config = get_worker_config()
 
 
 @mock.patch('iib.workers.api_utils.requests_session')
@@ -76,6 +79,7 @@ def test_update_request_connection_failed(mock_session):
 
     with pytest.raises(IIBError, match='The connection failed.+'):
         api_utils.update_request(3, {'index_image': 'index-image:latest'})
+        assert mock_session.patch.call_count == config.iib_total_attempts
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
TL;DR: When the API is momentarily unavailable, the request is not patched when the failed_request_callback function is called in case of a worker error and the request gets stuck.

When the API is down for a bit, possibly due to a new deployment or a kubernetes pod restart, and if the worker is processing a request at the same time and happens to update the request by calling the `patch` API endpoint, it's unreachable which causes the task on the worker to fail with an IIBError. Then, the `failed_request_callback` function is called from the worker which again tries to update the request with the "failed" state, again by calling the `patch` API endpoint. Again, that attempt fails because the API is down. So the worker task simply errors out and sends an `ack` message to RabbitMQ signalling that it has successfully processed the message and the request is stuck forever. (This is expected behavior because we want the `ack` to get delivered if the task fails due to any other reason - eg, failed to inspect the image. If the ack is not sent, RabbitMQ will keep requeuing the message). 

Refers to CLOUDDST-17935