### PR TITLE
Adding parameter ignore_bundle_ocp_version to merge-index API

### DIFF
--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -1091,6 +1091,7 @@ def merge_index_image() -> Tuple[flask.Response, int]:
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
         payload.get('build_tags', []),
         payload.get('graph_update_mode'),
+        payload.get('ignore_bundle_ocp_version'),
     ]
     safe_args = _get_safe_args(args, payload)
 

--- a/iib/web/iib_static_types.py
+++ b/iib/web/iib_static_types.py
@@ -391,6 +391,7 @@ class MergeIndexImageRequestResponse(APIPartImageBuildRequestResponse):
     deprecation_list: List[str]
     distribution_scope: str
     graph_update_mode: GRAPH_MODE_LITERAL
+    ignore_bundle_ocp_version: Optional[bool]
     index_image: Optional[str]
     source_from_index: str
     source_from_index_resolved: Optional[str]

--- a/iib/web/migrations/versions/1920ad83d0ab_adding_ignore_bundle_ocp_version.py
+++ b/iib/web/migrations/versions/1920ad83d0ab_adding_ignore_bundle_ocp_version.py
@@ -1,0 +1,26 @@
+"""Adding ignore_bundle_ocp_version.
+
+Revision ID: 1920ad83d0ab
+Revises: 9e9d4f9730c8
+Create Date: 2023-11-22 12:03:50.711489
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1920ad83d0ab'
+down_revision = '9e9d4f9730c8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('request_merge_index_image', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('ignore_bundle_ocp_version', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('request_merge_index_image', schema=None) as batch_op:
+        batch_op.drop_column('ignore_bundle_ocp_version')

--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -1534,6 +1534,7 @@ class RequestMergeIndexImage(Request):
     )
     distribution_scope: Mapped[Optional[str]]
     graph_update_mode: Mapped[Optional[str]]
+    ignore_bundle_ocp_version: Mapped[Optional[bool]]
 
     __mapper_args__ = {
         'polymorphic_identity': RequestTypeMapping.__members__['merge_index_image'].value
@@ -1663,6 +1664,7 @@ class RequestMergeIndexImage(Request):
         )
         rv['deprecation_list'] = [bundle.pull_specification for bundle in self.deprecation_list]
         rv['graph_update_mode'] = self.graph_update_mode
+        rv['ignore_bundle_ocp_version'] = self.ignore_bundle_ocp_version
         rv['index_image'] = getattr(self.index_image, 'pull_specification', None)
         rv['source_from_index'] = self.source_from_index.pull_specification
         rv['source_from_index_resolved'] = getattr(

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -1143,6 +1143,7 @@ components:
               type: string
               example: rm
     RegenerateBundleRequest:
+      $ref: '#/components/schemas/RegenerateBundleResponseVerbose'
       type: object
       properties:
         from_bundle_image:

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -1287,6 +1287,13 @@ components:
           items:
             type: string
           example: ["v4.5-10-08-2021"]
+        ignore_bundle_ocp_version:
+          type: boolean
+          description: >
+            When `ignore_bundle_ocp_version` is set to `true` and image set as target_index
+            is listed in `iib_no_ocp_label_allow_list` config then bundles without
+            "com.redhat.openshift.versions" label set will be added in the result `index_image`.
+          example: 'true'
       required:
         - source_from_index
     MergeIndexImageResponse:
@@ -1347,6 +1354,14 @@ components:
                 image pull specs configured in IIB_GRAPH_MODE_INDEX_ALLOW_LIST in the IIB API Config. If not
                 specified, "--mode" will not be added to OPM commands to add the bundle(s) to the index.
               default: None
+            ignore_bundle_ocp_version:
+              type: boolean
+              description: >
+                When `ignore_bundle_ocp_version` is set to `true` and image set as target_index
+                is listed in `iib_no_ocp_label_allow_list` config then bundles without
+                "com.redhat.openshift.versions" label set will be added in the result `index_image`.
+              example: 'true'
+              default: False
     RequestCreateEmptyIndex:
       type: object
       properties:

--- a/tests/test_web/test_api_v1.py
+++ b/tests/test_web/test_api_v1.py
@@ -1963,6 +1963,7 @@ def test_merge_index_image_success(
         'distribution_scope': distribution_scope,
         'graph_update_mode': 'semver',
         'id': 1,
+        'ignore_bundle_ocp_version': None,
         'index_image': None,
         'logs': {
             'expiration': '2020-02-15T17:03:00Z',
@@ -2067,6 +2068,7 @@ def test_merge_index_image_custom_user_queue(
         'source_from_index': 'source_index:image',
         'target_index': 'target_index:image',
         'graph_update_mode': 'replaces',
+        'ignore_bundle_ocp_version': True,
     }
     if overwrite_from_index:
         data['overwrite_target_index'] = True


### PR DESCRIPTION
If ignore_bundle_ocp_version parameter is set to true while calling merge-index API and target_index image is listed in iib_no_ocp_label_allow_list in config file then any bundle without "com.redhat.openshift.versions" set will be added to target_index.

[CLOUDDST-20869]