### PR TITLE
fix: validation for fbc_fragments_resolved

### DIFF
--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -681,7 +681,7 @@ def patch_request(request_id: int) -> Tuple[flask.Response, int]:
             for v in value.values():
                 if not isinstance(v, list) or any(not isinstance(s, str) for s in v):
                     raise ValidationError(exc_msg)
-        elif key == 'recursive_related_bundles':
+        elif key == 'recursive_related_bundles' or key == 'fbc_fragments_resolved':
             if not isinstance(value, list):
                 exc_msg = f'The value for "{key}" must be a list of non-empty strings'
                 raise ValidationError(exc_msg)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Treat `fbc_fragments_resolved` the same as `recursive_related_bundles` by enforcing list-of-strings validation