### PR TITLE
Update Grpcio and Protobuf versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,12 @@ amqp==5.0.6 \
     --hash=sha256:03e16e94f2b34c31f8bf1206d8ddd3ccaa4c315f7f6a1879b7b1210d229568c2 \
     --hash=sha256:493a2ac6788ce270a2f6a765b017299f60c1998f5a8617908ee9be082f7300fb
     # via kombu
+backoff==1.10.0 \
+    --hash=sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd \
+    --hash=sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 billiard==3.6.4.0 \
     --hash=sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547 \
     --hash=sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b
@@ -158,6 +164,10 @@ decorator==4.4.2 \
     # via
     #   dogpile-cache
     #   gssapi
+deprecated==1.2.13 \
+    --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
+    --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
+    # via opentelemetry-api
 dogpile-cache==1.0.2 \
     --hash=sha256:64fda39d25b46486a4876417ca03a4af06f35bfadba9f59613f9b3d748aa21ef
     # via iib (setup.py)
@@ -183,6 +193,12 @@ flask-sqlalchemy==3.0.3 \
     # via
     #   flask-migrate
     #   iib (setup.py)
+googleapis-common-protos==1.52.0 \
+    --hash=sha256:560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351 \
+    --hash=sha256:c8961760f5aad9a711d37b675be103e0cc4e9a39327e0d6d857872f698403e24
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 greenlet==2.0.2 \
     --hash=sha256:03a8f4f3430c3b3ff8d10a2a86028c660355ab637cee9333d63d66b56f09d52a \
     --hash=sha256:0bf60faf0bc2468089bdc5edd10555bab6e85152191df713e2ab1fcc86382b5a \
@@ -245,6 +261,53 @@ greenlet==2.0.2 \
     --hash=sha256:f82d4d717d8ef19188687aa32b8363e96062911e63ba22a0cff7802a8e58e5f1 \
     --hash=sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526
     # via sqlalchemy
