### PR TITLE
Release v9.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 9.4.2
+
+* bugfix: Avoid failing on git with no changes by @JAVGan in https://github.com/release-engineering/iib/pull/1165
+* chore(deps): update dependency pytest to v8.4.2 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1141
+* chore(deps): update actions/setup-python action to v6 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1138
+* chore(deps): update dependency pytest-cov to v6.3.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1142
+* chore(deps): update dependency botocore to v1.40.25 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1133
+* chore(deps): update dependency boto3 to v1.40.25 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1131
+* chore(deps): update dependency pycparser to v2.23 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1147
+* chore(deps): update dependency pytest-cov to v7 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1146
+* chore(deps): update dependency cffi to v2 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1145
+* chore(deps): update dependency botocore to v1.40.27 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1144
+* chore(deps): update dependency s3transfer to v0.14.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1148
+* chore(deps): update dependency boto3 to v1.40.27 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1143
+* chore(deps): update dependency botocore to v1.40.29 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1150
+* chore(deps): update dependency botocore to v1.40.30 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1154
+* chore(deps): update dependency boto3 to v1.40.30 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1149
+* chore(deps): update dependency cryptography to v46 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1164
+* chore(deps): update dependency grpcio to v1.75.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1163
+* chore(deps): update dependency botocore to v1.40.33 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1161
+* chore(deps): update dependency boto3 to v1.40.33 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1160
+
 ## 9.4.1
 
 * Fix: Do not drop old columns for fbc-operations migration by @yashvardhannanavati in https://github.com/release-engineering/iib/pull/1135

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='iib',
-    version='9.4.1',
+    version='9.4.2',
     long_description=__doc__,
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,


### PR DESCRIPTION
Release v9.4.2

Refers to CLOUDDST-29675

## Summary by Sourcery

Release version 9.4.2 with a git no-changes bugfix and dependency updates

Bug Fixes:
- Avoid failing on git operations when there are no changes

Documentation:
- Add CHANGELOG entries for the 9.4.2 release

Chores:
- Bump package version to 9.4.2
- Update multiple dependencies to their latest patch versions (pytest, pytest-cov, actions/setup-python, botocore, boto3, pycparser, cffi, s3transfer, cryptography, grpcio)