### PR TITLE
Fix opm registry serve command

### DIFF
--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -358,11 +358,10 @@ def opm_serve(
     return result
 
 
-@create_port_filelocks(port_purposes=["opm_port", "opm_pprof_port"])
+@create_port_filelocks(port_purposes=["opm_port"])
 def opm_registry_serve(
     opm_port: int,
     db_path: str,
-    opm_pprof_port: Optional[int] = None,
 ) -> Tuple[int, subprocess.Popen]:
     """
     Locally start OPM registry service, which can be communicated with using gRPC queries.
@@ -389,9 +388,6 @@ def opm_registry_serve(
         '-t',
         '/dev/null',
     ]
-    if opm_pprof_port:
-        # by default opm uses the 127.0.0.1:6060
-        cmd.extend(["--pprof-addr", f"127.0.0.1:{str(opm_pprof_port)}"])
 
     cwd = os.path.dirname(db_path)
     result = (

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -280,8 +280,8 @@ def test_create_port_filelocks_failure(mock_pfl_u, mock_pfl_la, mock_gops):
 @mock.patch(
     'iib.workers.tasks.opm_operations.get_opm_port_stacks',
     return_value=(
-        [[5001, 6001], [5002, 6002]],
-        ['opm_port', 'opm_pprof_port'],
+        [[5001], [5002]],
+        ['opm_port'],
     ),
 )
 @mock.patch('iib.workers.tasks.opm_operations.PortFileLock.lock_acquire')
@@ -291,8 +291,8 @@ def test_opm_registry_serve(mock_pfl_u, mock_pfl_la, mock_gops, mock_scap):
     port, _ = opm_operations.opm_registry_serve(db_path='some_path.db')
     assert port == 5001
     assert mock_scap.call_count == 1
-    assert mock_pfl_la.call_count == 2
-    assert mock_pfl_u.call_count == 2
+    assert mock_pfl_la.call_count == 1
+    assert mock_pfl_u.call_count == 1
 
 
 @pytest.mark.parametrize('is_fbc', (True, False))
@@ -325,8 +325,8 @@ def test_opm_serve_from_index(
     Also test create_port_filelocks working correctly with opm_serve_from_index.
     """
     mock_gops.return_value = (
-        [[5001, 6001], [5002, 6002], [5003, 6003]],
-        ['opm_port', 'opm_pprof_port'],
+        [[5001], [5002], [5003]],
+        ['opm_port'],
     )
     my_mock = mock.MagicMock()
     mock_ifbc.return_value = is_fbc


### PR DESCRIPTION
opm registry serve does not have --pprof-addr option, having this option enabled makes opm calls failing for opm >1.40