+grpcio==1.56.0 \
+    --hash=sha256:008767c0aed4899e657b50f2e0beacbabccab51359eba547f860e7c55f2be6ba \
+    --hash=sha256:03a80451530fd3b8b155e0c4480434f6be669daf7ecba56f73ef98f94222ee01 \
+    --hash=sha256:0409de787ebbf08c9d2bca2bcc7762c1efe72eada164af78b50567a8dfc7253c \
+    --hash=sha256:14e70b4dda3183abea94c72d41d5930c333b21f8561c1904a372d80370592ef3 \
+    --hash=sha256:17f47aeb9be0da5337f9ff33ebb8795899021e6c0741ee68bd69774a7804ca86 \
+    --hash=sha256:187b8f71bad7d41eea15e0c9812aaa2b87adfb343895fffb704fb040ca731863 \
+    --hash=sha256:1eadd6de258901929223f422ffed7f8b310c0323324caf59227f9899ea1b1674 \
+    --hash=sha256:38fdf5bd0a1c754ce6bf9311a3c2c7ebe56e88b8763593316b69e0e9a56af1de \
+    --hash=sha256:4241a1c2c76e748023c834995cd916570e7180ee478969c2d79a60ce007bc837 \
+    --hash=sha256:437af5a7673bca89c4bc0a993382200592d104dd7bf55eddcd141cef91f40bab \
+    --hash=sha256:43c50d810cc26349b093bf2cfe86756ab3e9aba3e7e681d360930c1268e1399a \
+    --hash=sha256:4c08ee21b3d10315b8dc26f6c13917b20ed574cdbed2d2d80c53d5508fdcc0f2 \
+    --hash=sha256:4f84a6fd4482e5fe73b297d4874b62a535bc75dc6aec8e9fe0dc88106cd40397 \
+    --hash=sha256:4feee75565d1b5ab09cb3a5da672b84ca7f6dd80ee07a50f5537207a9af543a4 \
+    --hash=sha256:50f4daa698835accbbcc60e61e0bc29636c0156ddcafb3891c987e533a0031ba \
+    --hash=sha256:59c4e606993a47146fbeaf304b9e78c447f5b9ee5641cae013028c4cca784617 \
+    --hash=sha256:5d2fc471668a7222e213f86ef76933b18cdda6a51ea1322034478df8c6519959 \
+    --hash=sha256:64bd3abcf9fb4a9fa4ede8d0d34686314a7075f62a1502217b227991d9ca4245 \
+    --hash=sha256:66f0369d27f4c105cd21059d635860bb2ea81bd593061c45fb64875103f40e4a \
+    --hash=sha256:6b5ce42a5ebe3e04796246ba50357f1813c44a6efe17a37f8dc7a5c470377312 \
+    --hash=sha256:72836b5a1d4f508ffbcfe35033d027859cc737972f9dddbe33fb75d687421e2e \
+    --hash=sha256:76b6e6e1ee9bda32e6e933efd61c512e9a9f377d7c580977f090d1a9c78cca44 \
+    --hash=sha256:79d4c5911d12a7aa671e5eb40cbb50a830396525014d2d6f254ea2ba180ce637 \
+    --hash=sha256:7beb84ebd0a3f732625124b73969d12b7350c5d9d64ddf81ae739bbc63d5b1ed \
+    --hash=sha256:8219f17baf069fe8e42bd8ca0b312b875595e43a70cabf397be4fda488e2f27d \
+    --hash=sha256:83ec714bbbe9b9502177c842417fde39f7a267031e01fa3cd83f1ca49688f537 \
+    --hash=sha256:8674fdbd28266d8efbcddacf4ec3643f76fe6376f73283fd63a8374c14b0ef7c \
+    --hash=sha256:881575f240eb5db72ddca4dc5602898c29bc082e0d94599bf20588fb7d1ee6a0 \
+    --hash=sha256:8b3b2c7b5feef90bc9a5fa1c7f97637e55ec3e76460c6d16c3013952ee479cd9 \
+    --hash=sha256:991224fd485e088d3cb5e34366053691a4848a6b7112b8f5625a411305c26691 \
+    --hash=sha256:aa08affbf672d051cd3da62303901aeb7042a2c188c03b2c2a2d346fc5e81c14 \
+    --hash=sha256:b1f4b6f25a87d80b28dd6d02e87d63fe1577fe6d04a60a17454e3f8077a38279 \
+    --hash=sha256:b4638a796778329cc8e142e4f57c705adb286b3ba64e00b0fa91eeb919611be8 \
+    --hash=sha256:bd55f743e654fb050c665968d7ec2c33f03578a4bbb163cfce38024775ff54cc \
+    --hash=sha256:c0bc9dda550785d23f4f025be614b7faa8d0293e10811f0f8536cf50435b7a30 \
+    --hash=sha256:c2148170e01d464d41011a878088444c13413264418b557f0bdcd1bf1b674a0e \
+    --hash=sha256:c243b158dd7585021d16c50498c4b2ec0a64a6119967440c5ff2d8c89e72330e \
+    --hash=sha256:c63bc5ac6c7e646c296fed9139097ae0f0e63f36f0864d7ce431cce61fe0118a \
+    --hash=sha256:c6f36621aabecbaff3e70c4d1d924c76c8e6a7ffec60c331893640a4af0a8037 \
+    --hash=sha256:d596408bab632ec7b947761e83ce6b3e7632e26b76d64c239ba66b554b7ee286 \
+    --hash=sha256:defdd14b518e6e468466f799aaa69db0355bca8d3a5ea75fb912d28ba6f8af31 \
+    --hash=sha256:e2db108b4c8e29c145e95b0226973a66d73ae3e3e7fae00329294af4e27f1c42 \
+    --hash=sha256:f92a99ab0c7772fb6859bf2e4f44ad30088d18f7c67b83205297bfb229e0d2cf \
+    --hash=sha256:fb34ace11419f1ae321c36ccaa18d81cd3f20728cd191250be42949d6845bb2d \
+    --hash=sha256:fdc3a895791af4addbb826808d4c9c35917c59bb5c430d729f44224e51c92d61
+    # via opentelemetry-exporter-otlp-proto-grpc
 gssapi==1.8.2 \
     --hash=sha256:02e0a8f35e1f5b1c0eada646e3da1af3022c25e8df26ded3fd18ee78abb155ea \
     --hash=sha256:13aba9a947994f5f5f1fb6f425b397a359b191cee2983fa33911cf5e212d6cfb \
@@ -367,13 +430,116 @@ markupsafe==2.1.2 \
     #   jinja2
     #   mako
     #   werkzeug
