### PR TITLE
Log a warning message when "architecture" label is missing under "Labels"

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -119,8 +119,15 @@ def _build_image(dockerfile_dir: str, dockerfile_name: str, request_id: int, arc
         exc_msg=f'Failed to build the container image on the arch {arch}',
     )
     log.debug('Verifying that %s was built with expected arch %s', destination, arch)
-    archmap = get_worker_config()['iib_supported_archs']
+    archmap = worker_config['iib_supported_archs']
     destination_arch = get_image_label(local_destination, 'architecture')
+
+    if not destination_arch:
+        log.warn(
+            'The "architecture" label was not found under "Labels".'
+            'Skipping the check that confirms if the architecture label was set correctly.'
+        )
+        return
 
     if destination_arch not in archmap.values() or destination_arch != archmap.get(arch):
         log.warning("Wrong arch created for %s", destination)

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -21,7 +21,12 @@ worker_config = get_worker_config()
 @mock.patch('iib.workers.tasks.build.run_cmd')
 def test_build_image(mock_run_cmd, mock_get_label, arch):
     mock_run_cmd.return_value = None
-    mock_get_label.return_value = worker_config['iib_supported_archs'][arch]
+
+    if arch == 'arm64':
+        mock_get_label.return_value = ''
+    else:
+        mock_get_label.return_value = worker_config['iib_supported_archs'][arch]
+
     build._build_image('/some/dir', 'some.Dockerfile', 3, arch)
     destination = f'iib-build:3-{arch}'
     local_destination = f'containers-storage:localhost/{destination}'


### PR DESCRIPTION
When using an Openshift binary as the binary_image, the "architecture" label is added under the "Labels" section on an index image. This is done for the OCP cluster to recognize the arch of the image. This is an OCP specific thing and it's not necessary that the "architecture" label will be added under "Labels" if a user specifies any other binary_image. Hence, in-case the label is missing from the index, do not fail the request.

Refers to CLOUDDST-19860