### PR TITLE
verify_operators_exists returns only unique packages

### DIFF
--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -4,7 +4,7 @@ import random
 import shutil
 import subprocess
 import time
-from typing import List, Optional, Tuple, Generator, Union
+from typing import List, Optional, Tuple, Generator, Union, Set
 
 from tenacity import (
     before_sleep_log,
@@ -900,14 +900,14 @@ def verify_operators_exists(
     :param list(str) operator_packages: operator_package to check
     :param str overwrite_from_index_token: token used to access the image
     :return: packages_in_index, index_db_path
-    :rtype: (list, str)
+    :rtype: (set, str)
     """
     from iib.workers.tasks.build import terminate_process, get_bundle_json
     from iib.workers.tasks.iib_static_types import BundleImage
     from iib.workers.tasks.utils import run_cmd
     from iib.workers.tasks.utils import set_registry_token
 
-    packages_in_index: List[str] = []
+    packages_in_index: Set[str] = set()
 
     log.info("Verifying if operator packages %s exists in index %s", operator_packages, from_index)
 
@@ -925,7 +925,7 @@ def verify_operators_exists(
 
     for bundle in present_bundles:
         if bundle['packageName'] in operator_packages:
-            packages_in_index.append(bundle['packageName'])
+            packages_in_index.add(bundle['packageName'])
 
     if packages_in_index:
         log.info("operator packages found in index_db %s:  %s", index_db_path, packages_in_index)

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -739,13 +739,19 @@ def test_opm_registry_add_fbc_fragment(
     [
         (
             '{"packageName": "test-operator", "version": "v1.0", "bundlePath":"bundle1"\n}'
+            '\n{"packageName": "test-operator", "version": "v1.2", "bundlePath":"bundle1"\n}'
             '\n{\n"packageName": "package2", "version": "v2.0", "bundlePath":"bundle2"}',
-            ["test-operator"],
+            {"test-operator"},
+        ),
+        (
+            '{"packageName": "test-operator", "version": "v1.0", "bundlePath":"bundle1"\n}'
+            '\n{\n"packageName": "package2", "version": "v2.0", "bundlePath":"bundle2"}',
+            {"test-operator"},
         ),
         (
             '{"packageName": "package1", "version": "v1.0", "bundlePath":"bundle1"\n}'
             '\n{\n"packageName": "package2", "version": "v2.0", "bundlePath":"bundle2"}',
-            [],
+            set(),
         ),
     ],
 )


### PR DESCRIPTION
It appears that are multiple `packageName` with same name present in the result of `'api.Registry/ListBundles'`.
This caused to add every occurrence in the list of packages in index.db. This list was then passed as argument to `opm registry rm` command which caused failure because same package wanted to be removed more then once.

This is fixed by returning only unique packages names.

[CLOUDDST-23175]