+opentelemetry-api==1.15.0 \
+    --hash=sha256:79ab791b4aaad27acc3dc3ba01596db5b5aac2ef75c70622c6038051d6c2cded \
+    --hash=sha256:e6c2d2e42140fd396e96edf75a7ceb11073f4efb4db87565a431cc9d0f93f2e0
+    # via
+    #   iib (setup.py)
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-exporter-otlp==1.15.0 \
+    --hash=sha256:4f7c49751d9720e2e726e13b0bb958ccade4e29122c305d92c033da432c8d2c5 \
+    --hash=sha256:79f22748b6a54808a0448093dfa189c8490e729f67c134d4c992533d9393b33e
+    # via iib (setup.py)
+opentelemetry-exporter-otlp-proto-grpc==1.15.0 \
+    --hash=sha256:844f2a4bb9bcda34e4eb6fe36765e5031aacb36dc60ed88c90fc246942ea26e7 \
+    --hash=sha256:c2a5492ba7d140109968135d641d06ce3c5bd73c50665f787526065d57d7fd1d
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.15.0 \
+    --hash=sha256:11b2c814249a49b22f6cca7a06b05701f561d577b747f3660dfd67b6eb9daf9c \
+    --hash=sha256:3ec2a02196c8a54bf5cbf7fe623a5238625638e83b6047a983bdf96e2bbb74c0
+    # via opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.36b0 \
+    --hash=sha256:83ba4ae7d5292b5b33e0f851cc5c76d8f91196b9b3527800fc13855c33383ac2 \
+    --hash=sha256:e3ddac9b3b93408ef26c8ecbf38f717042977e16381bb4cd329a5b4cf16998cf
+    # via
+    #   iib (setup.py)
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-botocore==0.36b0 \
+    --hash=sha256:339dc59659cd3f72004ca0a6e7ca86777e567c22eb367a1a4ec8c05ffd862950 \
+    --hash=sha256:fcb5bed8689401bc4fba5a4b72a1051858cd62601e1aea9d8d013867dc131443
+    # via iib (setup.py)
+opentelemetry-instrumentation-celery==0.36b0 \
+    --hash=sha256:929041edc4d367e49974730d2ad6802765e65d9a98714289c13b823913075445 \
+    --hash=sha256:bde0903801515d68011fcfff0deddab6506ce4accc99a389a91ff69965c0ff15
+    # via iib (setup.py)
+opentelemetry-instrumentation-flask==0.36b0 \
+    --hash=sha256:c11d232179bec91239a3e5b7fedec639ca5bad695cbb19611ee62e2d1306b880 \
+    --hash=sha256:f9fd7e9d2709e82e885e4f5ee9d07c10148b6dbe99dfaca73e56d817a52185f9
+    # via iib (setup.py)
+opentelemetry-instrumentation-logging==0.36b0 \
+    --hash=sha256:412d996a40912cd6b0a50beca98bb6a4c2e77dfe6546c4321c854dc66c8f3978 \
+    --hash=sha256:b4212b9ac50d8510b94d70419c8573c32375dc0e5f1d7db5ec39ab151f6919b0
+    # via iib (setup.py)
+opentelemetry-instrumentation-requests==0.36b0 \
+    --hash=sha256:39c65951a6bab3d41ec45a4ef42d8c1cdfeb618aa69da7177ad8958be12aee02 \
+    --hash=sha256:c40a075597325644e782e79e12065dfd8e363beac5259b89acda54c1d79a250c
+    # via iib (setup.py)
+opentelemetry-instrumentation-sqlalchemy==0.36b0 \
+    --hash=sha256:a19f0ae419832da77f50b3a7c3cbdadbe3c0bd690bfabb98977cd94383b75820 \
+    --hash=sha256:ba51cccf95a74f9774958f0bf7a87688742275288c52fa73875f76962314973f
+    # via iib (setup.py)
+opentelemetry-instrumentation-wsgi==0.36b0 \
+    --hash=sha256:16c9ea4fecf0d8e5af38508e3c5281245bc88cfa0cea00ca16bbbbfdbc24185a \
+    --hash=sha256:67d61b07bebe9c3f0df5ad66fc7e9ca812cd91e581fc065cd2f6ad7ccf744adb
+    # via
+    #   iib (setup.py)
+    #   opentelemetry-instrumentation-flask
+opentelemetry-proto==1.15.0 \
+    --hash=sha256:044b6d044b4d10530f250856f933442b8753a17f94ae37c207607f733fb9a844 \
+    --hash=sha256:9c4008e40ac8cab359daac283fbe7002c5c29c77ea2674ad5626a249e64e0101
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.15.0 \
+    --hash=sha256:555c533e9837766119bbccc7a80458c9971d853a6f1da683a2246cd5e53b4645 \
+    --hash=sha256:98dbffcfeebcbff12c0c974292d6ea603180a145904cf838b1fe4d5c99078425
+    # via
+    #   iib (setup.py)
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.36b0 \
+    --hash=sha256:829dc221795467d98b773c04096e29be038d77526dc8d6ac76f546fb6279bf01 \
+    --hash=sha256:adc05635e87b9d3e007c9f530eed487fc3ef2177d02f82f674f28ebf9aff8243
+    # via
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlalchemy
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.36b0 \
+    --hash=sha256:2d858af8ff8a035da650d564efb3ed1baba1de6479998d344de3a7597333fded \
+    --hash=sha256:804807d9f50f3e7e135356531e8662e37f8c4c3edd54fc5b1826cb62202098c9
+    # via
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-wsgi
 operator-manifest==0.0.5 \
     --hash=sha256:8e1dfc47fc133947ed575f947f0d51d7c5efb4beb0f5de5202214bea257c26b5
     # via iib (setup.py)
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
-    # via iib (setup.py)
+    # via
+    #   iib (setup.py)
+    #   opentelemetry-instrumentation-sqlalchemy
 pbr==5.4.5 \
     --hash=sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c \
     --hash=sha256:579170e23f8e0c2f24b0de612f71f648eccb79fb1322c814ae6b3c07b5ba23e8
