### PR TITLE
Check if source_from_index is in iib_no_ocp_label_allow_list

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -284,6 +284,10 @@ def validate_celery_config(conf: app.utils.Settings, **kwargs) -> None:
     if not isinstance(conf['iib_required_labels'], dict):
         raise ConfigError('iib_required_labels must be a dictionary')
 
+    if conf.get('iib_no_ocp_label_allow_list'):
+        if any(not index for index in conf['iib_no_ocp_label_allow_list']):
+            raise ConfigError('Empty string is not allowed in iib_no_ocp_label_allow_list')
+
     _validate_iib_org_customizations(conf['iib_organization_customizations'])
 
     if conf.get('iib_aws_s3_bucket_name'):

--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -128,13 +128,16 @@ def _add_bundles_missing_in_source(
             missing_bundles.append(bundle)
             missing_bundle_paths.append(bundle['bundlePath'])
 
-    if ignore_bundle_ocp_version and target_index is not None:
+    if ignore_bundle_ocp_version:
+        target_index_tmp = '' if target_index is None else target_index
         allow_no_ocp_version = any(
-            target_index.startswith(index)
+            target_index_tmp.startswith(index) or source_from_index.startswith(index)
             for index in get_worker_config()['iib_no_ocp_label_allow_list']
         )
+        log.info('Adding bundles without "com.redhat.openshift.versions" label is allowed.')
     else:
         allow_no_ocp_version = False
+        log.info('Bundles without "com.redhat.openshift.versions" label will not be added.')
 
     for bundle in itertools.chain(missing_bundles, source_index_bundles):
         if not is_bundle_version_valid(bundle['bundlePath'], ocp_version, allow_no_ocp_version):

--- a/tests/test_workers/test_config.py
+++ b/tests/test_workers/test_config.py
@@ -325,3 +325,16 @@ def test_validate_celery_config_invalid_recursive_related_bundles_config():
     )
     with pytest.raises(ConfigError, match=error):
         validate_celery_config(worker_config)
+
+
+def test_validate_celery_config_invalid_iib_no_ocp_label_allow_list():
+    worker_config = {
+        'iib_api_url': 'http://localhost:8080/api/v1/',
+        'iib_registry': 'registry',
+        'iib_required_labels': {},
+        'iib_no_ocp_label_allow_list': [''],
+    }
+
+    error = 'Empty string is not allowed in iib_no_ocp_label_allow_list'
+    with pytest.raises(ConfigError, match=error):
+        validate_celery_config(worker_config)


### PR DESCRIPTION
I wrongly assumed that ISV will use overwrite index token and set the check if image is on allow list only for the target (like we do this for bootstraping). However now I know it is not true and this use case slipped my hands. We have to also tests the source index image because the target can be newly created empty index image in our IIB repo. 

[CLOUDDST-20869]