### PR TITLE
Add OPM v1.40.0 to dev env

### DIFF
--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -28,6 +28,8 @@ ADD https://github.com/operator-framework/operator-registry/releases/download/v1
 RUN chmod +x /usr/bin/opm-v1.26.4
 ADD https://github.com/operator-framework/operator-registry/releases/download/v1.28.0/linux-amd64-opm /usr/bin/opm-v1.28.0
 RUN chmod +x /usr/bin/opm-v1.28.0
+ADD https://github.com/operator-framework/operator-registry/releases/download/v1.40.0/linux-amd64-opm /usr/bin/opm-v1.40.0
+RUN chmod +x /usr/bin/opm-v1.40.0
 # Create a link for default opm
 RUN ln -s /usr/bin/opm-v1.28.0 /usr/bin/opm
 RUN chmod +x /usr/bin/opm

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -26,12 +26,10 @@ RUN dnf -y install \
 
 ADD https://github.com/operator-framework/operator-registry/releases/download/v1.26.4/linux-amd64-opm /usr/bin/opm-v1.26.4
 RUN chmod +x /usr/bin/opm-v1.26.4
-ADD https://github.com/operator-framework/operator-registry/releases/download/v1.28.0/linux-amd64-opm /usr/bin/opm-v1.28.0
-RUN chmod +x /usr/bin/opm-v1.28.0
 ADD https://github.com/operator-framework/operator-registry/releases/download/v1.40.0/linux-amd64-opm /usr/bin/opm-v1.40.0
 RUN chmod +x /usr/bin/opm-v1.40.0
 # Create a link for default opm
-RUN ln -s /usr/bin/opm-v1.28.0 /usr/bin/opm
+RUN ln -s /usr/bin/opm-v1.26.4 /usr/bin/opm
 RUN chmod +x /usr/bin/opm
 ADD https://github.com/fullstorydev/grpcurl/releases/download/v1.8.5/grpcurl_1.8.5_linux_x86_64.tar.gz /src/grpcurl_1.8.5_linux_x86_64.tar.gz
 RUN cd /usr/bin && tar -xf /src/grpcurl_1.8.5_linux_x86_64.tar.gz grpcurl && rm -f /src/grpcurl_1.8.5_linux_x86_64.tar.gz

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -234,7 +234,7 @@ class DevelopmentConfig(Config):
         "v4.12": "opm-v1.26.4",
         "v4.13": "opm-v1.26.4",
         "v4.14": "opm-v1.26.4",
-        "v4.15": "opm-v1.28.0",
+        "v4.15": "opm-v1.26.4",
         "v4.16": "opm-v1.40.0",
     }
 

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -235,7 +235,7 @@ class DevelopmentConfig(Config):
         "v4.13": "opm-v1.26.4",
         "v4.14": "opm-v1.26.4",
         "v4.15": "opm-v1.28.0",
-        "v4.16": "opm-v1.28.0",
+        "v4.16": "opm-v1.40.0",
     }
 
 

--- a/tests/test_workers/test_tasks/test_build_create_empty_index.py
+++ b/tests/test_workers/test_tasks/test_build_create_empty_index.py
@@ -247,7 +247,7 @@ def test_handle_create_empty_index_request_fbc(
     'from_index, index_version, opm_version',
     [
         ('index-image:410', 'v4.10', 'opm-v1.26.4'),
-        ('index-image:415', 'v4.15', 'opm-v1.28.0'),
+        ('index-image:415', 'v4.15', 'opm-v1.26.4'),
     ],
 )
 @mock.patch('iib.workers.tasks.build_create_empty_index._cleanup')


### PR DESCRIPTION
We are now using OPM v1.40.0 for OCP v4.16 index images. This commit adds the OPM version to the dev env to facilitate local testing.

resolves:CLOUDDST-22689