### PR TITLE
Fix comma bundle version validation

### DIFF
--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -494,7 +494,7 @@ def is_bundle_version_valid(
                 return True
         # MYPY error: Unsupported right operand type for in ("Optional[str]")
         elif "," in bundle_version_label:  # type: ignore
-            versions = [Version(version) for version in bundle_version.split(",")]
+            versions = sorted([Version(version) for version in bundle_version.split(",")])
             if versions[0] <= ocp_version:
                 return True
         elif Version(bundle_version) <= ocp_version:

--- a/tests/test_workers/test_tasks/test_build_merge_index_image.py
+++ b/tests/test_workers/test_tasks/test_build_merge_index_image.py
@@ -631,7 +631,7 @@ def test_add_bundles_missing_in_source_none_missing(
             'csvName': 'bundle2-2.0',
         },
     ]
-    mock_gil.side_effect = ['v=4.5', 'v4.7,v4.6', 'v4.5-v4.8', 'v4.5,v4.6,v4.7']
+    mock_gil.side_effect = ['v=4.5', 'v4.8,v4.7', 'v4.5-v4.8', 'v4.5,v4.6,v4.7']
     mock_iifbc.return_value = False
     missing_bundles, invalid_bundles = build_merge_index_image._add_bundles_missing_in_source(
         source_bundles,


### PR DESCRIPTION
This PR resolves the difference between Pyxis and IIB bundle version validations.

Method `is_bundle_version_valid()` compares comma style list with ocp_version. The problem here was, that the result could be different, based on the order of the items in the list. On the other hand, code in [Pyxis ocpversion.py](https://gitlab.cee.redhat.com/metadata/pyxis/pyxis/-/blob/master/pyxis/graphql/custom/operator_index/ocpversion.py) approaches this check differently - they sort the list before the comparison. 



Related issue: [CLOUDDST-22327](https://issues.redhat.com/browse/CLOUDDST-22327)