### PR TITLE
modify _opm_registry_add calls so opm does not hit error "reached max number of arguments"

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -46,6 +46,7 @@ class Config(object):
     iib_index_configs_gitlab_tokens_map: Optional[Dict[str, Dict[str, str]]] = None
     iib_log_level: str = 'INFO'
     iib_deprecate_bundles_limit = 200
+    iib_max_number_of_bundles_as_cmd_argument = 500
     iib_max_recursive_related_bundles = 15
     # list of index images to which we can add bundles without "com.redhat.openshift.versions" label
     iib_no_ocp_label_allow_list: List[str] = []

--- a/iib/workers/tasks/opm_operations.py
+++ b/iib/workers/tasks/opm_operations.py
@@ -823,6 +823,8 @@ def opm_registry_add_fbc(
         The format of the token must be in the format "user:password".
     :param str container_tool: the container tool to be used to operate on the index image
     """
+    conf = get_worker_config()
+
     index_db_file = _get_or_create_temp_index_db_file(
         base_dir=base_dir,
         from_index=from_index,
@@ -830,14 +832,15 @@ def opm_registry_add_fbc(
         ignore_existing=True,
     )
 
-    _opm_registry_add(
-        base_dir=base_dir,
-        index_db=index_db_file,
-        bundles=bundles,
-        overwrite_csv=overwrite_csv,
-        container_tool=container_tool,
-        graph_update_mode=graph_update_mode,
-    )
+    for i in range(0, len(bundles), conf.iib_max_number_of_bundles_as_cmd_argument):
+        _opm_registry_add(
+            base_dir=base_dir,
+            index_db=index_db_file,
+            bundles=bundles[i : i + conf.iib_max_number_of_bundles_as_cmd_argument],
+            overwrite_csv=overwrite_csv,
+            container_tool=container_tool,
+            graph_update_mode=graph_update_mode,
+        )
 
     fbc_dir, _ = opm_migrate(index_db=index_db_file, base_dir=base_dir)
     # we should keep generating Dockerfile here


### PR DESCRIPTION
These modification changes the behavior the way _opm_registry_add function is being called inside opm_registry_add_fbc , by calling _opm_registry_add multiple times with chunks of bundles it prevents opm command execution error which happens when a large number of bundles is passed as arguments. 

@chandwanitulsi @yashvardhannanavati @xDaile @JAVGan @lipoja  PTAL

## Summary by Sourcery

Prevent opm command execution errors by limiting the number of bundle arguments per call and processing bundles in configurable chunks

Enhancements:
- Introduce iib_max_number_of_bundles_as_cmd_argument configuration parameter
- Refactor opm_registry_add_fbc to invoke _opm_registry_add in multiple chunked calls based on the new configuration

Tests:
- Update test_opm_registry_add_fbc to patch temp DB creation and assert multiple chunked _opm_registry_add invocations