### PR TITLE
Fix OTEL issues when dealing with unsupported objects

### DIFF
--- a/iib/common/tracing.py
+++ b/iib/common/tracing.py
@@ -136,7 +136,7 @@ def instrument_tracing(
                         span_result = {'response': response, 'http_code': code}
                     else:
                         # If the returned result is not of type dict, create one
-                        span_result = {'result': result or 'success'}
+                        span_result = {'result': str(result) or 'success'}
                 except Exception as exc:
                     span.set_status(Status(StatusCode.ERROR))
                     span.record_exception(exc)

--- a/iib/common/tracing.py
+++ b/iib/common/tracing.py
@@ -11,6 +11,7 @@ Usage:
           pass
 
 """
+import json
 import os
 import functools
 import getpass
@@ -20,6 +21,7 @@ from copy import deepcopy
 from typing import Any, Dict
 
 
+from flask import Response
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind, Status, StatusCode
 from opentelemetry.sdk.resources import Resource, SERVICE_NAME
@@ -128,6 +130,10 @@ def instrument_tracing(
                     result = func(*args, **kwargs)
                     if isinstance(result, dict):
                         span_result = normalize_data_for_span(result)
+                    elif isinstance(result, tuple) and isinstance(result[0], Response):
+                        response = json.dumps(result[0].json)
+                        code = result[1]
+                        span_result = {'response': response, 'http_code': code}
                     else:
                         # If the returned result is not of type dict, create one
                         span_result = {'result': result or 'success'}


### PR DESCRIPTION
This PR prevents the OTEL `instrument_tracing` method to crash when dealing with complex types.

It has the following changes:

First, it detects a typical IIB API response, which consists of a  tuple with a Flask.Response object and the HTTP code.
    
Example:
    
```
def add_bundles() -> Tuple[flask.Response, int]:
    ...
    return flask.jsonify(request.to_json()), 200
```
 
Then, it also changes the execution from the `else` condition on `instrument_tracing` so any object which is not properly mapped gets converted into `String` before being sent as a dictionary value to the OTEL `span_result`.

With this we no longer see the following messages in IIB-API logs:
    
 ```
 Invalid type Response in attribute 'result' value sequence.
 Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or None
 ```
    
Refers to CLOUDDST-23028