### PR TITLE
Backup index.db to prevent opm bug consequence

### DIFF
--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -251,8 +251,17 @@ def test_opm_generate_dockerfile_exist(mock_run_cmd, tmpdir, dockerfile, set_ind
 @pytest.mark.parametrize('container_tool', (None, 'podwoman'))
 @mock.patch('iib.workers.tasks.utils.set_registry_token')
 @mock.patch('iib.workers.tasks.utils.run_cmd')
+@mock.patch('iib.workers.tasks.opm_operations.shutil.copyfile')
+@mock.patch('iib.workers.tasks.opm_operations.os.remove')
 def test_opm_registry_add(
-    mock_run_cmd, mock_srt, from_index, bundles, overwrite_csv, container_tool
+    mock_os_remove,
+    mock_shutil_copyfile,
+    mock_run_cmd,
+    mock_srt,
+    from_index,
+    bundles,
+    overwrite_csv,
+    container_tool,
 ):
     opm_operations._opm_registry_add(
         base_dir='/tmp/somedir',


### PR DESCRIPTION
Related JIRA issue: [CLOUDDST-20957](https://issues.redhat.com/browse/CLOUDDST-20957)
Related OPM bug: [OCPBUGS-30214](https://issues.redhat.com/browse/OCPBUGS-30214)


Method `opm_registry_add_fbc` calls `_opm_registry_add.
  
The first time method `opm_registry_add_fbc` calls  `_opm_registry_add`,  `_opm_registry_add` fails. This failure is the correct expected behavior, however, the OPM command modifies the database file (should not be modified on an error). 

As this  `_opm_registry_add` method has the retry decorator, it is triggered again, now failing with a different error (the error is a consequence of the database modification in the previous run attempt). Only the second error (wrong one) is propagated to the parent `opm_registry_add_fbc`  method. (As we have the retry decorator with the `opm_registry_add_fbc`  method, this whole process is repeated). 

As a result, the error, resulting from running the OPM command on the modified database file, is propagated into the state_reason. 

In the solution, I propose a workaround, which creates a backup of the database file, then runs the OPM command and uses backup on command failure. 