### PR TITLE
Add oras_utils.py module to push and pull artifacts

### DIFF
--- a/iib/workers/tasks/oras_utils.py
+++ b/iib/workers/tasks/oras_utils.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""This file contains functions for ORAS (OCI Registry As Storage) operations."""
+import logging
+import os
+import shutil
+import tempfile
+from typing import Dict, Optional, Any
+
+from iib.common.tracing import instrument_tracing
+from iib.exceptions import IIBError
+from iib.workers.tasks.utils import run_cmd, set_registry_auths
+
+log = logging.getLogger(__name__)
+
+
+@instrument_tracing(span_name="workers.tasks.oras_utils.get_oras_artifact")
+def get_oras_artifact(
+    artifact_ref: str,
+    base_dir: str,
+    registry_auths: Optional[Dict[str, Any]] = None,
+    temp_dir_prefix: str = "iib-oras-",
+) -> str:
+    """
+    Pull an OCI artifact from a registry to a temporary directory.
+
+    This function is equivalent to: `oras pull {artifact_ref} -o {temp_dir}`
+
+    :param str artifact_ref: OCI artifact reference (e.g., 'quay.io/repo/repo:tag')
+    :param str base_dir: Base directory where the temporary subdirectory will be created.
+        Can be an absolute or relative path. If relative, the directory must exist.
+        The function always returns an absolute path regardless of the base_dir type.
+    :param dict registry_auths: Optional dockerconfig.json auth information for private registries
+    :param str temp_dir_prefix: Prefix for the temporary directory name
+    :return: Path to the temporary directory containing the artifact (always absolute)
+    :rtype: str
+    :raises IIBError: If the pull operation fails
+    """
+    log.info('Pulling OCI artifact %s to temporary directory', artifact_ref)
+
+    # Create a subdirectory within the provided base_dir
+    temp_dir = tempfile.mkdtemp(prefix=temp_dir_prefix, dir=base_dir)
+
+    # Use namespace-specific registry authentication if provided
+    with set_registry_auths(registry_auths, use_empty_config=True):
+        try:
+            run_cmd(
+                ['oras', 'pull', artifact_ref, '-o', temp_dir],
+                exc_msg=f'Failed to pull OCI artifact {artifact_ref}',
+            )
+            log.info('Successfully pulled OCI artifact %s to %s', artifact_ref, temp_dir)
+            return temp_dir
+        except Exception as e:
+            # Clean up temp directory on failure
+            if os.path.exists(temp_dir):
+                shutil.rmtree(temp_dir)
+            raise IIBError(f'Failed to pull OCI artifact {artifact_ref}: {e}')
+
+
+@instrument_tracing(span_name="workers.tasks.oras_utils.push_oras_artifact")
+def push_oras_artifact(
+    artifact_ref: str,
+    local_path: str,
+    artifact_type: str = "application/vnd.sqlite",
+    registry_auths: Optional[Dict[str, Any]] = None,
+    annotations: Optional[Dict[str, str]] = None,
+) -> None:
+    """
+    Push a local artifact to an OCI registry using ORAS.
+
+    This function is equivalent to: `oras push {artifact_ref} {local_path}:{artifact_type}`
+
+    :param str artifact_ref: OCI artifact reference to push to (e.g., 'quay.io/repo/repo:tag')
+    :param str local_path: Local path to the artifact file. Can be an absolute or relative path.
+        If an absolute path is provided, the --disable-path-validation flag will be
+        automatically added.
+    :param str artifact_type: MIME type of the artifact (default: 'application/vnd.sqlite')
+    :param dict registry_auths: Optional dockerconfig.json auth information for private registries
+    :param dict annotations: Optional annotations to add to the artifact
+    :raises IIBError: If the push operation fails
+    """
+    log.info('Pushing artifact from %s to %s with type %s', local_path, artifact_ref, artifact_type)
+
+    if not os.path.exists(local_path):
+        raise IIBError(f'Local artifact path does not exist: {local_path}')
+
+    # Build ORAS push command
+    cmd = ['oras', 'push', artifact_ref, f'{local_path}:{artifact_type}']
+
+    # Add --disable-path-validation flag for absolute paths
+    if os.path.isabs(local_path):
+        cmd.append('--disable-path-validation')
+
+    # Add annotations if provided
+    if annotations:
+        for key, value in annotations.items():
+            cmd.extend(['--annotation', f'{key}={value}'])
+
+    # Use namespace-specific registry authentication if provided
+    with set_registry_auths(registry_auths, use_empty_config=True):
+        try:
+            run_cmd(cmd, exc_msg=f'Failed to push OCI artifact to {artifact_ref}')
+            log.info('Successfully pushed OCI artifact to %s', artifact_ref)
+        except Exception as e:
+            raise IIBError(f'Failed to push OCI artifact to {artifact_ref}: {e}')

--- a/tests/test_workers/test_tasks/test_oras_utils.py
+++ b/tests/test_workers/test_tasks/test_oras_utils.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Basic unit tests for oras_utils."""
+import logging
+import pytest
+from unittest import mock
+
+from iib.exceptions import IIBError
+from iib.workers.tasks.oras_utils import (
+    get_oras_artifact,
+    push_oras_artifact,
+)
+
+
+@pytest.fixture()
+def registry_auths():
+    return {'auths': {'quay.io': {'auth': 'dXNlcjpwYXNz'}}}  # base64 encoded user:pass
+
+
+@mock.patch('tempfile.mkdtemp')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_get_oras_artifact_success(mock_run_cmd, mock_mkdtemp):
+    """Test successful artifact pull."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    base_dir = '/tmp/base'
+    mock_run_cmd.return_value = 'Success'
+    mock_mkdtemp.return_value = '/tmp/test-dir'
+
+    result = get_oras_artifact(artifact_ref, base_dir)
+
+    assert result == '/tmp/test-dir'
+    mock_mkdtemp.assert_called_once_with(prefix='iib-oras-', dir=base_dir)
+    mock_run_cmd.assert_called_once_with(
+        ['oras', 'pull', artifact_ref, '-o', '/tmp/test-dir'],
+        exc_msg=f'Failed to pull OCI artifact {artifact_ref}',
+    )
+
+
+@mock.patch('iib.workers.tasks.oras_utils.set_registry_auths')
+@mock.patch('tempfile.mkdtemp')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_get_oras_artifact_with_auth(mock_run_cmd, mock_mkdtemp, mock_auth, registry_auths):
+    """Test artifact pull with authentication."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    base_dir = '/tmp/base'
+    mock_run_cmd.return_value = 'Success'
+    mock_mkdtemp.return_value = '/tmp/test-dir'
+
+    result = get_oras_artifact(artifact_ref, base_dir, registry_auths)
+
+    assert result == '/tmp/test-dir'
+    mock_auth.assert_called_once_with(registry_auths, use_empty_config=True)
+    mock_mkdtemp.assert_called_once_with(prefix='iib-oras-', dir=base_dir)
+    mock_run_cmd.assert_called_once_with(
+        ['oras', 'pull', artifact_ref, '-o', '/tmp/test-dir'],
+        exc_msg=f'Failed to pull OCI artifact {artifact_ref}',
+    )
+
+
+@mock.patch('os.path.exists')
+@mock.patch('tempfile.mkdtemp')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+@mock.patch('shutil.rmtree')
+def test_get_oras_artifact_failure(mock_rmtree, mock_run_cmd, mock_mkdtemp, mock_exists):
+    """Test artifact pull failure."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    base_dir = '/tmp/base'
+    mock_run_cmd.side_effect = IIBError('Pull failed')
+    mock_mkdtemp.return_value = '/tmp/test-dir'
+    mock_exists.return_value = True
+
+    with pytest.raises(IIBError, match='Pull failed'):
+        get_oras_artifact(artifact_ref, base_dir)
+    mock_rmtree.assert_called_once_with('/tmp/test-dir')
+
+
+@mock.patch('tempfile.mkdtemp')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_get_oras_artifact_custom_prefix(mock_run_cmd, mock_mkdtemp):
+    """Test artifact pull with custom temp directory prefix."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    base_dir = '/tmp/base'
+    custom_prefix = 'custom-prefix-'
+    mock_run_cmd.return_value = 'Success'
+    mock_mkdtemp.return_value = '/tmp/custom-dir'
+
+    result = get_oras_artifact(artifact_ref, base_dir, temp_dir_prefix=custom_prefix)
+
+    assert result == '/tmp/custom-dir'
+    mock_mkdtemp.assert_called_once_with(prefix=custom_prefix, dir=base_dir)
+
+
+@mock.patch('tempfile.mkdtemp')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_get_oras_artifact_with_custom_base_dir(mock_run_cmd, mock_mkdtemp):
+    """Test artifact pull with custom base directory."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    base_dir = '/tmp/iib-123'
+    mock_run_cmd.return_value = 'Success'
+    mock_mkdtemp.return_value = '/tmp/iib-123/iib-oras-abc123'
+
+    result = get_oras_artifact(artifact_ref, base_dir)
+
+    assert result == '/tmp/iib-123/iib-oras-abc123'
+    mock_mkdtemp.assert_called_once_with(prefix='iib-oras-', dir=base_dir)
+    mock_run_cmd.assert_called_once_with(
+        ['oras', 'pull', artifact_ref, '-o', '/tmp/iib-123/iib-oras-abc123'],
+        exc_msg=f'Failed to pull OCI artifact {artifact_ref}',
+    )
+
+
+@mock.patch('os.path.exists')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_push_oras_artifact_success(mock_run_cmd, mock_exists):
+    """Test successful artifact push."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    local_path = '/tmp/test.db'
+    artifact_type = 'application/vnd.sqlite'
+    mock_run_cmd.return_value = 'Success'
+    mock_exists.return_value = True
+
+    push_oras_artifact(artifact_ref, local_path, artifact_type)
+
+    mock_run_cmd.assert_called_once_with(
+        [
+            'oras',
+            'push',
+            artifact_ref,
+            f'{local_path}:{artifact_type}',
+            '--disable-path-validation',
+        ],
+        exc_msg=f'Failed to push OCI artifact to {artifact_ref}',
+    )
+
+
+@mock.patch('iib.workers.tasks.oras_utils.set_registry_auths')
+@mock.patch('os.path.exists')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_push_oras_artifact_with_auth(mock_run_cmd, mock_exists, mock_auth, registry_auths):
+    """Test artifact push with authentication."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    local_path = '/tmp/test.db'
+    artifact_type = 'application/vnd.sqlite'
+    mock_run_cmd.return_value = 'Success'
+    mock_exists.return_value = True
+
+    push_oras_artifact(artifact_ref, local_path, artifact_type, registry_auths)
+
+    mock_auth.assert_called_once_with(registry_auths, use_empty_config=True)
+    mock_run_cmd.assert_called_once_with(
+        [
+            'oras',
+            'push',
+            artifact_ref,
+            f'{local_path}:{artifact_type}',
+            '--disable-path-validation',
+        ],
+        exc_msg=f'Failed to push OCI artifact to {artifact_ref}',
+    )
+
+
+@mock.patch('os.path.exists')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_push_oras_artifact_with_annotations(mock_run_cmd, mock_exists):
+    """Test artifact push with annotations."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    local_path = '/tmp/test.db'
+    artifact_type = 'application/vnd.sqlite'
+    annotations = {'key1': 'value1', 'key2': 'value2'}
+    mock_run_cmd.return_value = 'Success'
+    mock_exists.return_value = True
+
+    push_oras_artifact(artifact_ref, local_path, artifact_type, annotations=annotations)
+
+    expected_cmd = [
+        'oras',
+        'push',
+        artifact_ref,
+        f'{local_path}:{artifact_type}',
+        '--disable-path-validation',
+    ]
+    for key, value in annotations.items():
+        expected_cmd.extend(['--annotation', f'{key}={value}'])
+
+    mock_run_cmd.assert_called_once_with(
+        expected_cmd, exc_msg=f'Failed to push OCI artifact to {artifact_ref}'
+    )
+
+
+@mock.patch('os.path.exists')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_push_oras_artifact_failure(mock_run_cmd, mock_exists):
+    """Test artifact push failure."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    local_path = '/tmp/test.db'
+    artifact_type = 'application/vnd.sqlite'
+    mock_run_cmd.side_effect = IIBError('Push failed')
+    mock_exists.return_value = True
+
+    with pytest.raises(IIBError, match='Push failed'):
+        push_oras_artifact(artifact_ref, local_path, artifact_type)
+
+
+@mock.patch('os.path.exists')
+def test_push_oras_artifact_file_not_found(mock_exists):
+    """Test artifact push with non-existent file."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    local_path = '/tmp/test.db'
+    artifact_type = 'application/vnd.sqlite'
+    mock_exists.return_value = False
+
+    with pytest.raises(IIBError, match=f'Local artifact path does not exist: {local_path}'):
+        push_oras_artifact(artifact_ref, local_path, artifact_type)
+
+
+@pytest.mark.parametrize(
+    "artifact_ref,local_path,artifact_type,expected_cmd",
+    [
+        (
+            "quay.io/test/repo:latest",
+            "/tmp/test.db",
+            "application/vnd.sqlite",
+            [
+                "oras",
+                "push",
+                "quay.io/test/repo:latest",
+                "/tmp/test.db:application/vnd.sqlite",
+                "--disable-path-validation",
+            ],
+        ),
+        (
+            "registry.example.com/myapp:v1.0",
+            "/data/config.yaml",
+            "application/vnd.yaml",
+            [
+                "oras",
+                "push",
+                "registry.example.com/myapp:v1.0",
+                "/data/config.yaml:application/vnd.yaml",
+                "--disable-path-validation",
+            ],
+        ),
+        (
+            "docker.io/library/nginx:latest",
+            "/etc/nginx.conf",
+            "application/vnd.config",
+            [
+                "oras",
+                "push",
+                "docker.io/library/nginx:latest",
+                "/etc/nginx.conf:application/vnd.config",
+                "--disable-path-validation",
+            ],
+        ),
+    ],
+)
+@mock.patch('os.path.exists')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_push_oras_artifact_various_types(
+    mock_run_cmd, mock_exists, artifact_ref, local_path, artifact_type, expected_cmd
+):
+    """Test artifact push with various artifact types."""
+    mock_run_cmd.return_value = 'Success'
+    mock_exists.return_value = True
+
+    push_oras_artifact(artifact_ref, local_path, artifact_type)
+
+    mock_run_cmd.assert_called_once_with(
+        expected_cmd, exc_msg=f'Failed to push OCI artifact to {artifact_ref}'
+    )
+
+
+@mock.patch('os.path.exists')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_push_oras_artifact_with_relative_path(mock_run_cmd, mock_exists):
+    """Test artifact push with relative path (should not add --disable-path-validation)."""
+    artifact_ref = 'quay.io/test/repo:latest'
+    local_path = './test.db'  # Relative path
+    artifact_type = 'application/vnd.sqlite'
+    mock_run_cmd.return_value = 'Success'
+    mock_exists.return_value = True
+
+    push_oras_artifact(artifact_ref, local_path, artifact_type)
+
+    mock_run_cmd.assert_called_once_with(
+        ['oras', 'push', artifact_ref, f'{local_path}:{artifact_type}'],
+        exc_msg=f'Failed to push OCI artifact to {artifact_ref}',
+    )
+
+
+@mock.patch('iib.workers.tasks.oras_utils.set_registry_auths')
+@mock.patch('tempfile.mkdtemp')
+@mock.patch("iib.workers.tasks.utils.subprocess")
+def test_get_oras_artifact_with_base_dir_wont_leak_credentials(
+    mock_subprocess, mock_mkdtemp, mock_auth, registry_auths, caplog
+):
+    """Ensure the get_oras_artifact with base_dir won't leak credentials in logs."""
+    # Setting the logging level via caplog.set_level is not sufficient. The flask
+    # related settings from previous tests interfere with this.
+    oras_logger = logging.getLogger('iib.workers.tasks.utils')
+    oras_logger.disabled = False
+    oras_logger.setLevel(logging.DEBUG)
+
+    # Prepare the subprocess mock
+    mock_run_result = mock.MagicMock()
+    mock_run_result.returncode = 0
+    mock_subprocess.run.return_value = mock_run_result
+    default_run_cmd_args = {
+        "universal_newlines": True,
+        "encoding": "utf-8",
+        "stderr": mock_subprocess.PIPE,
+        "stdout": mock_subprocess.PIPE,
+    }
+
+    artifact_ref = 'quay.io/test/repo:latest'
+    base_dir = '/tmp/iib-123'
+    mock_mkdtemp.return_value = '/tmp/iib-123/iib-oras-abc123'
+
+    get_oras_artifact(artifact_ref, base_dir, registry_auths)
+
+    mock_subprocess.run.assert_called_with(
+        ['oras', 'pull', artifact_ref, '-o', '/tmp/iib-123/iib-oras-abc123'],
+        **default_run_cmd_args,
+    )
+
+    # Ensure the credentials aren't leaked
+    all_messages = ' '.join(caplog.messages)
+    assert 'dXNlcjpwYXNz' not in all_messages  # base64 encoded credentials
+    assert 'user:pass' not in all_messages  # decoded credentials


### PR DESCRIPTION
Oras doesn't work well with multiple auths for the same registry in config.json. This commit also enhances set_registry_auths to function such that it is possible to replace entire config.json with provided auth instead of simply appending to the existing file.

Refers to CLOUDDST-28647

Signed-off-by: Yashvardhan Nanavati <yashn@bu.edu>

Assisted-by: Cursor

## Summary by Sourcery

Introduce an ORAS utility module for OCI artifact operations and enhance registry authentication handling.

New Features:
- Add `get_oras_artifact` and `push_oras_artifact` functions to manage OCI artifact pull and push using ORAS with optional registry authentication.

Enhancements:
- Extend `set_registry_auths` context manager with a `use_empty_config` option to replace Docker config entirely with provided credentials instead of merging with a template.

Tests:
- Add unit tests for ORAS operations covering pull and push scenarios including authentication, annotations, failure cases, and credential leak prevention.
- Add a parametrized test for `set_registry_auths` behavior when using an empty configuration.