### PR TITLE
Fix bug on `fbc_utils.enforce_json_config_dir`

### DIFF
--- a/tests/test_workers/test_tasks/test_fbc_utils.py
+++ b/tests/test_workers/test_tasks/test_fbc_utils.py
@@ -2,6 +2,7 @@
 import json
 import os
 import tempfile
+from textwrap import dedent
 from unittest import mock
 
 import pytest
@@ -174,6 +175,30 @@ def test_enforce_json_config_dir(tmpdir):
 
     with open(expected_file, 'r') as f:
         assert json.load(f) == data
+
+
+def test_enforce_json_config_dir_multiple_chunks_input(tmpdir):
+    multiple_chunks_yaml = """\
+    ---
+    foo: bar
+    bar: foo
+    ---
+    another: data
+    ---
+    one_more: chunk
+    """
+
+    expected_result = """{"foo": "bar", "bar": "foo"}{"another": "data"}{"one_more": "chunk"}"""
+
+    input = os.path.join(tmpdir, f"test_file.yaml")
+    output = os.path.join(tmpdir, f"test_file.json")
+    with open(input, 'w') as w:
+        w.write(dedent(multiple_chunks_yaml))
+
+    enforce_json_config_dir(tmpdir)
+
+    with open(output, 'r') as f:
+        assert f.read() == expected_result
 
 
 @pytest.mark.parametrize('ldr_output', [['testoperator'], ['test1', 'test2'], []])


### PR DESCRIPTION
This commit fixes a bug on `fbc_utils.enforce_json_config_dir` which was caused by the incoming `catalog.yaml` being composed of multiple data chunks (multiple "inner yamls").

The bugfix was tested alongisde opm validate and can be verified manually with the following steps:

1. Pull ` registry-proxy.engineering.redhat.com/rh-osbs/iib-pub:v4.12`
2. Copy the directory `configs/rhbk-operator/` to a temporary location in your machine.
3. Create two sub-directories called `in` and `out`
3. Move the `catalog.yaml` to the sub-directory `in`
4. Create a new file named `converter.py` with the following snippet and run it:

```
import contextlib
import json
import os

import ruamel.yaml

yaml = ruamel.yaml.YAML()

with contextlib.suppress(FileNotFoundError):
    os.remove('out/catalog.json')

with open('in/catalog.yaml', 'r') as yaml_in, open('out/catalog.json', 'a') as json_out:
    data = yaml.load_all(yaml_in)

    for chunk in data:
        json.dump(chunk, json_out)
```

5. Use `opm validate out` to validate the output catalog.

Refers to CLOUDDST-22904