### PR TITLE
Add Index Catalog to GitLab push configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ The custom configuration options for the REST API are listed below:
   to another dictionary mapping ocp_version label to a binary image pull specification.
   This is useful in setting up customized binary image for different index image images thus
   reducing complexity for the end user. This defaults to `{}`.
+* `IIB_INDEX_TO_GITLAB_PUSH_MAP` - the mapping, `dict(<str>:<str>)`, to specify which index
+  images (keys) which should have its catalog pushed into a GitLab repository (value). This defaults to {}.
 * `IIB_GRAPH_MODE_INDEX_ALLOW_LIST` - the list of index image pull specs on which using the
   `graph_update_mode` parameter while submitting an IIB request is permitted. This defaults to `[]`
   . Please check out the [API Documentation](http://release-engineering.github.io/iib) for more

--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -99,6 +99,7 @@ def _get_rm_args(
         request.distribution_scope,
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
         payload.get('build_tags', []),
+        flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
     ]
 
 
@@ -136,6 +137,7 @@ def _get_add_args(
         payload.get('build_tags', []),
         payload.get('graph_update_mode'),
         payload.get('check_related_images', False),
+        flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
     ]
 
 
@@ -750,6 +752,7 @@ def patch_request(request_id: int) -> Tuple[flask.Response, int]:
         'parent_bundle_image_resolved',
         'source_from_index_resolved',
         'target_index_resolved',
+        'index_to_gitlab_push_map',
     )
     start_time = time.time()
     for key in image_keys:
@@ -1315,6 +1318,7 @@ def fbc_operations() -> Tuple[flask.Response, int]:
         payload.get('build_tags'),
         payload.get('add_arches'),
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
+        flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
     ]
     safe_args = _get_safe_args(args, payload)
     error_callback = failed_request_callback.s(request.id)

--- a/iib/web/config.py
+++ b/iib/web/config.py
@@ -20,6 +20,7 @@ class Config(object):
     IIB_ADDITIONAL_LOGGERS: List[str] = []
     IIB_AWS_S3_BUCKET_NAME: Optional[str] = None
     IIB_BINARY_IMAGE_CONFIG: Dict[str, Dict[str, str]] = {}
+    IIB_INDEX_TO_GITLAB_PUSH_MAP: Dict[str, str] = {}
     IIB_GRAPH_MODE_INDEX_ALLOW_LIST: List[str] = []
     IIB_GRAPH_MODE_OPTIONS: List[str] = ['replaces', 'semver', 'semver-skippatch']
     IIB_GREENWAVE_CONFIG: Dict[str, str] = {}

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -723,6 +723,7 @@ def handle_add_request(
     build_tags: Optional[List[str]] = None,
     graph_update_mode: Optional[str] = None,
     check_related_images: bool = False,
+    index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
     username: Optional[str] = None,
     traceparent: Optional[str] = None,
 ) -> None:
