### PR TITLE
Pinning werkzeug to allow generation of docs.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -27,3 +27,4 @@ sphinx==6.2.1
 sphinx_rtd_theme
 tenacity
 typing-extensions
+werkzeug==2.2.3


### PR DESCRIPTION
- Latest version of werkzeug removed some functionality which is used by flask so we have to pin lower version to pass build of documentation