### PR TITLE
Allow skopeo inspect to check for images for any arch

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -814,7 +814,7 @@ def inspect_related_images(bundles: List[str], request_id) -> None:
             for related_image in bundle_metadata['found_pullspecs']:
                 related_image_pull_spec = related_image.to_str()
                 try:
-                    skopeo_inspect(f"docker://{related_image_pull_spec}")
+                    skopeo_inspect(f'docker://{related_image_pull_spec}', '--raw')
                 except IIBError as e:
                     log.error(e)
                     invalid_related_images.append(related_image_pull_spec)

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -1376,6 +1376,7 @@ def test_inspect_related_images(mock_gil, mock_cffi, mock_fd, mock_gbd, mock_si,
     build.inspect_related_images(bundles=bundles, request_id=request_id)
 
     assert mock_si.call_count == 5
+    mock_si.assert_any_call('docker://quay.io/related/image@sha256:5', '--raw')
     assert mock_gbd.call_count == 2
     assert mock_gil.call_args_list == [
         mock.call(


### PR DESCRIPTION
When '--raw' option was not given in inspect, skopeo tries to look for manifest of amd64 arch, but some images are built for other arches only, hence skopeo inspect was failing for those images