@@ -382,6 +548,23 @@ prompt-toolkit==3.0.23 \
     --hash=sha256:5f29d62cb7a0ecacfa3d8ceea05a63cd22500543472d64298fc06ddda906b25d \
     --hash=sha256:7053aba00895473cb357819358ef33f11aa97e4ac83d38efb123e5649ceeecaf
     # via click-repl
+protobuf==4.23.4 \
+    --hash=sha256:0a5759f5696895de8cc913f084e27fd4125e8fb0914bb729a17816a33819f474 \
+    --hash=sha256:351cc90f7d10839c480aeb9b870a211e322bf05f6ab3f55fcb2f51331f80a7d2 \
+    --hash=sha256:5fea3c64d41ea5ecf5697b83e41d09b9589e6f20b677ab3c48e5f242d9b7897b \
+    --hash=sha256:6dd9b9940e3f17077e820b75851126615ee38643c2c5332aa7a359988820c720 \
+    --hash=sha256:7b19b6266d92ca6a2a87effa88ecc4af73ebc5cfde194dc737cf8ef23a9a3b12 \
+    --hash=sha256:8547bf44fe8cec3c69e3042f5c4fb3e36eb2a7a013bb0a44c018fc1e427aafbd \
+    --hash=sha256:9053df6df8e5a76c84339ee4a9f5a2661ceee4a0dab019e8663c50ba324208b0 \
+    --hash=sha256:c3e0939433c40796ca4cfc0fac08af50b00eb66a40bbbc5dee711998fb0bbc1e \
+    --hash=sha256:ccd9430c0719dce806b93f89c91de7977304729e55377f872a92465d548329a9 \
+    --hash=sha256:e1c915778d8ced71e26fcf43c0866d7499891bca14c4368448a82edc61fdbc70 \
+    --hash=sha256:e9d0be5bf34b275b9f87ba7407796556abeeba635455d036c7351f7c183ef8ff \
+    --hash=sha256:effeac51ab79332d44fba74660d40ae79985901ac21bca408f8dc335a81aa597 \
+    --hash=sha256:fee88269a090ada09ca63551bf2f573eb2424035bcf2cb1b121895b01a46594a
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 psycopg2-binary==2.9.3 \
     --hash=sha256:01310cf4cf26db9aea5158c217caa92d291f0500051a6469ac52166e1a16f5b7 \
     --hash=sha256:083a55275f09a62b8ca4902dd11f4b33075b743cf0d360419e2051a8a5d5ff76 \
@@ -481,6 +664,7 @@ requests==2.26.0 \
     --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
     # via
     #   iib (setup.py)
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-kerberos
 requests-kerberos==0.14.0 \
     --hash=sha256:cda9d1240ae5392e081869881c8742d0e171fd6a893a7ac0875db2748e966fd1 \
@@ -583,6 +767,13 @@ tenacity==8.1.0 \
     --hash=sha256:35525cd47f82830069f0d6b73f7eb83bc5b73ee2fff0437952cedf98b27653ac \
     --hash=sha256:e48c437fdf9340f5666b92cd7990e96bc5fc955e1298baf4a907e3972067a445
     # via iib (setup.py)
+typing-extensions==4.5.0 \
+    --hash=sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb \
+    --hash=sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4
+    # via
+    #   iib (setup.py)
+    #   opentelemetry-sdk
+    #   sqlalchemy
 urllib3==1.26.6 \
     --hash=sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4 \
     --hash=sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f
