### PR TITLE
create-emty-index - remove FBC opted in operators.

### DIFF
--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -764,6 +764,11 @@ def run_cmd(
             match = _regex_reverse_search(regex, response)
             if match:
                 raise IIBError(f'{exc_msg.rstrip(".")}: {match.groups()[0]}')
+            elif (
+                '"permissive mode disabled" error="error deleting packages from'
+                ' database: error removing operator package' in response.stderr
+            ):
+                raise IIBError("Error deleting packages from database")
         elif cmd[0] == 'buildah':
             # Check for HTTP 50X errors on buildah
             network_regexes = [


### PR DESCRIPTION
FBC opted in operator caused opm to fail when removing it because operator was not present in database. If this occurs we try to remove operators once again but we enable permissive mode which silents errors when operator is not present.

[CLOUDDST-23683]