### PR TITLE
Add support for multiple FBC fragments in fbc-operations endpoint

### DIFF
--- a/iib/web/iib_static_types.py
+++ b/iib/web/iib_static_types.py
@@ -133,7 +133,9 @@ class RmRequestPayload(TypedDict):
 class FbcOperationRequestPayload(TypedDict):
     """Datastructure of the request to /builds/fbc-operation API point."""
 
-    fbc_fragment: str
+    fbc_fragment: NotRequired[str]  # For backward compatibility
+    fbc_fragments: NotRequired[List[str]]
+    _used_fbc_fragment: NotRequired[bool]  # Internal flag for backward compatibility
     from_index: str
     binary_image: NotRequired[str]
     build_tags: NotRequired[List[str]]
@@ -221,7 +223,9 @@ class RequestPayload(TypedDict):
     check_related_images: NotRequired[bool]
     deprecation_list: NotRequired[List[str]]
     distribution_scope: NotRequired[str]
-    fbc_fragment: NotRequired[bool]
+    fbc_fragment: NotRequired[str]  # For backward compatibility
+    fbc_fragments: NotRequired[List[str]]
+    _used_fbc_fragment: NotRequired[bool]  # Internal flag for backward compatibility
     force_backport: NotRequired[bool]
     from_bundle_image: NotRequired[str]
     from_index: NotRequired[str]
