### PR TITLE
Add atomic port locking mechanism

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -3,7 +3,7 @@ import os
 import logging
 import shutil
 import types
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from kombu import Queue
 from celery import Celery, app
@@ -34,9 +34,13 @@ class Config(object):
     )
     iib_greenwave_url: Optional[str] = None
     iib_grpc_init_wait_time: int = 100
-    iib_grpc_max_port_tries: int = 100
     iib_grpc_max_tries: int = 5
-    iib_grpc_start_port: int = 50051
+    # size of both ranges, needs to be the same, ranges neeeds to be exclusive
+    iib_opm_port_ranges: Dict[str, Tuple[int, int]] = {
+        "opm_port": (50051, 50151),
+        "opm_pprof_port": (50151, 50251),
+    }
+    iib_opm_pprof_lock_required_min_version = "1.29.0"
     iib_image_push_template: str = '{registry}/iib-build:{request_id}'
     iib_index_image_output_registry: Optional[str] = None
     iib_log_level: str = 'INFO'

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -1,10 +1,14 @@
+from functools import wraps
 import logging
 import os
 import random
 import shutil
+import socket
 import subprocess
+import tempfile
 import time
-from typing import List, Optional, Tuple, Generator, Union, Set
+from typing import Callable, Generator, List, Optional, Set, Tuple, Union
+from packaging.version import Version
 
 from tenacity import (
     before_sleep_log,
@@ -26,29 +30,214 @@ from iib.workers.tasks.fbc_utils import (
 log = logging.getLogger(__name__)
 
 
-def _gen_port_for_grpc() -> Generator[int, None, None]:
-    """
-    Generate port for gRPC service from range set in IIB config.
+class PortFileLock:
+    """A class representing file-lock used during OPM operations."""
 
+    def __init__(self, purpose: str, port: int):
+        """
+        Initialize the PortFileLock object.
+
+        :param str purpose: Purpose of the lock
+        :param int port: The port number to be locked
+        """
+        self.purpose = purpose
+        self.port = port
+        self.locked = False
+        self.filename = os.path.join(
+            tempfile.gettempdir(),
+            f'iib_{purpose}_{port}.lock',
+        )
+
+    def __repr__(self):
+        """
+        Return string representation of the PortFileLock Object.
+
+        :return: String representation of the PortFileLock Object
+        :rtype: str
+        """
+        return f"PortFileLock(port: {self.port}, purpose: {self.purpose}, locked: {self.locked})"
+
+    def lock_acquire(self):
+        """
+        Create a file representing port lock.
+
+        Before trying to create a a port-lock file, we try to check if the port is free.
+        """
+        log.debug("Attempt to lock port %s.", self.port)
+
+        if self.locked:
+            err_msg = f"Error: Port {self.port} is already locked"
+            log.exception(err_msg)
+            raise IIBError(err_msg)
+
+        # check if the port is free, opm service is doing the check too,
+        # however this way, we do not have to rely on their error message format
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        f = None
+        try:
+            # test if port is free
+            s.bind(("localhost", self.port))
+            # create file-lock
+            f = os.open(self.filename, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+            self.locked = True
+            log.debug("Port %s used as %s was locked.", self.port, self.purpose)
+        except FileExistsError:
+            err_msg = f"Port {self.port} is already locked by other IIB worker."
+            log.exception(err_msg)
+            raise AddressAlreadyInUse(err_msg)
+        except socket.error:
+            err_msg = f"Port {self.port} is already in use."
+            log.exception(err_msg)
+            raise AddressAlreadyInUse(err_msg)
+        finally:
+            s.close()
+            if f:
+                f.close()
+
+    def unlock(self):
+        """Delete file representing port lock."""
+        if self.locked:
+            os.remove(self.filename)
+            self.locked = False
+            log.debug('Port %s used as %s was unlocked.', self.port, self.purpose)
+        else:
+            err_msg = f"Attempt to unlock not-locked {self}."
+            log.exception(err_msg)
+            raise IIBError(err_msg)
+
+
+def port_file_locks_generator(
+    port_stacks: List[List[int]],
+    port_purposes: List[str],
+) -> Generator[List[PortFileLock], None, None]:
+    """
+    Generate PortFileLock from port_stacks and port_purposes.
+
+    Each item in the port_stacks list represents set of ports, from which list of PortFileLocks
+    will be generated.
+
+    :param list(list(int)) port_stacks: list with list of port numbers for one generated item
+    :param list(str) port_purposes: Strings representing port purposes
+    :return: Generator which yields list of PortFileLocks objects
+    :rtype: Generator(list(PortFileLock))
     :raises: IIBError when all ports were already taken
     """
-    conf = get_worker_config()
-    port_start = conf['iib_grpc_start_port']
-    port_end = port_start + conf['iib_grpc_max_port_tries']
+    num_of_attempts = len(port_stacks)
 
-    port_stack = list(range(port_start, port_end))
-    random.shuffle(port_stack)
-
-    log.debug('Get random ports from range [%d, %d)', port_start, port_end)
-
-    while port_stack:
-        yield port_stack.pop(0)
+    # create port_lock_here
+    while port_stacks:
+        port_numbers = port_stacks.pop(0)
+        new_locks = [
+            PortFileLock(
+                purpose=port_purpose,
+                port=port_numbers[port_position],
+            )
+            for port_position, port_purpose in enumerate(port_purposes)
+        ]
+        yield new_locks
 
     # The port stack is empty - we tried out all ports from allowed range
     # therefore we will raise and IIB error
-    err_msg = f'No free port has been found after {port_end - port_start} attempts.'
+    err_msg = f'No free port has been found after {num_of_attempts} attempts.'
     log.error(err_msg)
     raise IIBError(err_msg)
+
+
+def get_opm_port_stacks() -> Tuple[List[List[int]], List[str]]:
+    """
+    Get stack with port numbers and list of their intended purposes.
+
+    This stack of ports is used later in the Generator of the port numbers.
+
+    This function returns a tuple consisting of two elements:
+    1. list(list(int)): Each inner list represents a set of port numbers used in a single attempt
+    of running the OPM command. Used port numbers are retrieved from the config iib_opm_port_ranges
+    values.
+    2. list(str): Each string describes the intended purpose of the port number, with the position
+    of each string corresponding to the ports in the inner items in the first list.
+    This list is constructed from the config iib_opm_port_ranges keys.
+
+    Example:
+        ports, purposes = get_opm_port_stacks()
+        ports contains: [[50051, 50151], [50052, 50152]]
+        purposes content: ['opm_port', 'pprof_port']
+
+    In this example, ports 50051 and 50052 are port intended to use as 'opm_port' and ports 50151
+    and 50152 as 'pprof_port'.
+    :return: tuple with port stacks and their purposes
+    :rtype: tuple(list(list(int)), list(str))
+    """
+    conf = get_worker_config()
+    port_purposes = list(conf.iib_opm_port_ranges)
+
+    if Version(Opm.opm_version) < Version(conf.iib_opm_pprof_lock_required_min_version):
+        port_purposes.remove('pprof_port')
+
+    # get port_ranges we need for the give opm_version
+    port_ranges = [range(*conf.iib_opm_port_ranges[port_purpose]) for port_purpose in port_purposes]
+
+    ports_list = list(map(list, zip(*port_ranges)))
+
+    # shuffles the order, port pairs remain
+    random.shuffle(ports_list)
+
+    return ports_list, port_purposes
+
+
+def create_port_filelocks(func: Callable) -> Callable:
+    """
+    Create a file-lock on random port from the configured range.
+
+    :param function func: the function to be decorated
+    :rtype: function
+    :return: the decorated function
+    """
+
+    @wraps(func)
+    def inner(*args, **kwargs):
+
+        port_stacks, port_purposes = get_opm_port_stacks()
+        # Attempt to acquire the lock for each port in the range (shuffled order)
+        lock_success = False
+
+        # Initialize the generator
+        gen = port_file_locks_generator(port_stacks=port_stacks, port_purposes=port_purposes)
+
+        # Use the function to retrieve values from the generator
+        while not lock_success:
+            new_locks = next(gen)
+            currently_active_locks = []
+
+            try:
+                # Atomically acquire the locks for the given ports
+                for new_lock in new_locks:
+                    new_lock.lock_acquire()
+                    currently_active_locks.append(new_lock)
+
+                port_args = {
+                    port_purpose: currently_active_locks[port_position].port
+                    for port_position, port_purpose in enumerate(port_purposes)
+                }
+
+                result = func(*args, **port_args, **kwargs)
+                lock_success = True
+
+            # Exception raised during execution of func()
+            except AddressAlreadyInUse:
+                lock_success = False
+                for active_lock in currently_active_locks:
+                    active_lock.unlock()
+
+            finally:
+                # Exit loop after successful lock acquisition
+                if lock_success:
+                    for active_lock in currently_active_locks:
+                        active_lock.unlock()
+                    break
+
+        return result
+
+    return inner
 
 
 def opm_serve_from_index(base_dir: str, from_index: str) -> Tuple[int, subprocess.Popen]:
@@ -68,75 +257,94 @@ def opm_serve_from_index(base_dir: str, from_index: str) -> Tuple[int, subproces
     log.info('Serving data from image %s', from_index)
     if not is_image_fbc(from_index):
         db_path = _get_index_database(from_index, base_dir)
-        return opm_registry_serve(db_path)
+        return opm_registry_serve(db_path=db_path)
 
     catalog_dir = get_catalog_dir(from_index, base_dir)
-    return opm_serve(catalog_dir)
+    return opm_serve(catalog_dir=catalog_dir)
 
 
-def opm_serve(catalog_dir: str) -> Tuple[int, subprocess.Popen]:
+@create_port_filelocks
+def opm_serve(
+    opm_port: int,
+    catalog_dir: str,
+    pprof_port: Optional[int] = None,
+) -> Tuple[int, subprocess.Popen]:
     """
     Locally start OPM service, which can be communicated with using gRPC queries.
 
     Due to IIB's paralellism, the service can run multiple times, which could lead to port
     binding conflicts. Resolution of port conflicts is handled in this function as well.
 
+    :param int opm_port: OPM port number obtained from create_port_filelock decorator
+    :param int pprof_port: Pprof opm port number obtained from create_port_filelock decorator
     :param str catalog_dir: path to file-based catalog directory that should be served.
     :return: tuple containing port number of the running service and the running Popen object.
     :rtype: (int, Popen)
     """
     log.info('Serving data from file-based catalog %s', catalog_dir)
 
-    for port in _gen_port_for_grpc():
-        try:
-            cmd = [Opm.opm_version, 'serve', catalog_dir, '-p', str(port), '-t', '/dev/null']
-            cwd = os.path.abspath(os.path.join(catalog_dir, os.path.pardir))
-            result = (
-                port,
-                _serve_cmd_at_port_defaults(cmd, cwd, port),
-            )
-            break
-        except AddressAlreadyInUse:
-            log.debug('Port %s is already taken. Checking next one...', port)
-            continue
+    cmd = [
+        Opm.opm_version,
+        'serve',
+        catalog_dir,
+        '-p',
+        opm_port,
+        '-t',
+        '/dev/null',
+    ]
+
+    if pprof_port:
+        # by default opm uses the 127.0.0.1:6060
+        cmd.extend(["--pprof-addr", f"127.0.0.1:{pprof_port}"])
+
+    cwd = os.path.abspath(os.path.join(catalog_dir, os.path.pardir))
+    result = (
+        opm_port,
+        _serve_cmd_at_port_defaults(cmd, cwd, opm_port),
+    )
     return result
 
 
-def opm_registry_serve(db_path: str) -> Tuple[int, subprocess.Popen]:
+@create_port_filelocks
+def opm_registry_serve(
+    opm_port: int,
+    db_path: str,
+    pprof_port: Optional[int] = None,
+) -> Tuple[int, subprocess.Popen]:
     """
     Locally start OPM registry service, which can be communicated with using gRPC queries.
 
     Due to IIB's paralellism, the service can run multiple times, which could lead to port
     binding conflicts. Resolution of port conflicts is handled in this function as well.
 
+    :param int opm_port: OPM port number obtained from create_port_filelock decorator
+    :param int pprof_port: Pprof opm port number obtained from create_port_filelock decorator
     :param str db_path: path to index database containing the registry data.
     :return: tuple containing port number of the running service and the running Popen object.
     :rtype: (int, Popen)
     """
     log.info('Serving data from index.db %s', db_path)
 
-    for port in _gen_port_for_grpc():
-        try:
-            cmd = [
-                Opm.opm_version,
-                'registry',
-                'serve',
-                '-p',
-                str(port),
-                '-d',
-                db_path,
-                '-t',
-                '/dev/null',
-            ]
-            cwd = os.path.dirname(db_path)
-            result = (
-                port,
-                _serve_cmd_at_port_defaults(cmd, cwd, port),
-            )
-            break
-        except AddressAlreadyInUse:
-            log.debug('Port %s is already taken. Checking next one...', port)
-            continue
+    cmd = [
+        Opm.opm_version,
+        'registry',
+        'serve',
+        '-p',
+        opm_port,
+        '-d',
+        db_path,
+        '-t',
+        '/dev/null',
+    ]
+    if pprof_port:
+        # by default opm uses the 127.0.0.1:6060
+        cmd.extend(["--pprof-addr", f"127.0.0.1:{pprof_port}"])
+
+    cwd = os.path.dirname(db_path)
+    result = (
+        opm_port,
+        _serve_cmd_at_port_defaults(cmd, cwd, opm_port),
+    )
     return result
 
 


### PR DESCRIPTION
Related issue: CLOUDDST-22624

As seen in RCA: gitops 1.10.3 not added to prod 4.13 index and also in CLOUDDST-22350, there was an issue where two workers picked the same port at the same VM. 

This decorator with atomic operation `os.open(lock_file, os.O_CREAT | os.O_EXCL)` should resolve this issue. 

Few notes:
- I did not use `continue` within the loop, as it was applied within the try-except block. Instead I used this `port_found` flag.
- os.open(lock_file, os.O_CREAT | os.O_EXCL) is atomic according to [man pages](https://linux.die.net/man/3/open)