### PR TITLE
Release v9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 9.1.0
+
+* Converting timestamp object to string
+* Force empty entrypoint to podman craete
+* Allow "binary_image" to receive "scratch"
+* Bump IIB's dependencies
+
 ## 9.0.1
 
 * Bump IIB's dependencies

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='iib',
-    version='9.0.1',
+    version='9.1.0',
     long_description=__doc__,
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,


### PR DESCRIPTION
Changes:

- Converting timestamp object to string
- Force empty entrypoint to podman craete
- Allow "binary_image" to receive "scratch"
- Bump IIB's dependencies