@@ -444,8 +448,10 @@ class BaseClassRequestResponse(APIPartImageBuildRequestResponse, CommonIndexImag
 class FbcOperationRequestResponse(BaseClassRequestResponse):
     """Datastructure of the response to request from /builds/fbc-operations API point."""
 
-    fbc_fragment: str
+    fbc_fragment: Optional[str]
+    fbc_fragments: List[str]
     fbc_fragment_resolved: Optional[str]
+    fbc_fragments_resolved: List[str]
 
 
 class AddDeprecationsRequestResponse(BaseClassRequestResponse):

--- a/iib/web/migrations/versions/c32bffd4dbea_add_support_for_multiple_fbc_fragments_.py
+++ b/iib/web/migrations/versions/c32bffd4dbea_add_support_for_multiple_fbc_fragments_.py
@@ -1,0 +1,99 @@
+"""Add support for multiple FBC fragments in fbc-operations.
+
+Revision ID: c32bffd4dbea
+Revises: 49d13af4b328
+Create Date: 2025-08-26 22:45:34.247259
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c32bffd4dbea'
+down_revision = '49d13af4b328'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'request_fbc_operations_fragment',
+        sa.Column('request_fbc_operations_id', sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column('image_id', sa.Integer(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ['image_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['request_fbc_operations_id'],
+            ['request_fbc_operations.id'],
+        ),
+        sa.PrimaryKeyConstraint('request_fbc_operations_id', 'image_id'),
+        sa.UniqueConstraint('request_fbc_operations_id', 'image_id'),
+    )
+    with op.batch_alter_table('request_fbc_operations_fragment', schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f('ix_request_fbc_operations_fragment_image_id'), ['image_id'], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f('ix_request_fbc_operations_fragment_request_fbc_operations_id'),
+            ['request_fbc_operations_id'],
+            unique=False,
+        )
+
+    op.create_table(
+        'request_fbc_operations_fragment_resolved',
+        sa.Column('request_fbc_operations_id', sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column('image_id', sa.Integer(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ['image_id'],
+            ['image.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['request_fbc_operations_id'],
+            ['request_fbc_operations.id'],
+        ),
+        sa.PrimaryKeyConstraint('request_fbc_operations_id', 'image_id'),
+        sa.UniqueConstraint('request_fbc_operations_id', 'image_id'),
+    )
+    with op.batch_alter_table('request_fbc_operations_fragment_resolved', schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f('ix_request_fbc_operations_fragment_resolved_image_id'),
+            ['image_id'],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f('ix_request_fbc_operations_fragment_resolved_request_fbc_operations_id'),
+            ['request_fbc_operations_id'],
+            unique=False,
+        )
+
+    with op.batch_alter_table('request_fbc_operations', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('used_fbc_fragment', sa.Boolean(), nullable=True))
+        batch_op.drop_column('fbc_fragment_id')
+
+
+def downgrade():
+    with op.batch_alter_table('request_fbc_operations', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('fbc_fragment_id', sa.INTEGER(), nullable=True))
+        batch_op.create_foreign_key(
+            'request_fbc_operations_fbc_fragment_id_fkey', 'image', ['fbc_fragment_id'], ['id']
+        )
+        batch_op.drop_column('used_fbc_fragment')
+
+    with op.batch_alter_table('request_fbc_operations_fragment_resolved', schema=None) as batch_op:
+        batch_op.drop_index(
+            batch_op.f('ix_request_fbc_operations_fragment_resolved_request_fbc_operations_id')
+        )
+        batch_op.drop_index(batch_op.f('ix_request_fbc_operations_fragment_resolved_image_id'))
+
+    op.drop_table('request_fbc_operations_fragment_resolved')
+    with op.batch_alter_table('request_fbc_operations_fragment', schema=None) as batch_op:
+        batch_op.drop_index(
+            batch_op.f('ix_request_fbc_operations_fragment_request_fbc_operations_id')
+        )
+        batch_op.drop_index(batch_op.f('ix_request_fbc_operations_fragment_image_id'))
+
+    op.drop_table('request_fbc_operations_fragment')

--- a/iib/web/static/api_v1.yaml
+++ b/iib/web/static/api_v1.yaml
@@ -578,9 +578,9 @@ paths:
   /builds/fbc-operations:
     post:
       description: >
-        Submit a request to add/update FBC fragment to an index image
+        Submit a request to add/update FBC fragments to an index image. Supports both single fragment (fbc_fragment) for backward compatibility and multiple fragments (fbc_fragments) for new requests.
       requestBody:
-        description: The request to add FBC fragment
+        description: The request to add FBC fragment(s)
         required: true
         content:
           application/json:
@@ -604,7 +604,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: '"fbc_fragment" should be a non-empty string'
+                    example: 'Either "fbc_fragment" or "fbc_fragments" must be provided'
         '401':
           description: >
             The user is not allowed to create a request with this input
@@ -1579,8 +1579,19 @@ components:
         fbc_fragment:
           type: string
           description: >
-            fbc_fragment is required.
+            FBC fragment to be added to the index image. For backward compatibility, this can be used
+            instead of fbc_fragments. Cannot be used together with fbc_fragments.
           example: 'quay.io/iib-stage/fbc_fragment:4'
+        fbc_fragments:
+          type: array
+          description: >
+            Array of FBC fragments to be added to the index image. This is the preferred format.
+            Cannot be used together with fbc_fragment.
+          items:
+            type: string
+          example:
+            - 'quay.io/iib-stage/fbc_fragment1:4'
+            - 'quay.io/iib-stage/fbc_fragment2:4'
         from_index:
           type: string
           description: >
@@ -1612,7 +1623,7 @@ components:
             type: string
           example: ["v4.5-10-08-2021"]
       required:
-        - bundles
+        - from_index
     FbcResponse:
       allOf:
         - $ref: '#/components/schemas/BaseResponse'
@@ -1670,10 +1681,32 @@ components:
               example: fbc-operations
             fbc_fragment:
               type: string
+              description: >
+                FBC fragment that was added (for backward compatibility). Present when fbc_fragment was used in request.
               example: "quay.io/iib/fbc-fragment:v1.0"
             fbc_fragment_resolved:
               type: string
+              description: >
+                Resolved FBC fragment that was added (for backward compatibility). Present when fbc_fragment was used in request.
               example: "quay.io/iib/fbc-fragment@sha256:7d8e5dddad0275bc903b6ef17840f98441b15b8b999609af2c9579960e52080e"
+            fbc_fragments:
+              type: array
+              description: >
+                Array of FBC fragments that were added. Present when fbc_fragments was used in request.
+              items:
+                type: string
+              example:
+                - "quay.io/iib/fbc-fragment1:v1.0"
+                - "quay.io/iib/fbc-fragment2:v1.0"
+            fbc_fragments_resolved:
+              type: array
+              description: >
+                Array of resolved FBC fragments that were added. Present when fbc_fragments was used in request.
+              items:
+                type: string
+              example:
+                - "quay.io/iib/fbc-fragment1@sha256:7d8e5dddad0275bc903b6ef17840f98441b15b8b999609af2c9579960e52080e"
+                - "quay.io/iib/fbc-fragment2@sha256:abcdef012356789"
     AddDeprecationsRequest:
       type: object
       properties:

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -599,6 +599,10 @@ def _update_index_image_build_state(
     if fbc_fragment_resolved:
         payload['fbc_fragment_resolved'] = fbc_fragment_resolved
 
+    fbc_fragments_resolved = prebuild_info.get('fbc_fragments_resolved')
+    if fbc_fragments_resolved:
+        payload['fbc_fragments_resolved'] = fbc_fragments_resolved
+
     exc_msg = 'Failed setting the resolved images on the request'
     update_request(request_id, payload, exc_msg)
 

--- a/iib/workers/tasks/iib_static_types.py
+++ b/iib/workers/tasks/iib_static_types.py
@@ -50,6 +50,7 @@ class PrebuildInfo(TypedDict):
     target_index_resolved: NotRequired[str]
     target_ocp_version: NotRequired[str]
     fbc_fragment_resolved: NotRequired[str]
+    fbc_fragments_resolved: NotRequired[List[str]]
 
 
 class BundleImage(TypedDict):
@@ -75,6 +76,8 @@ class UpdateRequestPayload(TypedDict, total=False):
     from_index_resolved: NotRequired[str]
     fbc_fragment: NotRequired[str]
     fbc_fragment_resolved: NotRequired[str]
+    fbc_fragments: NotRequired[List[str]]
+    fbc_fragments_resolved: NotRequired[List[str]]
     index_image: NotRequired[str]
     index_image_resolved: NotRequired[str]
     internal_index_image_copy: NotRequired[str]

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -375,21 +375,21 @@ class RequestConfigFBCOperation(RequestConfig):
         arches ``from_index`` is currently built for;
         if ``from_index`` is ``None``, then this is used as the list of arches
         to build the index image for
-    :param str frb_fragment: the fbc_fragment to add in index image
+    :param list fbc_fragments: the list of fbc fragments to add in index image
     """
 
     _attrs: List[str] = RequestConfig._attrs + [
         "overwrite_from_index_token",
         "from_index",
         "add_arches",
-        "fbc_fragment",
+        "fbc_fragments",
     ]
     __slots__ = _attrs
     if TYPE_CHECKING:
         overwrite_from_index_token: str
         from_index: str
         add_arches: Set[str]
-        fbc_fragment: str
+        fbc_fragments: List[str]
 
 
 class RequestConfigAddDeprecations(RequestConfig):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ def minimal_request_fbc_operations(db):
     request = models.RequestFbcOperations(
         batch=batch,
         binary_image=binary_image,
-        fbc_fragment=fbc_fragment_image,
+        fbc_fragments=[fbc_fragment_image],
         from_index=from_index_image,
     )
     db.session.add(request)

--- a/tests/test_workers/test_tasks/test_build_fbc_operations.py
+++ b/tests/test_workers/test_tasks/test_build_fbc_operations.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-
 from iib.workers.tasks import build_fbc_operations
 from iib.workers.tasks.utils import RequestConfigFBCOperation
 
@@ -37,7 +36,7 @@ def test_handle_fbc_operation_request(
     from_index = 'from-index:latest'
     binary_image = 'binary-image:latest'
     binary_image_config = {'prod': {'v4.5': 'some_image'}}
-    fbc_fragment = 'fbc-fragment:latest'
+    fbc_fragments = ['fbc-fragment:latest']
     arches = {'amd64', 's390x'}
     from_index_resolved = 'from-index@sha256:bcdefg'
 
@@ -53,7 +52,7 @@ def test_handle_fbc_operation_request(
 
     build_fbc_operations.handle_fbc_operation_request(
         request_id=request_id,
-        fbc_fragment=fbc_fragment,
+        fbc_fragments=fbc_fragments,
         from_index=from_index,
         binary_image=binary_image,
         binary_image_config=binary_image_config,
@@ -67,14 +66,538 @@ def test_handle_fbc_operation_request(
             add_arches=None,
             binary_image_config=binary_image_config,
             distribution_scope='prod',
-            fbc_fragment='fbc-fragment@sha256:qwerty',
+            fbc_fragments=fbc_fragments,
         ),
     )
     mock_sov.assert_called_once_with(from_index_resolved)
-    mock_oraff.assert_called_once()
+    mock_oraff.assert_called_once_with(
+        request_id,
+        mock.ANY,  # temp_dir
+        from_index_resolved,
+        'binary-image@sha256:abcdef',
+        ['fbc-fragment@sha256:qwerty'],  # Now a list
+        None,  # overwrite_from_index_token
+    )
+    mock_cpml.assert_called_once_with(request_id, {'s390x', 'amd64'}, None)
+    assert mock_srs.call_count == 3  # 3 original calls (no internal calls due to mocking)
+    assert mock_alti.call_count == 2
+    assert mock_bi.call_count == 2
+    assert mock_pi.call_count == 2
+    assert mock_srs.call_args[0][1] == 'complete'
+
+
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_fbc_operations._create_and_push_manifest_list')
+@mock.patch('iib.workers.tasks.build_fbc_operations._push_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._build_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_fbc_operations.opm_registry_add_fbc_fragment')
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations.prepare_request_for_build')
+@mock.patch('iib.workers.tasks.utils.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.set_request_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations._cleanup')
+@mock.patch('iib.workers.tasks.opm_operations.Opm.set_opm_version')
+def test_handle_fbc_operation_request_multiple_fragments(
+    mock_sov,
+    mock_cleanup,
+    mock_srs,
+    mock_gri,
+    mock_ugri,
+    mock_prfb,
+    mock_uiibs,
+    mock_oraff,
+    mock_alti,
+    mock_bi,
+    mock_pi,
+    mock_cpml,
+    mock_uiips,
+):
+    request_id = 10
+    from_index = 'from-index:latest'
+    binary_image = 'binary-image:latest'
+    binary_image_config = {'prod': {'v4.5': 'some_image'}}
+    fbc_fragments = ['fbc-fragment1:latest', 'fbc-fragment2:latest']
+    arches = {'amd64', 's390x'}
+    from_index_resolved = 'from-index@sha256:bcdefg'
+
+    mock_prfb.return_value = {
+        'arches': arches,
+        'binary_image': binary_image,
+        'binary_image_resolved': 'binary-image@sha256:abcdef',
+        'from_index_resolved': from_index_resolved,
+        'ocp_version': 'v4.6',
+        'distribution_scope': "prod",
+    }
+    mock_gri.side_effect = ['fbc-fragment1@sha256:qwerty', 'fbc-fragment2@sha256:asdfgh']
+
+    build_fbc_operations.handle_fbc_operation_request(
+        request_id=request_id,
+        fbc_fragments=fbc_fragments,
+        from_index=from_index,
+        binary_image=binary_image,
+        binary_image_config=binary_image_config,
+    )
+
+    # Verify that opm_registry_add_fbc_fragment was called once with all fragments
+    assert mock_oraff.call_count == 1
+
+    # Verify the call was made with the correct resolved fragments list
+    mock_oraff.assert_called_once_with(
+        request_id,
+        mock.ANY,  # temp_dir
+        from_index_resolved,
+        'binary-image@sha256:abcdef',
+        ['fbc-fragment1@sha256:qwerty', 'fbc-fragment2@sha256:asdfgh'],  # List of fragments
+        None,  # overwrite_from_index_token
+    )
+
+    # Verify final completion message mentions both fragments
+    completion_call = mock_srs.call_args_list[-1]
+    assert '2 FBC fragment(s) were successfully added' in completion_call[0][2]
+
+    mock_sov.assert_called_once_with(from_index_resolved)
+    mock_cpml.assert_called_once_with(request_id, {'s390x', 'amd64'}, None)
+    assert mock_srs.call_count == 3  # 3 original calls (no internal calls due to mocking)
+    assert mock_alti.call_count == 2
+    assert mock_bi.call_count == 2
+    assert mock_pi.call_count == 2
+    assert mock_srs.call_args[0][1] == 'complete'
+
+
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_fbc_operations._create_and_push_manifest_list')
+@mock.patch('iib.workers.tasks.build_fbc_operations._push_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._build_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_fbc_operations.opm_registry_add_fbc_fragment')
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations.prepare_request_for_build')
+@mock.patch('iib.workers.tasks.utils.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.set_request_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations._cleanup')
+@mock.patch('iib.workers.tasks.opm_operations.Opm.set_opm_version')
+def test_handle_fbc_operation_request_empty_fragments(
+    mock_sov,
+    mock_cleanup,
+    mock_srs,
+    mock_gri,
+    mock_ugri,
+    mock_prfb,
+    mock_uiibs,
+    mock_oraff,
+    mock_alti,
+    mock_bi,
+    mock_pi,
+    mock_cpml,
+    mock_uiips,
+):
+    request_id = 10
+    from_index = 'from-index:latest'
+    binary_image = 'binary-image:latest'
+    binary_image_config = {'prod': {'v4.5': 'some_image'}}
+    fbc_fragments = []
+    arches = {'amd64', 's390x'}
+    from_index_resolved = 'from-index@sha256:bcdefg'
+
+    mock_prfb.return_value = {
+        'arches': arches,
+        'binary_image': binary_image,
+        'binary_image_resolved': 'binary-image@sha256:abcdef',
+        'from_index_resolved': from_index_resolved,
+        'ocp_version': 'v4.6',
+        'distribution_scope': "prod",
+    }
+
+    build_fbc_operations.handle_fbc_operation_request(
+        request_id=request_id,
+        fbc_fragments=fbc_fragments,
+        from_index=from_index,
+        binary_image=binary_image,
+        binary_image_config=binary_image_config,
+    )
+
+    # Verify that opm_registry_add_fbc_fragment was called with empty list
+    mock_oraff.assert_called_once_with(
+        request_id,
+        mock.ANY,  # temp_dir
+        from_index_resolved,
+        'binary-image@sha256:abcdef',
+        [],  # Empty list of fragments
+        None,  # overwrite_from_index_token
+    )
+
+    # Verify completion message mentions 0 fragments
+    completion_call = mock_srs.call_args_list[-1]
+    assert '0 FBC fragment(s) were successfully added' in completion_call[0][2]
+
+    mock_sov.assert_called_once_with(from_index_resolved)
     mock_cpml.assert_called_once_with(request_id, {'s390x', 'amd64'}, None)
     assert mock_srs.call_count == 3
     assert mock_alti.call_count == 2
     assert mock_bi.call_count == 2
     assert mock_pi.call_count == 2
     assert mock_srs.call_args[0][1] == 'complete'
+
+
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_fbc_operations._create_and_push_manifest_list')
+@mock.patch('iib.workers.tasks.build_fbc_operations._push_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._build_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_fbc_operations.opm_registry_add_fbc_fragment')
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations.prepare_request_for_build')
+@mock.patch('iib.workers.tasks.utils.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.set_request_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations._cleanup')
+@mock.patch('iib.workers.tasks.opm_operations.Opm.set_opm_version')
+def test_handle_fbc_operation_request_with_overwrite_token(
+    mock_sov,
+    mock_cleanup,
+    mock_srs,
+    mock_gri,
+    mock_ugri,
+    mock_prfb,
+    mock_uiibs,
+    mock_oraff,
+    mock_alti,
+    mock_bi,
+    mock_pi,
+    mock_cpml,
+    mock_uiips,
+):
+    """Test FBC operation with overwrite_from_index_token."""
+    request_id = 10
+    from_index = 'from-index:latest'
+    binary_image = 'binary-image:latest'
+    binary_image_config = {'prod': {'v4.5': 'some_image'}}
+    fbc_fragments = ['fbc-fragment1:latest', 'fbc-fragment2:latest']
+    overwrite_from_index_token = 'user:password'
+    arches = {'amd64', 's390x'}
+    from_index_resolved = 'from-index@sha256:bcdefg'
+
+    mock_prfb.return_value = {
+        'arches': arches,
+        'binary_image': binary_image,
+        'binary_image_resolved': 'binary-image@sha256:abcdef',
+        'from_index_resolved': from_index_resolved,
+        'ocp_version': 'v4.6',
+        'distribution_scope': "prod",
+    }
+    mock_gri.side_effect = ['fbc-fragment1@sha256:qwerty', 'fbc-fragment2@sha256:asdfgh']
+
+    build_fbc_operations.handle_fbc_operation_request(
+        request_id=request_id,
+        fbc_fragments=fbc_fragments,
+        from_index=from_index,
+        binary_image=binary_image,
+        binary_image_config=binary_image_config,
+        overwrite_from_index_token=overwrite_from_index_token,
+    )
+
+    # Verify that opm_registry_add_fbc_fragment was called once with all fragments and token
+    assert mock_oraff.call_count == 1
+
+    # Verify the call was made with the correct resolved fragments list and token
+    mock_oraff.assert_called_once_with(
+        request_id,
+        mock.ANY,  # temp_dir
+        from_index_resolved,
+        'binary-image@sha256:abcdef',
+        ['fbc-fragment1@sha256:qwerty', 'fbc-fragment2@sha256:asdfgh'],  # List of fragments
+        overwrite_from_index_token,
+    )
+
+    # Verify config was called with token
+    mock_prfb.assert_called_once_with(
+        request_id,
+        RequestConfigFBCOperation(
+            _binary_image=binary_image,
+            from_index=from_index,
+            overwrite_from_index_token=overwrite_from_index_token,
+            add_arches=None,
+            binary_image_config=binary_image_config,
+            distribution_scope='prod',
+            fbc_fragments=fbc_fragments,
+        ),
+    )
+
+
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_fbc_operations._create_and_push_manifest_list')
+@mock.patch('iib.workers.tasks.build_fbc_operations._push_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._build_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_fbc_operations.opm_registry_add_fbc_fragment')
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations.prepare_request_for_build')
+@mock.patch('iib.workers.tasks.utils.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.set_request_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations._cleanup')
+@mock.patch('iib.workers.tasks.opm_operations.Opm.set_opm_version')
+def test_handle_fbc_operation_request_with_build_tags(
+    mock_sov,
+    mock_cleanup,
+    mock_srs,
+    mock_gri,
+    mock_ugri,
+    mock_prfb,
+    mock_uiibs,
+    mock_oraff,
+    mock_alti,
+    mock_bi,
+    mock_pi,
+    mock_cpml,
+    mock_uiips,
+):
+    """Test FBC operation with build tags."""
+    request_id = 10
+    from_index = 'from-index:latest'
+    binary_image = 'binary-image:latest'
+    binary_image_config = {'prod': {'v4.5': 'some_image'}}
+    fbc_fragments = ['fbc-fragment:latest']
+    build_tags = {'tag1', 'tag2'}
+    arches = {'amd64', 's390x'}
+    from_index_resolved = 'from-index@sha256:bcdefg'
+
+    mock_prfb.return_value = {
+        'arches': arches,
+        'binary_image': binary_image,
+        'binary_image_resolved': 'binary-image@sha256:abcdef',
+        'from_index_resolved': from_index_resolved,
+        'ocp_version': 'v4.6',
+        'distribution_scope': "prod",
+    }
+    mock_gri.return_value = 'fbc-fragment@sha256:qwerty'
+    mock_cpml.return_value = 'output-image:latest'
+
+    build_fbc_operations.handle_fbc_operation_request(
+        request_id=request_id,
+        fbc_fragments=fbc_fragments,
+        from_index=from_index,
+        binary_image=binary_image,
+        binary_image_config=binary_image_config,
+        build_tags=build_tags,
+    )
+
+    # Verify create_and_push_manifest_list was called with build tags
+    mock_cpml.assert_called_once_with(request_id, {'s390x', 'amd64'}, build_tags)
+
+
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_fbc_operations._create_and_push_manifest_list')
+@mock.patch('iib.workers.tasks.build_fbc_operations._push_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._build_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_fbc_operations.opm_registry_add_fbc_fragment')
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations.prepare_request_for_build')
+@mock.patch('iib.workers.tasks.utils.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.set_request_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations._cleanup')
+@mock.patch('iib.workers.tasks.opm_operations.Opm.set_opm_version')
+def test_handle_fbc_operation_request_with_add_arches(
+    mock_sov,
+    mock_cleanup,
+    mock_srs,
+    mock_gri,
+    mock_ugri,
+    mock_prfb,
+    mock_uiibs,
+    mock_oraff,
+    mock_alti,
+    mock_bi,
+    mock_pi,
+    mock_cpml,
+    mock_uiips,
+):
+    """Test FBC operation with add_arches."""
+    request_id = 10
+    from_index = 'from-index:latest'
+    binary_image = 'binary-image:latest'
+    binary_image_config = {'prod': {'v4.5': 'some_image'}}
+    fbc_fragments = ['fbc-fragment:latest']
+    add_arches = {'ppc64le', 'arm64'}
+    arches = {'amd64', 's390x', 'ppc64le', 'arm64'}
+    from_index_resolved = 'from-index@sha256:bcdefg'
+
+    mock_prfb.return_value = {
+        'arches': arches,
+        'binary_image': binary_image,
+        'binary_image_resolved': 'binary-image@sha256:abcdef',
+        'from_index_resolved': from_index_resolved,
+        'ocp_version': 'v4.6',
+        'distribution_scope': "prod",
+    }
+    mock_gri.return_value = 'fbc-fragment@sha256:qwerty'
+
+    build_fbc_operations.handle_fbc_operation_request(
+        request_id=request_id,
+        fbc_fragments=fbc_fragments,
+        from_index=from_index,
+        binary_image=binary_image,
+        binary_image_config=binary_image_config,
+        add_arches=add_arches,
+    )
+
+    # Verify config was called with add_arches
+    mock_prfb.assert_called_once_with(
+        request_id,
+        RequestConfigFBCOperation(
+            _binary_image=binary_image,
+            from_index=from_index,
+            overwrite_from_index_token=None,
+            add_arches=add_arches,
+            binary_image_config=binary_image_config,
+            distribution_scope='prod',
+            fbc_fragments=fbc_fragments,
+        ),
+    )
+
+
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_fbc_operations._create_and_push_manifest_list')
+@mock.patch('iib.workers.tasks.build_fbc_operations._push_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._build_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_fbc_operations.opm_registry_add_fbc_fragment')
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations.prepare_request_for_build')
+@mock.patch('iib.workers.tasks.utils.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.set_request_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations._cleanup')
+@mock.patch('iib.workers.tasks.opm_operations.Opm.set_opm_version')
+def test_handle_fbc_operation_request_with_distribution_scope(
+    mock_sov,
+    mock_cleanup,
+    mock_srs,
+    mock_gri,
+    mock_ugri,
+    mock_prfb,
+    mock_uiibs,
+    mock_oraff,
+    mock_alti,
+    mock_bi,
+    mock_pi,
+    mock_cpml,
+    mock_uiips,
+):
+    """Test FBC operation with distribution_scope."""
+    request_id = 10
+    from_index = 'from-index:latest'
+    binary_image = 'binary-image:latest'
+    binary_image_config = {'prod': {'v4.5': 'some_image'}}
+    fbc_fragments = ['fbc-fragment:latest']
+    distribution_scope = 'stage'
+    arches = {'amd64', 's390x'}
+    from_index_resolved = 'from-index@sha256:bcdefg'
+
+    mock_prfb.return_value = {
+        'arches': arches,
+        'binary_image': binary_image,
+        'binary_image_resolved': 'binary-image@sha256:abcdef',
+        'from_index_resolved': from_index_resolved,
+        'ocp_version': 'v4.6',
+        'distribution_scope': distribution_scope,
+    }
+    mock_gri.return_value = 'fbc-fragment@sha256:qwerty'
+
+    build_fbc_operations.handle_fbc_operation_request(
+        request_id=request_id,
+        fbc_fragments=fbc_fragments,
+        from_index=from_index,
+        binary_image=binary_image,
+        binary_image_config=binary_image_config,
+        distribution_scope=distribution_scope,
+    )
+
+    # Verify config was called with distribution_scope
+    mock_prfb.assert_called_once_with(
+        request_id,
+        RequestConfigFBCOperation(
+            _binary_image=binary_image,
+            from_index=from_index,
+            overwrite_from_index_token=None,
+            add_arches=None,
+            binary_image_config=binary_image_config,
+            distribution_scope=distribution_scope,
+            fbc_fragments=fbc_fragments,
+        ),
+    )
+
+
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_fbc_operations._create_and_push_manifest_list')
+@mock.patch('iib.workers.tasks.build_fbc_operations._push_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._build_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_fbc_operations.opm_registry_add_fbc_fragment')
+@mock.patch('iib.workers.tasks.build_fbc_operations._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations.prepare_request_for_build')
+@mock.patch('iib.workers.tasks.utils.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.get_resolved_image')
+@mock.patch('iib.workers.tasks.build_fbc_operations.set_request_state')
+@mock.patch('iib.workers.tasks.build_fbc_operations._cleanup')
+@mock.patch('iib.workers.tasks.opm_operations.Opm.set_opm_version')
+def test_handle_fbc_operation_request_with_overwrite_from_index(
+    mock_sov,
+    mock_cleanup,
+    mock_srs,
+    mock_gri,
+    mock_ugri,
+    mock_prfb,
+    mock_uiibs,
+    mock_oraff,
+    mock_alti,
+    mock_bi,
+    mock_pi,
+    mock_cpml,
+    mock_uiips,
+):
+    """Test FBC operation with overwrite_from_index flag."""
+    request_id = 10
+    from_index = 'from-index:latest'
+    binary_image = 'binary-image:latest'
+    binary_image_config = {'prod': {'v4.5': 'some_image'}}
+    fbc_fragments = ['fbc-fragment:latest']
+    overwrite_from_index = True
+    arches = {'amd64', 's390x'}
+    from_index_resolved = 'from-index@sha256:bcdefg'
+
+    mock_prfb.return_value = {
+        'arches': arches,
+        'binary_image': binary_image,
+        'binary_image_resolved': 'binary-image@sha256:abcdef',
+        'from_index_resolved': from_index_resolved,
+        'ocp_version': 'v4.6',
+        'distribution_scope': "prod",
+    }
+    mock_gri.return_value = 'fbc-fragment@sha256:qwerty'
+
+    build_fbc_operations.handle_fbc_operation_request(
+        request_id=request_id,
+        fbc_fragments=fbc_fragments,
+        from_index=from_index,
+        binary_image=binary_image,
+        binary_image_config=binary_image_config,
+        overwrite_from_index=overwrite_from_index,
+    )
+
+    # Verify _update_index_image_pull_spec was called with overwrite_from_index
+    mock_uiips.assert_called_once_with(
+        output_pull_spec=mock.ANY,
+        request_id=request_id,
+        arches=arches,
+        from_index=from_index,
+        overwrite_from_index=overwrite_from_index,
+        overwrite_from_index_token=None,
+        resolved_prebuild_from_index=from_index_resolved,
+        add_or_rm=True,
+    )

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -893,7 +893,7 @@ def test_opm_registry_add_fbc_fragment(
     assert os.path.exists(deprecation_file)
 
     opm_operations.opm_registry_add_fbc_fragment(
-        10, tmpdir, from_index, binary_image, fbc_fragment, None
+        10, tmpdir, from_index, binary_image, [fbc_fragment], None
     )
 
     mock_eff.assert_called_with(temp_dir=tmpdir, fbc_fragment=fbc_fragment)


### PR DESCRIPTION
Signed-off-by: Yashvardhan Nanavati <yashn@bu.edu>

Assisted-by: Cursor

## Summary by Sourcery

Enable batch processing of multiple FBC fragments throughout the fbc-operations API, model, and worker logic while preserving backward compatibility for single-fragment requests.

New Features:
- Support adding multiple FBC fragments in a single fbc-operations request

Enhancements:
- Maintain backward compatibility by converting single fbc_fragment inputs to the new fbc_fragments list and populating legacy response fields

Tests:
- Extend tests for handling multiple, empty, and backward-compatible fragment lists, overwrite tokens, build tags, added arches, and distribution scope