### PR TITLE
Check request state, before its update

### DIFF
--- a/iib/exceptions.py
+++ b/iib/exceptions.py
@@ -13,6 +13,10 @@ class IIBError(BaseException):
     """An error was encountered in IIB."""
 
 
+class FinalStateAlreadyReached(BaseException):
+    """Request is already in the final state."""
+
+
 class ValidationError(BaseException):
     """Denote invalid input."""
 

--- a/iib/workers/tasks/general.py
+++ b/iib/workers/tasks/general.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import celery.app.task
 
-from iib.exceptions import IIBError
+from iib.exceptions import IIBError, FinalStateAlreadyReached
 from iib.workers.api_utils import set_request_state
 from iib.workers.tasks.celery import app
 from iib.workers.tasks.utils import request_logger
@@ -32,6 +32,8 @@ def failed_request_callback(
     """
     if isinstance(exc, IIBError):
         msg = str(exc)
+    elif isinstance(exc, FinalStateAlreadyReached):
+        return
     else:
         msg = 'An unknown error occurred. See logs for details'
         log.error(msg, exc_info=exc)


### PR DESCRIPTION
[Related JIRA issue - CLOUDDST-21515](https://issues.redhat.com/browse/CLOUDDST-21515)

When we mark a request that is in a queue, as failed, the IIB worker still picks it up, as it is still in the queue (`apply_async` method). IIB worker sets the state to `in_progress` at the beginning of each handle method with a call to the `update_request` method under the hood, no matter what, the actual state of the request is.

With the proposed changes, the method `update_request` now checks if the request is already in the final state. If so, it will raise an exception, and continue with other requests in the queue. To be able to not retry this 'update_request' method (retry decorator), a new exception was needed (different from IIBError). 

Also, an edit in the `failed_request_callback` was needed, as this method also updates the state of the request.

