### PR TITLE
Fix bug on failed_request_callback

### DIFF
--- a/iib/workers/tasks/general.py
+++ b/iib/workers/tasks/general.py
@@ -36,9 +36,9 @@ def failed_request_callback(
         log.info(f"Request {request_id} is in a final state,ignoring update.")
         _cleanup()
         return
-
-    msg = 'An unknown error occurred. See logs for details'
-    log.error(msg, exc_info=exc)
+    else:
+        msg = 'An unknown error occurred. See logs for details'
+        log.error(msg, exc_info=exc)
 
     _cleanup()
     set_request_state(request_id, 'failed', msg)

--- a/tests/test_workers/test_tasks/test_general.py
+++ b/tests/test_workers/test_tasks/test_general.py
@@ -11,7 +11,10 @@ from iib.workers.tasks import general
     'exc, expected_msg',
     (
         (IIBError('Is it lunch time yet?'), 'Is it lunch time yet?'),
-        (RuntimeError('I cannot run in the rain!'), 'An unknown error occurred'),
+        (
+            RuntimeError('I cannot run in the rain!'),
+            'An unknown error occurred. See logs for details',
+        ),
         (FinalStateOverwriteError("can not overwite final state"), "Already in final state"),
     ),
 )
@@ -19,5 +22,8 @@ from iib.workers.tasks import general
 @mock.patch('iib.workers.tasks.general.set_request_state')
 def test_failed_request_callback(mock_srs, mock_cleanup, exc, expected_msg):
     general.failed_request_callback(None, exc, None, 3)
-    mock_srs(3, expected_msg)
+    if isinstance(exc, FinalStateOverwriteError):
+        mock_srs.assert_not_called()
+    else:
+        mock_srs.assert_called_once_with(3, 'failed', expected_msg)
     mock_cleanup.assert_called_once()


### PR DESCRIPTION
This commit fixes a bug on `failed_request_callback` which were causing the `IIBError` messages to being overwritten with `An unknown error occurred. See logs for details`.

It also fixes the unit-test that wasn't properly constructed and didn't catch this issue.

## Summary by Sourcery

Fix failed_request_callback to preserve exception-specific messages and use the generic error message only for unknown errors, and update its unit test to validate the new behavior

Bug Fixes:
- Prevent failed_request_callback from overwriting specific exception messages with a generic unknown error message
- Ensure FinalStateOverwriteError does not trigger a state update

Tests:
- Correct test_failed_request_callback to use the full default error message and properly assert set_request_state calls
- Add conditional assertion to skip set_request_state for FinalStateOverwriteError