### PR TITLE
Use py3.9 for Renovate bot runs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,7 @@
 {
+  "constraints": {
+    "python": "==3.9"
+  },
   "enabled": true,
   "enabledManagers": ["docker-compose", "dockerfile", "github-actions", "pip_requirements", "pyenv"],
   "branchConcurrentLimit": 5,


### PR DESCRIPTION
These are the runs that are done on the server side i.e done by renovate bot on its own server. By default, renovate bot uses the latest python version for its runs and the recent failures were because of a bug in one of the python 3.12 libraries

Refers to CLOUDDST-20512