@@ -761,6 +762,8 @@ def handle_add_request(
     :param list build_tags: List of tags which will be applied to intermediate index images.
     :param str graph_update_mode: Graph update mode that defines how channel graphs are updated
         in the index.
+    :param dict index_to_gitlab_push_map: the dict mapping index images (keys) to GitLab repos
+        (values) in order to push their catalogs into GitLab.
     :param str traceparent: the traceparent header value to be used for tracing the request.
     :raises IIBError: if the index image build fails.
     """
@@ -1012,6 +1015,7 @@ def handle_rm_request(
     distribution_scope: Optional[str] = None,
     binary_image_config: Optional[Dict[str, Dict[str, str]]] = None,
     build_tags: Optional[List[str]] = None,
+    index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
 ) -> None:
     """
     Coordinate the work needed to remove the input operators and rebuild the index image.
@@ -1035,6 +1039,8 @@ def handle_rm_request(
     :param dict binary_image_config: the dict of config required to identify the appropriate
         ``binary_image`` to use.
     :param list build_tags: List of tags which will be applied to intermediate index images.
+    :param dict index_to_gitlab_push_map: the dict mapping index images (keys) to GitLab repos
+        (values) in order to remove their catalogs from GitLab.
     :raises IIBError: if the index image build fails.
     """
     _cleanup()

--- a/iib/workers/tasks/build_fbc_operations.py
+++ b/iib/workers/tasks/build_fbc_operations.py
@@ -46,6 +46,7 @@ def handle_fbc_operation_request(
     build_tags: Optional[Set[str]] = None,
     add_arches: Optional[Set[str]] = None,
     binary_image_config: Optional[Dict[str, Dict[str, str]]] = None,
+    index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
 ) -> None:
     """
     Add a fbc fragment to an fbc index image.
@@ -59,6 +60,8 @@ def handle_fbc_operation_request(
     :param set add_arches: the set of arches to build in addition to the arches ``from_index`` is
         currently built for; if ``from_index`` is ``None``, then this is used as the list of arches
         to build the index image for
+    :param dict index_to_gitlab_push_map: the dict mapping index images (keys) to GitLab repos
+        (values) in order to push their catalogs into GitLab.
     """
     _cleanup()
     set_request_state(request_id, 'in_progress', 'Resolving the fbc fragment')

--- a/tests/test_web/test_api_v1.py
+++ b/tests/test_web/test_api_v1.py
@@ -959,9 +959,9 @@ def test_add_bundle_overwrite_token_redacted(mock_smfsc, mock_har, app, auth_env
     assert rv.status_code == 201
     mock_har.apply_async.assert_called_once()
     # Tenth to last element in args is the overwrite_from_index parameter
-    assert mock_har.apply_async.call_args[1]['args'][-10] is True
+    assert mock_har.apply_async.call_args[1]['args'][-11] is True
     # Ninth to last element in args is the overwrite_from_index_token parameter
-    assert mock_har.apply_async.call_args[1]['args'][-9] == token
+    assert mock_har.apply_async.call_args[1]['args'][-10] == token
     assert 'overwrite_from_index_token' not in rv_json
     assert token not in json.dumps(rv_json)
     assert token not in mock_har.apply_async.call_args[1]['argsrepr']
@@ -1492,8 +1492,8 @@ def test_remove_operator_overwrite_token_redacted(mock_smfsc, mock_hrr, app, aut
     assert rv.status_code == 201
     mock_hrr.apply_async.assert_called_once()
     # Third to last element in args is the overwrite_from_index parameter
-    assert mock_hrr.apply_async.call_args[1]['args'][-5] is True
-    assert mock_hrr.apply_async.call_args[1]['args'][-4] == token
+    assert mock_hrr.apply_async.call_args[1]['args'][-6] is True
+    assert mock_hrr.apply_async.call_args[1]['args'][-5] == token
     assert 'overwrite_from_index_token' not in rv_json
     assert token not in json.dumps(rv_json)
     assert token not in mock_hrr.apply_async.call_args[1]['argsrepr']
@@ -1858,12 +1858,14 @@ def test_add_rm_batch_success(mock_smfnbor, mock_hrr, mock_har, app, auth_env, c
                     [],
                     None,
                     False,
+                    {},
                 ],
                 argsrepr=(
                     "[['registry-proxy/rh-osbs/lgallett-bundle:v1.0-9'], "
                     "1, 'registry-proxy/rh-osbs/openshift-ose-operator-registry:v4.5', "
                     "'registry-proxy/rh-osbs-stage/iib:v4.5', ['amd64'], '*****', "
-                    "'hello-operator', None, True, '*****', None, None, {}, [], [], None, False]"
+                    "'hello-operator', None, True, '*****', None, None, {}, [], [], None, "
+                    "False, {}]"
                 ),
                 link_error=mock.ANY,
                 queue=None,
@@ -1884,11 +1886,12 @@ def test_add_rm_batch_success(mock_smfnbor, mock_hrr, mock_har, app, auth_env, c
                     None,
                     {},
                     [],
+                    {},
                 ],
                 argsrepr=(
                     "[['kiali-ossm'], 2, 'registry:8443/iib-build:11', "
                     "'registry-proxy/rh-osbs/openshift-ose-operator-registry:v4.5'"
-                    ", None, False, None, None, {}, []]"
+                    ", None, False, None, None, {}, [], {}]"
                 ),
                 link_error=mock.ANY,
                 queue=None,


### PR DESCRIPTION
This commit introduces a new API configuration named `IIB_INDEX_TO_GITLAB_PUSH_MAP`, which may contain a mapping between index images (keys) to push its catalogs into certain GitLab repositories (values).

The implementation of GitLab push will be added into a different PR.

Refers to CLOUDDST-26435