### PR TITLE
Add "--migrate-level" for opm_migrate if opm>1.46

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -122,6 +122,8 @@ class Config(object):
     # Enable send events to the broker. This is needed for celery promethues exporter
     worker_send_task_events: bool = True
     task_send_sent_event: bool = True
+    # The minimal version of OPM which requires setting the --migrate-level flag for migrate
+    iib_opm_new_migrate_version = "v1.46.0"
 
 
 class ProductionConfig(Config):

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -621,7 +621,13 @@ def opm_migrate(
     if os.path.exists(fbc_dir_path):
         shutil.rmtree(fbc_dir_path)
 
-    cmd = [Opm.opm_version, 'migrate', index_db, fbc_dir_path]
+    migrate_args = []
+    opm_new_migrate_version = get_worker_config().get('iib_opm_new_migrate_version')
+    opm_version_number = Opm.get_opm_version_number()
+    if Version(opm_version_number) > Version(opm_new_migrate_version):
+        migrate_args = ['--migrate-level', 'bundle-object-to-csv-metadata']
+
+    cmd = [Opm.opm_version, 'migrate', *migrate_args, index_db, fbc_dir_path]
 
     run_cmd(cmd, {'cwd': base_dir}, exc_msg='Failed to migrate index.db to file-based catalog')
     log.info("Migration to file-based catalog was completed.")


### PR DESCRIPTION
This commit modifies the `opm_migrate` function to include the `--migrate-level bundle-object-to-csv-metadata` arguments to the command whenever the OPM version is greater than 1.46

Refers to CLOUDDST-25703