@@ -606,204 +797,6 @@ werkzeug==2.2.3 \
     # via
     #   flask
     #   flask-login
-zipp==3.15.0 \
-    --hash=sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b \
-    --hash=sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556
-    # via
-    #   importlib-metadata
-    #   importlib-resources
-backoff==1.10.0 \
-    --hash=sha256:5e73e2cbe780e1915a204799dba0a01896f45f4385e636bcca7a0614d879d0cd \
-    --hash=sha256:b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4
-    # via
-    #   -r requirements.in
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-deprecated==1.2.13 \
-    --hash=sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d \
-    --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
-    # via
-    #   -r requirements.in
-    #   opentelemetry-api
-googleapis-common-protos==1.52.0 \
-    --hash=sha256:560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351 \
-    --hash=sha256:c8961760f5aad9a711d37b675be103e0cc4e9a39327e0d6d857872f698403e24
-    # via
-    #   -r requirements.in
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.51.3 \
-    --hash=sha256:040eb421613b57c696063abde405916dd830203c184c9000fc8c3b3b3c950325 \
-    --hash=sha256:165b05af77e6aecb4210ae7663e25acf234ba78a7c1c157fa5f2efeb0d6ec53c \
-    --hash=sha256:200d69857f9910f7458b39b9bcf83ee4a180591b40146ba9e49314e3a7419313 \
-    --hash=sha256:22bdfac4f7f27acdd4da359b5e7e1973dc74bf1ed406729b07d0759fde2f064b \
-    --hash=sha256:2a8e17286c4240137d933b8ca506465472248b4ce0fe46f3404459e708b65b68 \
-    --hash=sha256:2cd2e4cefb724cab1ba2df4b7535a9980531b9ec51b4dbb5f137a1f3a3754ef0 \
-    --hash=sha256:2f8ff75e61e1227ba7a3f16b2eadbcc11d0a54096d52ab75a6b88cfbe56f55d1 \
-    --hash=sha256:2fdd6333ce96435408565a9dbbd446212cd5d62e4d26f6a3c0feb1e3c35f1cc8 \
-    --hash=sha256:30e09b5e0531685e176f49679b6a3b190762cc225f4565e55a899f5e14b3aa62 \
-    --hash=sha256:3667c06e37d6cd461afdd51cefe6537702f3d1dc5ff4cac07e88d8b4795dc16f \
-    --hash=sha256:36c8abbc5f837111e7bd619612eedc223c290b0903b952ce0c7b00840ea70f14 \
-    --hash=sha256:3709048fe0aa23dda09b3e69849a12055790171dab9e399a72ea8f9dfbf9ac80 \
-    --hash=sha256:3c1b9f8afa62ff265d86a4747a2990ec5a96e4efce5d5888f245a682d66eca47 \
-    --hash=sha256:3ea4341efe603b049e8c9a5f13c696ca37fcdf8a23ca35f650428ad3606381d9 \
-    --hash=sha256:3f9a7d88082b2a17ae7bd3c2354d13bab0453899e0851733f6afa6918373f476 \
-    --hash=sha256:49ede0528e9dac7e8a9fe30b16c73b630ddd9a576bf4b675eb6b0c53ee5ca00f \
-    --hash=sha256:54b0c29bdd9a3b1e1b61443ab152f060fc719f1c083127ab08d03fac5efd51be \
-    --hash=sha256:54e36c2ee304ff15f2bfbdc43d2b56c63331c52d818c364e5b5214e5bc2ad9f6 \
-    --hash=sha256:5694448256e3cdfe5bd358f1574a3f2f51afa20cc834713c4b9788d60b7cc646 \
-    --hash=sha256:5e77ee138100f0bb55cbd147840f87ee6241dbd25f09ea7cd8afe7efff323449 \
-    --hash=sha256:5eed34994c095e2bf7194ffac7381c6068b057ef1e69f8f08db77771350a7566 \
-    --hash=sha256:6604f614016127ae10969176bbf12eb0e03d2fb3d643f050b3b69e160d144fb4 \
-    --hash=sha256:68a7514b754e38e8de9075f7bb4dee919919515ec68628c43a894027e40ddec4 \
-    --hash=sha256:6972b009638b40a448d10e1bc18e2223143b8a7aa20d7def0d78dd4af4126d12 \
-    --hash=sha256:6c677581ce129f5fa228b8f418cee10bd28dd449f3a544ea73c8ba590ee49d0b \
-    --hash=sha256:6c99a73a6260bdf844b2e5ddad02dcd530310f80e1fa72c300fa19c1c7496962 \
-    --hash=sha256:82b0ad8ac825d4bb31bff9f638557c045f4a6d824d84b21e893968286f88246b \
-    --hash=sha256:881ecb34feabf31c6b3b9bbbddd1a5b57e69f805041e5a2c6c562a28574f71c4 \
-    --hash=sha256:8de30f0b417744288cec65ec8cf84b8a57995cf7f1e84ccad2704d93f05d0aae \
-    --hash=sha256:b69c7adc7ed60da1cb1b502853db61f453fc745f940cbcc25eb97c99965d8f41 \
-    --hash=sha256:be1bf35ce82cdbcac14e39d5102d8de4079a1c1a6a06b68e41fcd9ef64f9dd28 \
-    --hash=sha256:be7b2265b7527bb12109a7727581e274170766d5b3c9258d4e466f4872522d7a \
-    --hash=sha256:c02abd55409bfb293371554adf6a4401197ec2133dd97727c01180889014ba4d \
-    --hash=sha256:c831f31336e81243f85b6daff3e5e8a123302ce0ea1f2726ad752fd7a59f3aee \
-    --hash=sha256:cd0daac21d9ef5e033a5100c1d3aa055bbed28bfcf070b12d8058045c4e821b1 \
-    --hash=sha256:cd9a5e68e79c5f031500e67793048a90209711e0854a9ddee8a3ce51728de4e5 \
-    --hash=sha256:d5cd1389669a847555df54177b911d9ff6f17345b2a6f19388707b7a9f724c88 \
-    --hash=sha256:d81528ffe0e973dc840ec73a4132fd18b8203ad129d7410155d951a0a7e4f5d0 \
-    --hash=sha256:e860a3222139b41d430939bbec2ec9c3f6c740938bf7a04471a9a8caaa965a2e \
-    --hash=sha256:e95c7ccd4c5807adef1602005513bf7c7d14e5a41daebcf9d8d30d8bf51b8f81 \
-    --hash=sha256:eafbe7501a3268d05f2e450e1ddaffb950d842a8620c13ec328b501d25d2e2c3 \
-    --hash=sha256:eef0450a4b5ed11feab639bf3eb1b6e23d0efa9b911bf7b06fb60e14f5f8a585 \
-    --hash=sha256:f601aaeae18dab81930fb8d4f916b0da21e89bb4b5f7367ef793f46b4a76b7b0 \
-    --hash=sha256:f7a0d0bf44438869d307f85a54f25a896ad6b4b0ca12370f76892ad732928d87 \
-    --hash=sha256:ffaaf7e93fcb437356b5a4b23bf36e8a3d0221399ff77fd057e4bc77776a24be
-    # via
-    #   -r requirements.in
-    #   opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-api==1.15.0 \
-    --hash=sha256:79ab791b4aaad27acc3dc3ba01596db5b5aac2ef75c70622c6038051d6c2cded \
-    --hash=sha256:e6c2d2e42140fd396e96edf75a7ceb11073f4efb4db87565a431cc9d0f93f2e0
-    # via
-    #   -r requirements.in
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-    #   opentelemetry-instrumentation
-    #   opentelemetry-instrumentation-flask
-    #   opentelemetry-instrumentation-wsgi
-    #   opentelemetry-sdk
-opentelemetry-exporter-otlp==1.15.0 \
-    --hash=sha256:4f7c49751d9720e2e726e13b0bb958ccade4e29122c305d92c033da432c8d2c5 \
-    --hash=sha256:79f22748b6a54808a0448093dfa189c8490e729f67c134d4c992533d9393b33e
-    # via -r requirements.in
-opentelemetry-exporter-otlp-proto-grpc==1.15.0 \
-    --hash=sha256:844f2a4bb9bcda34e4eb6fe36765e5031aacb36dc60ed88c90fc246942ea26e7 \
-    --hash=sha256:c2a5492ba7d140109968135d641d06ce3c5bd73c50665f787526065d57d7fd1d
-    # via
-    #   -r requirements.in
-    #   opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.15.0 \
-    --hash=sha256:11b2c814249a49b22f6cca7a06b05701f561d577b747f3660dfd67b6eb9daf9c \
-    --hash=sha256:3ec2a02196c8a54bf5cbf7fe623a5238625638e83b6047a983bdf96e2bbb74c0
-    # via
-    #   -r requirements.in
-    #   opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.36b0 \
-    --hash=sha256:83ba4ae7d5292b5b33e0f851cc5c76d8f91196b9b3527800fc13855c33383ac2 \
-    --hash=sha256:e3ddac9b3b93408ef26c8ecbf38f717042977e16381bb4cd329a5b4cf16998cf
-    # via
-    #   -r requirements.in
-    #   opentelemetry-instrumentation-flask
-    #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-flask==0.36b0 \
-    --hash=sha256:c11d232179bec91239a3e5b7fedec639ca5bad695cbb19611ee62e2d1306b880 \
-    --hash=sha256:f9fd7e9d2709e82e885e4f5ee9d07c10148b6dbe99dfaca73e56d817a52185f9
-    # via -r requirements.in
-opentelemetry-instrumentation-wsgi==0.36b0 \
-    --hash=sha256:16c9ea4fecf0d8e5af38508e3c5281245bc88cfa0cea00ca16bbbbfdbc24185a \
-    --hash=sha256:67d61b07bebe9c3f0df5ad66fc7e9ca812cd91e581fc065cd2f6ad7ccf744adb
-    # via
-    #   -r requirements.in
-    #   opentelemetry-instrumentation-flask
-opentelemetry-proto==1.15.0 \
-    --hash=sha256:044b6d044b4d10530f250856f933442b8753a17f94ae37c207607f733fb9a844 \
-    --hash=sha256:9c4008e40ac8cab359daac283fbe7002c5c29c77ea2674ad5626a249e64e0101
-    # via
-    #   -r requirements.in
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.15.0 \
-    --hash=sha256:555c533e9837766119bbccc7a80458c9971d853a6f1da683a2246cd5e53b4645 \
-    --hash=sha256:98dbffcfeebcbff12c0c974292d6ea603180a145904cf838b1fe4d5c99078425
-    # via
-    #   -r requirements.in
-    #   opentelemetry-exporter-otlp-proto-grpc
-    #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.36b0 \
-    --hash=sha256:829dc221795467d98b773c04096e29be038d77526dc8d6ac76f546fb6279bf01 \
-    --hash=sha256:adc05635e87b9d3e007c9f530eed487fc3ef2177d02f82f674f28ebf9aff8243
-    # via
-    #   -r requirements.in
-    #   opentelemetry-instrumentation-flask
-    #   opentelemetry-instrumentation-wsgi
-    #   opentelemetry-sdk
-opentelemetry-util-http==0.36b0 \
-    --hash=sha256:2d858af8ff8a035da650d564efb3ed1baba1de6479998d344de3a7597333fded \
-    --hash=sha256:804807d9f50f3e7e135356531e8662e37f8c4c3edd54fc5b1826cb62202098c9
-    # via
-    #   -r requirements.in
-    #   opentelemetry-instrumentation-flask
-    #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-sqlalchemy==0.36b0 \
-    --hash=sha256:a19f0ae419832da77f50b3a7c3cbdadbe3c0bd690bfabb98977cd94383b75820 \
-    --hash=sha256:ba51cccf95a74f9774958f0bf7a87688742275288c52fa73875f76962314973f
-opentelemetry-instrumentation-celery==0.36b0 \
-    --hash=sha256:929041edc4d367e49974730d2ad6802765e65d9a98714289c13b823913075445 \
-    --hash=sha256:bde0903801515d68011fcfff0deddab6506ce4accc99a389a91ff69965c0ff15
-opentelemetry-instrumentation-logging==0.36b0 \
-    --hash=sha256:412d996a40912cd6b0a50beca98bb6a4c2e77dfe6546c4321c854dc66c8f3978 \
-    --hash=sha256:b4212b9ac50d8510b94d70419c8573c32375dc0e5f1d7db5ec39ab151f6919b0
-opentelemetry-instrumentation-requests==0.36b0 \
-    --hash=sha256:39c65951a6bab3d41ec45a4ef42d8c1cdfeb618aa69da7177ad8958be12aee02 \
-    --hash=sha256:c40a075597325644e782e79e12065dfd8e363beac5259b89acda54c1d79a250c
-opentelemetry-instrumentation-botocore==0.36b0 \
-    --hash=sha256:339dc59659cd3f72004ca0a6e7ca86777e567c22eb367a1a4ec8c05ffd862950 \
-    --hash=sha256:fcb5bed8689401bc4fba5a4b72a1051858cd62601e1aea9d8d013867dc131443
-protobuf==3.20.0 \
-    --hash=sha256:001c2160c03b6349c04de39cf1a58e342750da3632f6978a1634a3dcca1ec10e \
-    --hash=sha256:0b250c60256c8824219352dc2a228a6b49987e5bf94d3ffcf4c46585efcbd499 \
-    --hash=sha256:1d24c81c2310f0063b8fc1c20c8ed01f3331be9374b4b5c2de846f69e11e21fb \
-    --hash=sha256:1eb13f5a5a59ca4973bcfa2fc8fff644bd39f2109c3f7a60bd5860cb6a49b679 \
-    --hash=sha256:25d2fcd6eef340082718ec9ad2c58d734429f2b1f7335d989523852f2bba220b \
-    --hash=sha256:32bf4a90c207a0b4e70ca6dd09d43de3cb9898f7d5b69c2e9e3b966a7f342820 \
-    --hash=sha256:38fd9eb74b852e4ee14b16e9670cd401d147ee3f3ec0d4f7652e0c921d6227f8 \
-    --hash=sha256:47257d932de14a7b6c4ae1b7dbf592388153ee35ec7cae216b87ae6490ed39a3 \
-    --hash=sha256:4eda68bd9e2a4879385e6b1ea528c976f59cd9728382005cc54c28bcce8db983 \
-    --hash=sha256:52bae32a147c375522ce09bd6af4d2949aca32a0415bc62df1456b3ad17c6001 \
-    --hash=sha256:542f25a4adf3691a306dcc00bf9a73176554938ec9b98f20f929a044f80acf1b \
-    --hash=sha256:5b5860b790498f233cdc8d635a17fc08de62e59d4dcd8cdb6c6c0d38a31edf2b \
-    --hash=sha256:6efe066a7135233f97ce51a1aa007d4fb0be28ef093b4f88dac4ad1b3a2b7b6f \
-    --hash=sha256:71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702 \
-    --hash=sha256:7a53d4035427b9dbfbb397f46642754d294f131e93c661d056366f2a31438263 \
-    --hash=sha256:7dcd84dc31ebb35ade755e06d1561d1bd3b85e85dbdbf6278011fc97b22810db \
-    --hash=sha256:88c8be0558bdfc35e68c42ae5bf785eb9390d25915d4863bbc7583d23da77074 \
-    --hash=sha256:8be43a91ab66fe995e85ccdbdd1046d9f0443d59e060c0840319290de25b7d33 \
-    --hash=sha256:8d84453422312f8275455d1cb52d850d6a4d7d714b784e41b573c6f5bfc2a029 \
-    --hash=sha256:9d0f3aca8ca51c8b5e204ab92bd8afdb2a8e3df46bd0ce0bd39065d79aabcaa4 \
-    --hash=sha256:a1eebb6eb0653e594cb86cd8e536b9b083373fca9aba761ade6cd412d46fb2ab \
-    --hash=sha256:bc14037281db66aa60856cd4ce4541a942040686d290e3f3224dd3978f88f554 \
-    --hash=sha256:fbcbb068ebe67c4ff6483d2e2aa87079c325f8470b24b098d6bf7d4d21d57a69 \
-    --hash=sha256:fd7133b885e356fa4920ead8289bb45dc6f185a164e99e10279f33732ed5ce15
-    # via
-    #   -r requirements.in
-    #   googleapis-common-protos
-    #   opentelemetry-proto
-typing-extensions==4.5.0 \
-    --hash=sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb \
-    --hash=sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4
-    # via
-    #   -r requirements.in
-    #   opentelemetry-sdk
 wrapt==1.14.1 \
     --hash=sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3 \
     --hash=sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b \
@@ -870,10 +863,17 @@ wrapt==1.14.1 \
     --hash=sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015 \
     --hash=sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af
     # via
-    #   -r requirements.in
     #   deprecated
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-sqlalchemy
+zipp==3.15.0 \
+    --hash=sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b \
+    --hash=sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # WARNING: The following packages were not pinned, but pip requires them to be
-# pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
+# pinned when the requirements file includes hashes and the requirement is not
+# satisfied by a package already installed. Consider using the --allow-unsafe flag.
 # setuptools


### PR DESCRIPTION
We need to update those two libraries, due to the discovery of CVE for current versions of Grpcio and Protobuf.

Only Grpcio and Protobuf versions are changed. Other libraries are just reordered automatically by pip-compile.

Grpc CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-1428
Protobuf CVE: https://nvd.nist.gov/vuln/detail/CVE-2022-3509#range-8681514