### PR TITLE
bugfix: use git_diff after staging files

### DIFF
--- a/iib/workers/tasks/git_utils.py
+++ b/iib/workers/tasks/git_utils.py
@@ -110,15 +110,6 @@ def push_configs_to_git(
             )
             log.info(git_status)
 
-            # Check if there's anything to commit
-            changes = run_cmd(
-                ["git", "-C", local_repo_dir, "diff"], exc_msg="Error getting git diff"
-            )
-            if not changes:
-                _clean_up_local_repo(local_repo_dir)
-                log.warning("No changes to commit.")
-                return
-
             # Add updates
             log.info("Commiting changes to local Git repository.")
             run_cmd(
@@ -128,6 +119,16 @@ def push_configs_to_git(
                 ["git", "-C", local_repo_dir, "status"], exc_msg="Error getting git status"
             )
             log.info(git_status)
+
+            # Check if there's anything to commit
+            changes = run_cmd(
+                ["git", "-C", local_repo_dir, "diff", "--staged"], exc_msg="Error getting git diff"
+            )
+            if not changes:
+                _clean_up_local_repo(local_repo_dir)
+                log.warning("No changes to commit.")
+                return
+
             commit_and_push(
                 request_id,
                 local_repo_dir,


### PR DESCRIPTION
This commit is a fix related to !1165 which makes the `git diff` to be executed after adding the files to commit in order to avoid an empty diff due to untracked files.

## Summary by Sourcery

Fix the order of git diff in push_configs_to_git to handle untracked files by running git diff --staged after staging, and add a test to validate this behavior

Bug Fixes:
- Make push_configs_to_git verify staged changes with git diff --staged after staging files to correctly detect untracked files

Tests:
- Add test_push_configs_to_git_untracked_files to ensure untracked files are committed