### PR TITLE
fix(git_utils): get_git_token format adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ The custom configuration options for the Celery workers are listed below:
   `{registry}/iib-build:{request_id}`.
 * `iib_index_configs_gitlab_tokens_map` - A map of index image addresses to GitLab tokens.
   These Gitlab repositories are intended to store image `/configs` directories.
+  Its format should be the full repository URL as keys and `token-name:token-value` as value.
 * `iib_log_level` - the Python log level for `iib.workers` logger. This defaults to `INFO`.
 * `iib_max_recursive_related_bundles` - the maximum number of recursive related bundles IIB will
   recurse through. This is to avoid DOS attacks.

--- a/iib/workers/tasks/git_utils.py
+++ b/iib/workers/tasks/git_utils.py
@@ -185,7 +185,15 @@ def get_git_token(git_repo) -> Tuple[str, str]:
     git_token_map = get_worker_config()['iib_index_configs_gitlab_tokens_map']
     if git_repo not in git_token_map:
         raise IIBError(f"Missing key '{git_repo}' in 'iib_index_configs_gitlab_tokens_map'")
-    return git_token_map[git_repo]
+    str_token_name_value = git_token_map[git_repo]
+    splitted_token = str_token_name_value.split(":")
+    if ":" not in str_token_name_value or '' in splitted_token[:2]:
+        raise IIBError(
+            f"Invalid token format for '{git_repo}' in 'iib_index_configs_gitlab_tokens_map'. "
+            "Expected 'token_name:token_value'."
+        )
+    token_name, token_value = splitted_token[:2]
+    return token_name, token_value
 
 
 def clone_git_repo(


### PR DESCRIPTION
This commit fixes a bug on `get_git_token` as the
`iib_index_configs_gitlab_tokens_map` will always be a `dict[str, str]` from HashiVault, never being able to be a Tuple.

In order to return a Tuple we need to split the token-name from token-value. For that, we're stablishing the standard as a column `:` to separate such values.

Refers to CLOUDDST-29117

## Summary by Sourcery

Standardize the Git token mapping to use colon-separated strings instead of tuples and add validation for the new format

Bug Fixes:
- Raise an error if a token string lacks the expected ':' separator

Enhancements:
- Parse token mappings as "token_name:token_value" strings in get_git_token

Documentation:
- Update README to document the new "token-name:token-value" mapping format

Tests:
- Update unit tests to use the new string format for tokens and add a test for missing token format