### PR TITLE
git_utils: Fix behavior for RM request

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -256,6 +256,7 @@ def _update_index_image_pull_spec(
     add_or_rm: bool = False,
     is_image_fbc: bool = False,
     index_repo_map: Optional[Dict[str, str]] = None,
+    rm_operators: Optional[List[str]] = None,
 ) -> None:
     """
     Update the request with the modified index image.
@@ -277,6 +278,8 @@ def _update_index_image_pull_spec(
     :param is_image_fbc: Set to True if the index image is an FBC (File-Based Catalog) image.
     :param dict(str) index_repo_map: The mapping between index images and git repositories. Only
         required if ``is_image_fbc`` is ``True``.
+    :param list(str) rm_operators: List of operators to remove from the index image. Only
+        required if ``add_or_rm`` is ``True`` and an RM operation is requested.
     :raises IIBError: if the manifest list couldn't be created and pushed
     """
     conf = get_worker_config()
@@ -291,6 +294,7 @@ def _update_index_image_pull_spec(
             overwrite_from_index_token=overwrite_from_index_token,
             is_image_fbc=is_image_fbc,
             index_repo_map=index_repo_map or {},
+            rm_operators=rm_operators,
         )
         index_image = from_index
     elif conf['iib_index_image_output_registry']:
@@ -466,6 +470,7 @@ def _overwrite_from_index(
     overwrite_from_index_token: Optional[str] = None,
     is_image_fbc: bool = False,
     index_repo_map: Optional[Dict[str, str]] = None,
+    rm_operators: Optional[List[str]] = None,
 ) -> None:
     """
     Overwrite the ``from_index`` image.
@@ -479,6 +484,8 @@ def _overwrite_from_index(
         ``from_index`` image. If this is not set, IIB's configured credentials will be used.
     :param dict(str) index_repo_map: The mapping between index images and git repositories. Only
         required if ``is_image_fbc`` is ``True``.
+    :param list(str) rm_operators: List of operators to remove from the index image. Only
+        required if ``add_or_rm`` is ``True`` and an RM operation is requested.
     :raises IIBError: if one of the skopeo commands fails or if the index image has changed
         since IIB build started.
     """
@@ -531,6 +538,7 @@ def _overwrite_from_index(
                     from_index=from_index,
                     src_configs_path=src_configs,
                     index_repo_map=index_repo_map or {},
+                    rm_operators=rm_operators,
                 )
 
         # Revert the Git commit if the skopeo_copy fails
@@ -1234,6 +1242,7 @@ def handle_rm_request(
         add_or_rm=True,
         is_image_fbc=image_is_fbc,
         index_repo_map=index_to_gitlab_push_map or {},
+        rm_operators=operators,
     )
     _cleanup()
     set_request_state(


### PR DESCRIPTION
The `RM` request should cause the `git_utils` to remove the operators from the `git` repository and commit the changes, which was something that didn't happen in the previous versions.

This commit changes the `git_utils` module as by adding a new parameter to `push_configs_to_git` named `rm_operators` which should only receive a list of operators when a `RM` operation is handled.

It also updates the `build` module to send the `RM` operators list to `push_configs_to_git` by passing it over to the necessary functions.

Finally, it adds new unit-tests and improve some existing ones.

Signed-off-by: Jonathan Gangi <jgangi@redhat.com>

Assisted-by: Cursor/Gemini

## Summary by Sourcery

Add support for handling RM requests by introducing a new rm_operators parameter to push_configs_to_git, implementing removal logic for operators during Git updates, and propagating this parameter through the build workflow. Update and extend unit tests to cover removal scenarios and introduce a RegexMatcher helper for verifying directory deletions.

New Features:
- Add rm_operators parameter to push_configs_to_git to enable operator removal on RM requests
- Propagate rm_operators through build tasks (_update_index_image_pull_spec, _overwrite_from_index, handle_rm_request) to push_configs_to_git

Enhancements:
- Implement logic in git_utils to remove specified operator directories when rm_operators is provided
- Introduce RegexMatcher utility in tests for regex-based call assertions

Tests:
- Add comprehensive unit tests for push_configs_to_git removal scenarios (partial, full, none, and empty repo)
- Update existing tests to include rm_operators parameter and verify commit_and_push behavior