### PR TITLE
Adding helper functions for index.db caching

### DIFF
--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -503,6 +503,27 @@ def _get_container_image_name(pull_spec: str) -> str:
         return pull_spec.rsplit(':', 1)[0]
 
 
+def get_image_digest(pull_spec: str) -> str:
+    """
+    Get the digest of the image defined by pull_spec.
+
+    :param str pull_spec: the pull specification of the container image
+    :return: the digest of the image
+    :rtype: str
+    """
+    skopeo_output = skopeo_inspect(f'docker://{pull_spec}', '--raw', return_json=False)
+    if json.loads(skopeo_output).get('schemaVersion') == 2:
+        raw_digest = hashlib.sha256(skopeo_output.encode('utf-8')).hexdigest()
+        return f'sha256:{raw_digest}'
+
+    # Schema 1 is not a stable format. The contents of the manifest may change slightly
+    # between requests causing a different digest to be computed. Instead, let's leverage
+    # skopeo's own logic for determining the digest in this case. In the future, we
+    # may want to use skopeo in all cases, but this will have significant performance
+    # issues until https://github.com/containers/skopeo/issues/785
+    return skopeo_inspect(f'docker://{pull_spec}')['Digest']
+
+
 def get_resolved_image(pull_spec: str) -> str:
     """
     Get the pull specification of the container image using its digest.
@@ -513,17 +534,7 @@ def get_resolved_image(pull_spec: str) -> str:
     """
     log.debug('Resolving %s', pull_spec)
     name = _get_container_image_name(pull_spec)
-    skopeo_output = skopeo_inspect(f'docker://{pull_spec}', '--raw', return_json=False)
-    if json.loads(skopeo_output).get('schemaVersion') == 2:
-        raw_digest = hashlib.sha256(skopeo_output.encode('utf-8')).hexdigest()
-        digest = f'sha256:{raw_digest}'
-    else:
-        # Schema 1 is not a stable format. The contents of the manifest may change slightly
-        # between requests causing a different digest to be computed. Instead, let's leverage
-        # skopeo's own logic for determining the digest in this case. In the future, we
-        # may want to use skopeo in all cases, but this will have significant performance
-        # issues until https://github.com/containers/skopeo/issues/785
-        digest = skopeo_inspect(f'docker://{pull_spec}')['Digest']
+    digest = get_image_digest(pull_spec)
     pull_spec_resolved = f'{name}@{digest}'
     log.debug('%s resolved to %s', pull_spec, pull_spec_resolved)
     return pull_spec_resolved


### PR DESCRIPTION
[CLOUDDST-28870]

## Summary by Sourcery

Introduce utility functions for computing container image digests and managing the OpenShift `index-db-cache` ImageStream cache.

New Features:
- Add get_image_digest helper in workers.tasks.utils to compute image digests for both schema v1 and v2 manifests.
- Add get_image_stream_digest in workers.tasks.oras_utils to retrieve ImageStream digests from OpenShift.
- Add verify_indexdb_cache_sync to compare remote registry and ImageStream digests and report sync status.
- Add refresh_indexdb_cache to import images into the `index-db-cache` ImageStream and force cache synchronization.

Enhancements:
- Refactor get_resolved_image to delegate digest retrieval to the new get_image_digest function.

Tests:
- Add unit tests for get_image_digest covering schema v2, schema v1, and invalid JSON scenarios.
- Add tests for get_image_stream_digest, verify_indexdb_cache_sync, and refresh_indexdb_cache success and failure cases.