### PR TITLE
Fixing github actions

### DIFF
--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -23,6 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          sudo apt update -y
           sudo apt install libkrb5-dev -y
           python -m pip install --upgrade pip
           pip install --upgrade virtualenv


### PR DESCRIPTION
We were not able to download packages from Ubuntu repositories.
By running update we will update apt cache for correct links and we are able to access packages again.