### PR TITLE
suggestion: add black-format to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,14 @@ deps =
 commands =
     black --check --diff iib tests
 
+[testenv:black-format]
+description = black format command
+skip_install = true
+deps =
+    black==22.3.0
+commands =
+    black iib tests
+
 [testenv:docs]
 description = build docs [Mandatory]
 skip_install = true


### PR DESCRIPTION
This commit adds a `black-format` command to `tox` which allows IIB code to be automatically formatted whenever required by running

```
tox -e black-format
```

The goal is to reduce the manual burden of formatting code.

## Summary by Sourcery

New Features:
- Add 'black-format' tox environment for auto-formatting code using Black