### PR TITLE
Add support for "graph_update_mode" parameter in Add request

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ The custom configuration options for the REST API are listed below:
   to another dictionary mapping ocp_version label to a binary image pull specification.
   This is useful in setting up customized binary image for different index image images thus
   reducing complexity for the end user. This defaults to `{}`.
+* `IIB_GRAPH_MODE_INDEX_ALLOW_LIST` - the list of index image pull specs on which using the
+  `graph_update_mode` parameter while submitting an IIB request is permitted. This defaults to `[]`
+  . Please check out the [API Documentation](http://release-engineering.github.io/iib) for more
+  information on how to use "graph_update_mode" for Add requests.
+* `IIB_GRAPH_MODE_OPTIONS` - the list of valid options for the `graph_update_mode` parameter in
+  the Add API endpoint. It defaults to `['replaces', 'semver', 'semver-skippatch']` i.e. the list
+  of modes supported by OPM.
 * `IIB_GREENWAVE_CONFIG` - the mapping, `dict(<str>: dict(<str>:<str>))`, of celery task queues to
   another dictionary of [Greenwave](https://docs.pagure.org/greenwave/) query parameters to their
   values. This is useful in setting up customized gating for each queue. This defaults to `{}`. Use

--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -127,6 +127,7 @@ def _get_add_args(
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
         payload.get('deprecation_list', []),
         payload.get('build_tags', []),
+        payload.get('graph_update_mode'),
     ]
 
 

--- a/iib/web/config.py
+++ b/iib/web/config.py
@@ -20,6 +20,8 @@ class Config(object):
     IIB_ADDITIONAL_LOGGERS: List[str] = []
     IIB_AWS_S3_BUCKET_NAME: Optional[str] = None
     IIB_BINARY_IMAGE_CONFIG: Dict[str, Dict[str, str]] = {}
+    IIB_GRAPH_MODE_INDEX_ALLOW_LIST: List[str] = []
+    IIB_GRAPH_MODE_OPTIONS: List[str] = ['replaces', 'semver', 'semver-skippatch']
     IIB_GREENWAVE_CONFIG: Dict[str, str] = {}
     IIB_LOG_FORMAT: str = '%(asctime)s %(name)s %(levelname)s %(module)s.%(funcName)s %(message)s'
     # This sets the level of the "flask.app" logger, which is accessed from current_app.logger

--- a/iib/web/iib_static_types.py
+++ b/iib/web/iib_static_types.py
@@ -65,6 +65,7 @@ PossiblePayloadParameters = Sequence[
         'force_backport',
         'from_bundle_image',
         'from_index',
+        'graph_update_mode',
         'labels',
         'operators',
         'organization',
@@ -92,6 +93,7 @@ class AddRequestPayload(TypedDict):
     distribution_scope: NotRequired[str]
     force_backport: NotRequired[bool]
     from_index: NotRequired[str]
+    graph_update_mode: NotRequired[str]
     organization: NotRequired[str]
     overwrite_from_index: NotRequired[bool]
     overwrite_from_index_token: NotRequired[str]
@@ -344,6 +346,7 @@ class AddRmRequestResponseBase(CommonIndexImageResponseBase, APIPartImageBuildRe
 class AddRequestResponse(AddRmRequestResponseBase):
     """Datastructure of the response to request from /builds/add API point."""
 
+    graph_update_mode: str
     omps_operator_version: Dict[str, Any]
 
 

--- a/iib/web/migrations/versions/daf67ddcf4a1_add_support_for_graph_update_mode_in_.py
+++ b/iib/web/migrations/versions/daf67ddcf4a1_add_support_for_graph_update_mode_in_.py
@@ -1,0 +1,25 @@
+"""Add support for graph_update_mode in Add endpoint.
+
+Revision ID: daf67ddcf4a1
+Revises: 8d50f82f0be9
+Create Date: 2023-07-27 15:37:59.568914
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'daf67ddcf4a1'
+down_revision = '8d50f82f0be9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('request_add', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('graph_update_mode', sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('request_add', schema=None) as batch_op:
+        batch_op.drop_column('graph_update_mode')

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -1012,6 +1012,14 @@ components:
           description: >
             from_index is required when add_arches is not provided.
           example: 'quay.io/iib-stage/iib:4'
+        graph_update_mode:
+          type: string
+          description: >
+            Graph update mode that defines how channel graphs are updated in the index. It must be one
+            of "replaces", "semver" or "semver-skippatch". This attribute can only be used on index
+            image pull specs configured in IIB_GRAPH_MODE_INDEX_ALLOW_LIST in the IIB API Config. If not
+            specified, "--mode" will not be added to OPM commands to add the bundle(s) to the index.
+          default: None
         organization:
           type: string
           description: >
@@ -1055,6 +1063,9 @@ components:
               example: add
             omps_operator_version:
               $ref: '#/components/schemas/OMPSOperatorVersion'
+            graph_update_mode:
+              type: string
+              example: semver
     RmRequest:
       type: object
       properties:

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -453,6 +453,7 @@ def _opm_index_add(
     bundles: List[str],
     binary_image: str,
     from_index: Optional[str] = None,
+    graph_update_mode: Optional[str] = None,
     overwrite_from_index_token: Optional[str] = None,
     overwrite_csv: bool = False,
     container_tool: Optional[str] = None,
@@ -469,6 +470,8 @@ def _opm_index_add(
         gets copied from. This should point to a digest or stable tag.
     :param str from_index: the pull specification of the container image containing the index that
         the index image build will be based from.
+    :param str graph_update_mode: Graph update mode that defines how channel graphs are updated
+        in the index.
     :param str overwrite_from_index_token: the token used for overwriting the input
         ``from_index`` image. This is required to use ``overwrite_from_index``.
         The format of the token must be in the format "user:password".
@@ -496,6 +499,10 @@ def _opm_index_add(
     if container_tool:
         cmd.append('--container-tool')
         cmd.append(container_tool)
+
+    if graph_update_mode:
+        log.info('Using %s mode to update the channel graph in the index', graph_update_mode)
+        cmd.extend(['--mode', graph_update_mode])
 
     log.info('Generating the database file with the following bundle(s): %s', ', '.join(bundles))
     if from_index:
@@ -789,6 +796,7 @@ def handle_add_request(
     binary_image_config: Optional[Dict[str, Dict[str, str]]] = None,
     deprecation_list: Optional[List[str]] = None,
     build_tags: Optional[List[str]] = None,
+    graph_update_mode: Optional[str] = None,
     traceparent: Optional[str] = None,
 ) -> None:
     """
@@ -824,6 +832,8 @@ def handle_add_request(
     :param list deprecation_list: list of deprecated bundles for the target index image. Defaults
         to ``None``.
     :param list build_tags: List of tags which will be applied to intermediate index images.
+    :param str graph_update_mode: Graph update mode that defines how channel graphs are updated
+        in the index.
     :param str traceparent: the traceparent header value to be used for tracing the request.
     :raises IIBError: if the index image build fails.
     """
@@ -898,6 +908,7 @@ def handle_add_request(
                 bundles=resolved_bundles,
                 binary_image=prebuild_info['binary_image_resolved'],
                 from_index=from_index_resolved,
+                graph_update_mode=graph_update_mode,
                 overwrite_from_index_token=overwrite_from_index_token,
                 overwrite_csv=(prebuild_info['distribution_scope'] in ['dev', 'stage']),
             )
@@ -907,6 +918,7 @@ def handle_add_request(
                 bundles=resolved_bundles,
                 binary_image=prebuild_info['binary_image_resolved'],
                 from_index=from_index_resolved,
+                graph_update_mode=graph_update_mode,
                 overwrite_from_index_token=overwrite_from_index_token,
                 overwrite_csv=(prebuild_info['distribution_scope'] in ['dev', 'stage']),
             )

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -524,6 +524,7 @@ def _opm_registry_add(
     bundles: List[str],
     overwrite_csv: bool = False,
     container_tool: Optional[str] = None,
+    graph_update_mode: Optional[str] = None,
 ) -> None:
     """
     Add the input bundles to an operator index database.
@@ -537,6 +538,8 @@ def _opm_registry_add(
     :param bool overwrite_csv: a boolean determining if a bundle will be replaced if the CSV
         already exists.
     :param str container_tool: the container tool to be used to operate on the index image
+    :param str graph_update_mode: Graph update mode that defines how channel graphs are updated
+        in the index.
     """
     from iib.workers.tasks.utils import run_cmd
 
@@ -561,6 +564,10 @@ def _opm_registry_add(
         cmd.append('--container-tool')
         cmd.append(container_tool)
 
+    if graph_update_mode:
+        log.info('Using %s mode to update the channel graph in the index', graph_update_mode)
+        cmd.extend(['--mode', graph_update_mode])
+
     log.info('Generating the database file with the following bundle(s): %s', ', '.join(bundles))
 
     if overwrite_csv:
@@ -581,6 +588,7 @@ def opm_registry_add_fbc(
     bundles: List[str],
     binary_image: str,
     from_index: Optional[str] = None,
+    graph_update_mode: Optional[str] = None,
     overwrite_csv: bool = False,
     overwrite_from_index_token: Optional[str] = None,
     container_tool: Optional[str] = None,
@@ -597,6 +605,8 @@ def opm_registry_add_fbc(
         gets copied from. This should point to a digest or stable tag.
     :param str from_index: the pull specification of the container image containing the index that
         the index image build will be based from.
+    :param str graph_update_mode: Graph update mode that defines how channel graphs are updated
+        in the index.
     :param bool overwrite_csv: a boolean determining if a bundle will be replaced if the CSV
         already exists.
     :param str overwrite_from_index_token: the token used for overwriting the input
@@ -617,6 +627,7 @@ def opm_registry_add_fbc(
         bundles=bundles,
         overwrite_csv=overwrite_csv,
         container_tool=container_tool,
+        graph_update_mode=graph_update_mode,
     )
 
     fbc_dir, _ = opm_migrate(index_db=index_db_file, base_dir=base_dir)

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -334,14 +334,18 @@ def test_get_local_pull_spec(request_id, arch):
 @pytest.mark.parametrize('bundles', (['bundle:1.2', 'bundle:1.3'], []))
 @pytest.mark.parametrize('overwrite_csv', (True, False))
 @pytest.mark.parametrize('container_tool', (None, 'podwoman'))
+@pytest.mark.parametrize('graph_update_mode', (None, 'semver'))
 @mock.patch('iib.workers.tasks.build.set_registry_token')
 @mock.patch('iib.workers.tasks.build.run_cmd')
-def test_opm_index_add(mock_run_cmd, mock_srt, from_index, bundles, overwrite_csv, container_tool):
+def test_opm_index_add(
+    mock_run_cmd, mock_srt, from_index, bundles, overwrite_csv, container_tool, graph_update_mode
+):
     build._opm_index_add(
         '/tmp/somedir',
         bundles,
         'binary-image:latest',
         from_index,
+        graph_update_mode,
         'user:pass',
         overwrite_csv,
         container_tool=container_tool,
@@ -368,6 +372,11 @@ def test_opm_index_add(mock_run_cmd, mock_srt, from_index, bundles, overwrite_cs
         assert container_tool in opm_args
     else:
         assert '--container-tool' not in opm_args
+    if graph_update_mode:
+        assert '--mode' in opm_args
+        assert graph_update_mode in opm_args
+    else:
+        assert '--mode' not in opm_args
     assert "--enable-alpha" in opm_args
 
     mock_srt.assert_called_once_with('user:pass', from_index, append=True)

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -286,6 +286,7 @@ def test_opm_registry_add(
 @pytest.mark.parametrize('bundles', (['bundle:1.2', 'bundle:1.3'], []))
 @pytest.mark.parametrize('overwrite_csv', (True, False))
 @pytest.mark.parametrize('container_tool', (None, 'podwoman'))
+@pytest.mark.parametrize('graph_update_mode', (None, 'semver-skippatch'))
 @mock.patch('iib.workers.tasks.opm_operations.opm_generate_dockerfile')
 @mock.patch('iib.workers.tasks.opm_operations.opm_migrate')
 @mock.patch('iib.workers.tasks.opm_operations._opm_registry_add')
@@ -303,6 +304,7 @@ def test_opm_registry_add_fbc(
     bundles,
     overwrite_csv,
     container_tool,
+    graph_update_mode,
     is_fbc,
     tmpdir,
 ):
@@ -319,6 +321,7 @@ def test_opm_registry_add_fbc(
         bundles=bundles,
         binary_image="some:image",
         from_index=from_index,
+        graph_update_mode=graph_update_mode,
         overwrite_csv=overwrite_csv,
         container_tool=container_tool,
     )
@@ -329,6 +332,7 @@ def test_opm_registry_add_fbc(
         bundles=bundles,
         overwrite_csv=overwrite_csv,
         container_tool=container_tool,
+        graph_update_mode=graph_update_mode,
     )
 
     mock_om.assert_called_once_with(index_db=index_db_file, base_dir=tmpdir)


### PR DESCRIPTION
Refers to CLOUDDST-19655

This PR allows the user to specify "graph_update_mode" as a parameter while submitting an `Add` request to IIB. It allows the user to specify the OPM graph update mode that defines how the channel graphs are updated in the index. It is a restricted parameter only acceptING OPM specific values and will only be allowed for index image pull specs ("from_index") that are explicitly configured in the IIB API config under `IIB_GRAPH_MODE_ALLOW_LIST`. 