### PR TITLE
Fix: Do not drop old columns for fbc-operations migration

### DIFF
--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -745,7 +745,6 @@ def patch_request(request_id: int) -> Tuple[flask.Response, int]:
         'from_index_resolved',
         'fbc_fragment',
         'fbc_fragment_resolved',
-        'fbc_fragments_resolved',
         'index_image',
         'index_image_resolved',
         'internal_index_image_copy',
@@ -1328,6 +1327,7 @@ def fbc_operations() -> Tuple[flask.Response, int]:
         payload.get('add_arches'),
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
         flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
+        request._used_fbc_fragment,  # Pass the legacy flag to the worker
     ]
     safe_args = _get_safe_args(args, payload)
     error_callback = failed_request_callback.s(request.id)

--- a/iib/web/migrations/versions/691c5d6465a0_add_support_for_multiple_fbc_fragments_.py
+++ b/iib/web/migrations/versions/691c5d6465a0_add_support_for_multiple_fbc_fragments_.py
@@ -1,8 +1,8 @@
 """Add support for multiple FBC fragments in fbc-operations.
 
-Revision ID: c32bffd4dbea
+Revision ID: 691c5d6465a0
 Revises: 49d13af4b328
-Create Date: 2025-08-26 22:45:34.247259
+Create Date: 2025-09-03 01:22:46.421750
 
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'c32bffd4dbea'
+revision = '691c5d6465a0'
 down_revision = '49d13af4b328'
 branch_labels = None
 depends_on = None
@@ -72,15 +72,10 @@ def upgrade():
 
     with op.batch_alter_table('request_fbc_operations', schema=None) as batch_op:
         batch_op.add_column(sa.Column('used_fbc_fragment', sa.Boolean(), nullable=True))
-        batch_op.drop_column('fbc_fragment_id')
 
 
 def downgrade():
     with op.batch_alter_table('request_fbc_operations', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('fbc_fragment_id', sa.INTEGER(), nullable=True))
-        batch_op.create_foreign_key(
-            'request_fbc_operations_fbc_fragment_id_fkey', 'image', ['fbc_fragment_id'], ['id']
-        )
         batch_op.drop_column('used_fbc_fragment')
 
     with op.batch_alter_table('request_fbc_operations_fragment_resolved', schema=None) as batch_op:

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -603,13 +603,15 @@ def _update_index_image_build_state(
     if target_index_resolved:
         payload['target_index_resolved'] = target_index_resolved
 
-    fbc_fragment_resolved = prebuild_info.get('fbc_fragment_resolved')
-    if fbc_fragment_resolved:
-        payload['fbc_fragment_resolved'] = fbc_fragment_resolved
-
     fbc_fragments_resolved = prebuild_info.get('fbc_fragments_resolved')
     if fbc_fragments_resolved:
         payload['fbc_fragments_resolved'] = fbc_fragments_resolved
+
+    # Handle old single fragment field for backward compatibility
+    # Only update if the worker actually populated this field
+    fbc_fragment_resolved = prebuild_info.get('fbc_fragment_resolved')
+    if fbc_fragment_resolved:
+        payload['fbc_fragment_resolved'] = fbc_fragment_resolved
 
     exc_msg = 'Failed setting the resolved images on the request'
     update_request(request_id, payload, exc_msg)


### PR DESCRIPTION
In order to avoid losing legacy data, we need to support both the old db structure and the new db structure. This commit fixes the issue.

Signed-off-by: Yashvardhan Nanavati <yashn@bu.edu>

Assisted-by: Cursor

## Summary by Sourcery

Preserve legacy single-fragment support in fbc-operations by retaining old columns and model relationships, adjusting serialization, migrations, API, and worker code to honor a used_fbc_fragment flag alongside the new multiple-fragments support.

Enhancements:
- Retain old fbc_fragment and fbc_fragment_resolved columns and relationships alongside new fbc_fragments arrays for backward compatibility
- Update from_json and to_json to populate legacy single-fragment fields from new fragments based on the used_fbc_fragment flag
- Propagate used_fbc_fragment flag from the API through worker tasks to control when legacy fields are populated
- Adjust Alembic migration to keep the fbc_fragment_id column and bump the revision ID
- Include legacy fragment relationships in query options and conditionally set fbc_fragment_resolved in build tasks