### PR TITLE
Fix memory leak in `opm_render`

### DIFF
--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -420,7 +420,8 @@ def opm_render(
         return []
 
     log.debug("Parsing data from opm render")
-    return [json.loads(package) for package in re.split(r'(?<=})\n(?={)', opm_render_output)]
+    for package in re.split(r'(?<=})\n(?={)', opm_render_output):
+        yield json.loads(package)
 
 
 def _get_or_create_temp_index_db_file(


### PR DESCRIPTION
This commit aims to fix a memory leak on `opm_render` caused by returning a list of JSON elements whenever the render operations results in a voluptous amount of operators.

The adopted solution was to simply tranform the returned list into a generator which will return chunks of the render data in order to prevent the memory leak.

Relates to #784