### PR TITLE
Release v9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 9.2.0
+
+* IIB uses opm render
+* Add support for building binaryless catalogs
+* Bump dependencies
+
 ## 9.1.1
 
 * Add "--migrate-level" for opm_migrate if opm>1.46 by @JAVGan in https://github.com/release-engineering/iib/pull/795

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='iib',
-    version='9.1.1',
+    version='9.2.0',
     long_description=__doc__,
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,


### PR DESCRIPTION
Changes:

- IIB uses opm render
- Add support for building binaryless catalogs
- Bump dependencies

Refers to CLOUDDST-23094