### PR TITLE
Fix normalization bug when return value is non-dict

### DIFF
--- a/iib/common/tracing.py
+++ b/iib/common/tracing.py
@@ -120,14 +120,18 @@ def instrument_tracing(
                     span.set_attribute('function_name', func.__name__)
                 try:
                     result = func(*args, **kwargs)
-                    span_result = normalize_data_for_span(result)
+                    if isinstance(result, dict):
+                        span_result = normalize_data_for_span(result)
+                    else:
+                        # If the returned result is not of type dict, create one
+                        span_result = {'result': result or 'success'}
                 except Exception as exc:
                     span.set_status(Status(StatusCode.ERROR))
                     span.record_exception(exc)
                     raise
                 else:
-                    if result:
-                        log.debug('result %s', result)
+                    if span_result:
+                        log.debug('result %s', span_result)
                         span.set_attributes(span_result)
                     if kwargs:
                         # Need to handle all the types of kwargs


### PR DESCRIPTION
The changes added in #557 assumed the return value of a function will be a dictionary. In the current instrumentation, _get_catalog_dir is the exception and returns the string in which case we need the change that was originally present. This PR combines the two changes and allows the decorator to process a non-dict return_value.