### PR TITLE
Allow "binary_image" to receive "scratch"

### DIFF
--- a/iib/web/models.py
+++ b/iib/web/models.py
@@ -251,7 +251,11 @@ class Image(db.Model):
         :rtype: Image
         :raise ValidationError: if pull_specification for the image is invalid
         """
-        if '@' not in pull_specification and ':' not in pull_specification:
+        if (
+            '@' not in pull_specification
+            and ':' not in pull_specification
+            and pull_specification != "scratch"
+        ):
             raise ValidationError(
                 f'Image {pull_specification} should have a tag or a digest specified.'
             )

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -807,6 +807,15 @@ def handle_add_request(
         ),
     )
     from_index_resolved = prebuild_info['from_index_resolved']
+
+    # FIXME: To be removed when the binaryless image build support is implemented
+    is_binaryless = prebuild_info['binary_image'] == "scratch"
+    if is_binaryless:
+        _cleanup()
+        log.warning("IIB is not yet able to process binaryless images.")
+        set_request_state(request_id, 'failed', 'IIB is not yet able to process binaryless images')
+        return
+
     Opm.set_opm_version(from_index_resolved)
     with set_registry_token(overwrite_from_index_token, from_index_resolved):
         is_fbc = is_image_fbc(from_index_resolved) if from_index else False
@@ -1061,6 +1070,14 @@ def handle_rm_request(
     _update_index_image_build_state(request_id, prebuild_info)
 
     from_index_resolved = prebuild_info['from_index_resolved']
+    # FIXME: To be removed when the binaryless image build support is implemented
+    is_binaryless = prebuild_info['binary_image'] == "scratch"
+    if is_binaryless:
+        _cleanup()
+        log.warning("IIB is not yet able to process binaryless images.")
+        set_request_state(request_id, 'failed', 'IIB is not yet able to process binaryless images')
+        return
+
     Opm.set_opm_version(from_index_resolved)
 
     with tempfile.TemporaryDirectory(prefix=f'iib-{request_id}-') as temp_dir:

--- a/iib/workers/tasks/build_create_empty_index.py
+++ b/iib/workers/tasks/build_create_empty_index.py
@@ -95,6 +95,13 @@ def handle_create_empty_index_request(
     )
     from_index_resolved = prebuild_info['from_index_resolved']
     prebuild_info['labels'] = labels
+    # FIXME: To be removed when the binaryless image build support is implemented
+    is_binaryless = prebuild_info['binary_image'] == "scratch"
+    if is_binaryless:
+        _cleanup()
+        log.warning("IIB is not yet able to process binaryless images.")
+        set_request_state(request_id, 'failed', 'IIB is not yet able to process binaryless images')
+        return
     Opm.set_opm_version(from_index_resolved)
 
     if not output_fbc and is_image_fbc(from_index_resolved):

--- a/iib/workers/tasks/build_fbc_operations.py
+++ b/iib/workers/tasks/build_fbc_operations.py
@@ -81,6 +81,14 @@ def handle_fbc_operation_request(
 
     from_index_resolved = prebuild_info['from_index_resolved']
     binary_image_resolved = prebuild_info['binary_image_resolved']
+    # FIXME: To be removed when the binaryless image build support is implemented
+    is_binaryless = prebuild_info['binary_image'] == "scratch"
+    if is_binaryless:
+        _cleanup()
+        log.warning("IIB is not yet able to process binaryless images.")
+        set_request_state(request_id, 'failed', 'IIB is not yet able to process binaryless images')
+        return
+
     Opm.set_opm_version(from_index_resolved)
 
     prebuild_info['fbc_fragment_resolved'] = resolved_fbc_fragment

--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -252,6 +252,14 @@ def handle_merge_request(
         )
     source_from_index_resolved = prebuild_info['source_from_index_resolved']
     target_index_resolved = prebuild_info['target_index_resolved']
+    # FIXME: To be removed when the binaryless image build support is implemented
+    is_binaryless = prebuild_info['binary_image'] == "scratch"
+    if is_binaryless:
+        _cleanup()
+        log.warning("IIB is not yet able to process binaryless images.")
+        set_request_state(request_id, 'failed', 'IIB is not yet able to process binaryless images')
+        return
+
     Opm.set_opm_version(target_index_resolved)
 
     _update_index_image_build_state(request_id, prebuild_info)


### PR DESCRIPTION
This commit changes IIB to accept string "scratch" as `binary_image` in order to support the binaryless build in the future.

With this change IIB accept string "scratch" as binary image:

- defined in IIB_BINARY_IMAGE_CONFIG
- passed by binary_image parameter

Refers to CLOUDDST-23094