### PR TITLE
Revert "Update dependency Mako to v1.3.1"

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -400,9 +400,9 @@ krb5==0.3.0 \
     # via
     #   -r requirements.txt
     #   pyspnego
-Mako==1.3.1 \
-    --hash=sha256:463f03e04559689adaee25e0967778d6ad41285ed607dc1e7df0dd4e4df81f9e \
-    --hash=sha256:baee30b9c61718e093130298e678abed0dbfa1b411fcc4c1ab4df87cd631a0f2
+Mako==1.3.0 \
+    --hash=sha256:57d4e997349f1a92035aa25c17ace371a4213f2ca42f99bee9a602500cfd54d9 \
+    --hash=sha256:e3a9d388fd00e87043edbe8792f45880ac0114e9c4adc69f6e9bfb2c55e3b11b
     # via
     #   -r requirements.txt
     #   alembic

--- a/requirements.txt
+++ b/requirements.txt
@@ -377,9 +377,9 @@ krb5==0.3.0 \
     --hash=sha256:d049fb3eb4ec11c9e81d8a1591a32b21b178b65bd03046933f7de1ddc981dc2a \
     --hash=sha256:dcf10648273e5722df67645d1979cb4084c31d03d63e6445b54d308e01d86b6d
     # via pyspnego
-Mako==1.3.1 \
-    --hash=sha256:463f03e04559689adaee25e0967778d6ad41285ed607dc1e7df0dd4e4df81f9e \
-    --hash=sha256:baee30b9c61718e093130298e678abed0dbfa1b411fcc4c1ab4df87cd631a0f2
+Mako==1.3.0 \
+    --hash=sha256:57d4e997349f1a92035aa25c17ace371a4213f2ca42f99bee9a602500cfd54d9 \
+    --hash=sha256:e3a9d388fd00e87043edbe8792f45880ac0114e9c4adc69f6e9bfb2c55e3b11b
     # via alembic
 MarkupSafe==2.1.4 \
     --hash=sha256:0042d6a9880b38e1dd9ff83146cc3c9c18a059b9360ceae207805567aacccc69 \


### PR DESCRIPTION
Reverts release-engineering/iib#611

Release of mako was yanked:
backwards incompatible change in percent handling