### PR TITLE
Fix: Use unique sub-dir for extracting each FBC fragment

### DIFF
--- a/iib/workers/tasks/build_fbc_operations.py
+++ b/iib/workers/tasks/build_fbc_operations.py
@@ -150,6 +150,6 @@ def handle_fbc_operation_request(
     set_request_state(
         request_id,
         'complete',
-        f"The {len(resolved_fbc_fragments)} FBC fragment(s) were successfully added"
+        f"The {len(resolved_fbc_fragments)} FBC fragment(s) were successfully added "
         "in the index image",
     )

--- a/iib/workers/tasks/fbc_utils.py
+++ b/iib/workers/tasks/fbc_utils.py
@@ -102,22 +102,27 @@ def merge_catalogs_dirs(src_config: str, dest_config: str):
     opm_validate(conf_dir)
 
 
-def extract_fbc_fragment(temp_dir: str, fbc_fragment: str) -> Tuple[str, List[str]]:
+def extract_fbc_fragment(
+    temp_dir: str, fbc_fragment: str, fragment_index: int = 0
+) -> Tuple[str, List[str]]:
     """
     Extract operator packages from the fbc_fragment image.
 
     :param str temp_dir: base temp directory for IIB request.
     :param str fbc_fragment: pull specification of fbc_fragment in the IIB request.
+    :param int fragment_index: index of the fragment to create unique paths and
+        prevent cross-contamination.
     :return: fbc_fragment path, fbc_operator_packages.
     :rtype: tuple
     """
     from iib.workers.tasks.build import _copy_files_from_image
 
     log.info("Extracting the fbc_fragment's catalog from  %s", fbc_fragment)
-    # store the fbc_fragment at /tmp/iib-**/fbc-fragment
+    # store the fbc_fragment at /tmp/iib-**/fbc-fragment-{index} to prevent
+    # cross-contamination
     conf = get_worker_config()
-    fbc_fragment_path = os.path.join(temp_dir, conf['temp_fbc_fragment_path'])
-    # Copy fbc_fragment's catalog to /tmp/iib-**/fbc-fragment
+    fbc_fragment_path = os.path.join(temp_dir, f"{conf['temp_fbc_fragment_path']}-{fragment_index}")
+    # Copy fbc_fragment's catalog to /tmp/iib-**/fbc-fragment-{index}
     _copy_files_from_image(fbc_fragment, conf['fbc_fragment_catalog_path'], fbc_fragment_path)
 
     log.info("fbc_fragment extracted at %s", fbc_fragment_path)

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -1020,10 +1020,10 @@ def opm_registry_add_fbc_fragment(
     fragment_data = []
     all_fragment_operators = []
 
-    for fbc_fragment in fbc_fragments:
+    for i, fbc_fragment in enumerate(fbc_fragments):
         # fragment path will look like /tmp/iib-**/fbc-fragment-{index}
         fragment_path, fragment_operators = extract_fbc_fragment(
-            temp_dir=temp_dir, fbc_fragment=fbc_fragment
+            temp_dir=temp_dir, fbc_fragment=fbc_fragment, fragment_index=i
         )
         fragment_data.append((fragment_path, fragment_operators))
         all_fragment_operators.extend(fragment_operators)
@@ -1066,7 +1066,8 @@ def opm_registry_add_fbc_fragment(
         set_request_state(
             request_id,
             'in_progress',
-            f'Adding fbc fragment {i + 1}/{len(fbc_fragments)} to from_index',
+            f'Adding package(s) {fragment_operators} from fbc fragment '
+            f'{i + 1}/{len(fbc_fragments)} to from_index',
         )
 
         for fragment_operator in fragment_operators:

--- a/tests/test_workers/test_tasks/test_opm_operations.py
+++ b/tests/test_workers/test_tasks/test_opm_operations.py
@@ -896,7 +896,7 @@ def test_opm_registry_add_fbc_fragment(
         10, tmpdir, from_index, binary_image, [fbc_fragment], None
     )
 
-    mock_eff.assert_called_with(temp_dir=tmpdir, fbc_fragment=fbc_fragment)
+    mock_eff.assert_called_with(temp_dir=tmpdir, fbc_fragment=fbc_fragment, fragment_index=0)
     mock_voe.assert_called_with(
         from_index=from_index,
         base_dir=tmpdir,


### PR DESCRIPTION
IIB used a config value to name the sub-directory when extracting the FBC fragment. This worked fine until we allowed one fragment per request. With the support for multiple fragments data gets overwritten causing unexpected behavior. This commit fixes that behavior

Signed-off-by: Yashvardhan Nanavati <yashn@bu.edu>

Assisted-by: Cursor

## Summary by Sourcery

Use unique subdirectories for each FBC fragment extraction by introducing a fragment_index parameter, update task implementation and tests to support multiple fragments without cross-contamination, and refine related progress messages

Bug Fixes:
- Prevent data overwriting when processing multiple FBC fragments by extracting each into a unique subdirectory

Enhancements:
- Add a fragment_index parameter to extract_fbc_fragment to generate distinct extraction paths per fragment
- Improve progress messages to include the specific package names being added from each fragment
- Add a trailing space in the final completion message for consistency

Tests:
- Update test_extract_fbc_fragment and opm_operations tests to expect the -0 suffix by default and verify fragment_index usage