### PR TITLE
Fix bug with FBC YAML Operators

### DIFF
--- a/iib/workers/tasks/fbc_utils.py
+++ b/iib/workers/tasks/fbc_utils.py
@@ -5,8 +5,8 @@ import logging
 import shutil
 import json
 from pathlib import Path
-
 from typing import Tuple, List
+
 import ruamel.yaml
 
 from iib.exceptions import IIBError
@@ -86,12 +86,15 @@ def merge_catalogs_dirs(src_config: str, dest_config: str):
     :param str src_config: source config directory
     :param str dest_config: destination config directory
     """
+    from iib.workers.tasks.opm_operations import opm_validate
+
     for conf_dir in (src_config, dest_config):
         if not os.path.isdir(conf_dir):
             msg = f"config directory does not exist: {conf_dir}"
             log.error(msg)
             raise IIBError(msg)
         enforce_json_config_dir(conf_dir)
+        opm_validate(conf_dir)
 
     log.info("Merging config folders: %s to %s", src_config, dest_config)
     shutil.copytree(src_config, dest_config, dirs_exist_ok=True)

--- a/iib/workers/tasks/fbc_utils.py
+++ b/iib/workers/tasks/fbc_utils.py
@@ -93,11 +93,11 @@ def merge_catalogs_dirs(src_config: str, dest_config: str):
             msg = f"config directory does not exist: {conf_dir}"
             log.error(msg)
             raise IIBError(msg)
-        enforce_json_config_dir(conf_dir)
-        opm_validate(conf_dir)
 
     log.info("Merging config folders: %s to %s", src_config, dest_config)
     shutil.copytree(src_config, dest_config, dirs_exist_ok=True)
+    enforce_json_config_dir(conf_dir)
+    opm_validate(conf_dir)
 
 
 def extract_fbc_fragment(temp_dir: str, fbc_fragment: str) -> Tuple[str, List[str]]:

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -366,6 +366,7 @@ def opm_migrate(
 
     run_cmd(cmd, {'cwd': base_dir}, exc_msg='Failed to migrate index.db to file-based catalog')
     log.info("Migration to file-based catalog was completed.")
+    opm_validate(fbc_dir_path)
 
     if generate_cache:
         # Remove outdated cache before generating new one
@@ -1116,6 +1117,20 @@ def deprecate_bundles(
         cmd.append(container_tool)
     with set_registry_token(overwrite_target_index_token, from_index):
         run_cmd(cmd, {'cwd': base_dir}, exc_msg='Failed to deprecate the bundles')
+
+
+def opm_validate(config_dir: str) -> None:
+    """
+    Validate the declarative config files in a given directory.
+
+    :param str config_dir: directory containing the declarative config files.
+    :raises IIBError: if the validation fails
+    """
+    from iib.workers.tasks.utils import run_cmd
+
+    log.info("Validating files under %s", config_dir)
+    cmd = [Opm.opm_version, 'validate', config_dir]
+    run_cmd(cmd, exc_msg=f'Failed to validate the content from config_dir {config_dir}')
 
 
 class Opm:

--- a/tests/test_workers/test_tasks/test_fbc_utils.py
+++ b/tests/test_workers/test_tasks/test_fbc_utils.py
@@ -1,13 +1,23 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+import json
 import os
 import tempfile
 from unittest import mock
 
 import pytest
+import ruamel.yaml
 
 from iib.exceptions import IIBError
 from iib.workers.config import get_worker_config
-from iib.workers.tasks.fbc_utils import is_image_fbc, merge_catalogs_dirs, extract_fbc_fragment
+from iib.workers.tasks.fbc_utils import (
+    is_image_fbc,
+    merge_catalogs_dirs,
+    enforce_json_config_dir,
+    extract_fbc_fragment,
+)
+
+
+yaml = ruamel.yaml.YAML()
 
 
 @pytest.mark.parametrize(
@@ -92,7 +102,8 @@ def test_is_image_fbc(mock_si, skopeo_output, is_fbc):
     assert is_image_fbc(image) is is_fbc
 
 
-def test_merge_catalogs_dirs(tmpdir):
+@mock.patch("iib.workers.tasks.fbc_utils.enforce_json_config_dir")
+def test_merge_catalogs_dirs(mock_enforce_json, tmpdir):
     source_dir = os.path.join(tmpdir, 'src')
     destination_dir = os.path.join(tmpdir, 'dst')
     os.makedirs(destination_dir, exist_ok=True)
@@ -104,6 +115,12 @@ def test_merge_catalogs_dirs(tmpdir):
         tempfile.NamedTemporaryFile(dir=operator_dir, delete=False)
 
     merge_catalogs_dirs(src_config=source_dir, dest_config=destination_dir)
+    mock_enforce_json.assert_has_calls(
+        [
+            mock.call(source_dir),
+            mock.call(destination_dir),
+        ]
+    )
 
     for r, d, f in os.walk(source_dir):
 
@@ -139,6 +156,23 @@ def test_merge_catalogs_dirs_raise(mock_isdir, mock_cpt, tmpdir):
         merge_catalogs_dirs(src_config=source_dir, dest_config=destination_dir)
 
     mock_cpt.not_called()
+
+
+def test_enforce_json_config_dir(tmpdir):
+    file_prefix = "test_file"
+    data = {"foo": "bar"}
+    test_file = os.path.join(tmpdir, f"{file_prefix}.yaml")
+    expected_file = os.path.join(tmpdir, f"{file_prefix}.json")
+    with open(test_file, 'w') as w:
+        yaml.dump(data, w)
+
+    enforce_json_config_dir(tmpdir)
+
+    assert os.path.isfile(expected_file)
+    assert not os.path.isfile(test_file)
+
+    with open(expected_file, 'r') as f:
+        assert json.load(f) == data
 
 
 @pytest.mark.parametrize('ldr_output', [['testoperator'], ['test1', 'test2'], []])

--- a/tests/test_workers/test_tasks/test_fbc_utils.py
+++ b/tests/test_workers/test_tasks/test_fbc_utils.py
@@ -102,8 +102,10 @@ def test_is_image_fbc(mock_si, skopeo_output, is_fbc):
     assert is_image_fbc(image) is is_fbc
 
 
+@mock.patch('iib.workers.tasks.opm_operations.Opm')
+@mock.patch('iib.workers.tasks.utils.run_cmd')
 @mock.patch("iib.workers.tasks.fbc_utils.enforce_json_config_dir")
-def test_merge_catalogs_dirs(mock_enforce_json, tmpdir):
+def test_merge_catalogs_dirs(mock_enforce_json, mock_rc, mock_opm, tmpdir):
     source_dir = os.path.join(tmpdir, 'src')
     destination_dir = os.path.join(tmpdir, 'dst')
     os.makedirs(destination_dir, exist_ok=True)
@@ -119,6 +121,18 @@ def test_merge_catalogs_dirs(mock_enforce_json, tmpdir):
         [
             mock.call(source_dir),
             mock.call(destination_dir),
+        ]
+    )
+    mock_rc.assert_has_calls(
+        [
+            mock.call(
+                [mock_opm.opm_version, 'validate', source_dir],
+                exc_msg=f'Failed to validate the content from config_dir {source_dir}',
+            ),
+            mock.call(
+                [mock_opm.opm_version, 'validate', destination_dir],
+                exc_msg=f'Failed to validate the content from config_dir {destination_dir}',
+            ),
         ]
     )
 

--- a/tests/test_workers/test_tasks/test_fbc_utils.py
+++ b/tests/test_workers/test_tasks/test_fbc_utils.py
@@ -117,23 +117,10 @@ def test_merge_catalogs_dirs(mock_enforce_json, mock_rc, mock_opm, tmpdir):
         tempfile.NamedTemporaryFile(dir=operator_dir, delete=False)
 
     merge_catalogs_dirs(src_config=source_dir, dest_config=destination_dir)
-    mock_enforce_json.assert_has_calls(
-        [
-            mock.call(source_dir),
-            mock.call(destination_dir),
-        ]
-    )
-    mock_rc.assert_has_calls(
-        [
-            mock.call(
-                [mock_opm.opm_version, 'validate', source_dir],
-                exc_msg=f'Failed to validate the content from config_dir {source_dir}',
-            ),
-            mock.call(
-                [mock_opm.opm_version, 'validate', destination_dir],
-                exc_msg=f'Failed to validate the content from config_dir {destination_dir}',
-            ),
-        ]
+    mock_enforce_json.assert_called_once_with(destination_dir)
+    mock_rc.called_once_with(
+        [mock_opm.opm_version, 'validate', destination_dir],
+        exc_msg=f'Failed to validate the content from config_dir {destination_dir}',
     )
 
     for r, d, f in os.walk(source_dir):

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -152,6 +152,7 @@ def test_serve_cmd_at_port_delayed_initialize(
     assert mock_run_cmd.call_count == 7
 
 
+@mock.patch('iib.workers.tasks.opm_operations.opm_validate')
 @mock.patch('iib.workers.tasks.opm_operations.shutil.rmtree')
 @mock.patch('iib.workers.tasks.opm_operations.generate_cache_locally')
 @mock.patch('iib.workers.tasks.utils.run_cmd')
@@ -160,6 +161,7 @@ def test_opm_migrate(
     mock_run_cmd,
     mock_gcl,
     moch_srmtree,
+    mock_opmvalidate,
     tmpdir,
 ):
     index_db_file = os.path.join(tmpdir, 'database/index.db')
@@ -175,6 +177,7 @@ def test_opm_migrate(
         exc_msg='Failed to migrate index.db to file-based catalog',
     )
 
+    mock_opmvalidate.assert_called_once_with(fbc_dir)
     mock_gcl.assert_called_once_with(tmpdir, fbc_dir, mock.ANY)
 
 


### PR DESCRIPTION
When an operator has catalog in yaml insted of json, some requests (like add) fails on "duplicate package" as `merge_catalogs_dirs` function generates FBC from hidden index.db created as json files and then copy over its content to final location where are all yaml files.

To prevent this issue this simple fix will walk through the config directory and convert any YAML files into JSON to ensure that everything uses the same format in the index image.

Refers to CLOUDDST-21432