### PR TITLE
Fixing generate dockerfile

### DIFF
--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -683,7 +683,7 @@ def create_dockerfile(
                     CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
                     # Copy declarative config root and cache into image
-                    ADD catalog /configs
+                    ADD {os.path.basename(fbc_dir)} /configs
                     COPY --chown=1001:0 cache /tmp/cache
 
                     # Set DC-specific label for the location of the DC root directory

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -438,7 +438,7 @@ def test_create_dockerfile(tmpdir, dockerfile):
         CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
 
         # Copy declarative config root and cache into image
-        ADD catalog /configs
+        ADD catalogs /configs
         COPY --chown=1001:0 cache /tmp/cache
 
         # Set DC-specific label for the location of the DC root directory


### PR DESCRIPTION
Propagate FBC configs directory to Dockerfile template so it is copied correctly.

[CLOUDDST-23891]