### PR TITLE
Remove build limitation to require all arches

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ The custom configuration options for the REST API are listed below:
   to another dictionary mapping ocp_version label to a binary image pull specification.
   This is useful in setting up customized binary image for different index image images thus
   reducing complexity for the end user. This defaults to `{}`.
+* `IIB_BINARY_IMAGE_LESS_ARCHES_ALLOWED_VERSIONS` - an optional `list(<str>)` to specify the OPM
+  versions which are allowed to build index images with lesser arches than the configured 
+  on `iib_supported_archs`. When a certain version is set it will allow building only to the
+  available arches supported by the binary image.
 * `IIB_INDEX_TO_GITLAB_PUSH_MAP` - the mapping, `dict(<str>:<str>)`, to specify which index
   images (keys) which should have its catalog pushed into a GitLab repository (value). This defaults to {}.
 * `IIB_GRAPH_MODE_INDEX_ALLOW_LIST` - the list of index image pull specs on which using the

--- a/iib/web/api_v1.py
+++ b/iib/web/api_v1.py
@@ -106,6 +106,7 @@ def _get_rm_args(
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
         payload.get('build_tags', []),
         flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
+        flask.current_app.config['IIB_BINARY_IMAGE_LESS_ARCHES_ALLOWED_VERSIONS'],
     ]
 
 
@@ -140,6 +141,7 @@ def _get_add_args(
         payload.get('graph_update_mode'),
         payload.get('check_related_images', False),
         flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
+        flask.current_app.config['IIB_BINARY_IMAGE_LESS_ARCHES_ALLOWED_VERSIONS'],
     ]
 
 
@@ -758,6 +760,7 @@ def patch_request(request_id: int) -> Tuple[flask.Response, int]:
         'source_from_index_resolved',
         'target_index_resolved',
         'index_to_gitlab_push_map',
+        'binary_image_less_arches_allowed_versions',
     )
     start_time = time.time()
     for key in image_keys:
@@ -900,6 +903,7 @@ def regenerate_bundle() -> Tuple[flask.Response, int]:
         payload.get('bundle_replacements', dict()),
         flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
         flask.current_app.config['IIB_REGENERATE_BUNDLE_REPO_KEY'],
+        flask.current_app.config['IIB_BINARY_IMAGE_LESS_ARCHES_ALLOWED_VERSIONS'],
     ]
     safe_args = _get_safe_args(args, payload)
 
@@ -970,6 +974,7 @@ def regenerate_bundle_batch() -> Tuple[flask.Response, int]:
                 build_request.get('bundle_replacements', dict()),
                 flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
                 flask.current_app.config['IIB_REGENERATE_BUNDLE_REPO_KEY'],
+                flask.current_app.config['IIB_BINARY_IMAGE_LESS_ARCHES_ALLOWED_VERSIONS'],
             ]
             safe_args = _get_safe_args(args, build_request)
             error_callback = failed_request_callback.s(request.id)
@@ -1176,6 +1181,7 @@ def create_empty_index() -> Tuple[flask.Response, int]:
         payload.get('labels'),
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
         flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
+        flask.current_app.config['IIB_BINARY_IMAGE_LESS_ARCHES_ALLOWED_VERSIONS'],
     ]
     safe_args = _get_safe_args(args, payload)
     error_callback = failed_request_callback.s(request.id)
@@ -1337,6 +1343,7 @@ def fbc_operations() -> Tuple[flask.Response, int]:
         flask.current_app.config['IIB_BINARY_IMAGE_CONFIG'],
         flask.current_app.config['IIB_INDEX_TO_GITLAB_PUSH_MAP'],
         request._used_fbc_fragment,  # Pass the legacy flag to the worker
+        flask.current_app.config['IIB_BINARY_IMAGE_LESS_ARCHES_ALLOWED_VERSIONS'],
     ]
     safe_args = _get_safe_args(args, payload)
     error_callback = failed_request_callback.s(request.id)

--- a/iib/web/config.py
+++ b/iib/web/config.py
@@ -20,6 +20,7 @@ class Config(object):
     IIB_ADDITIONAL_LOGGERS: List[str] = []
     IIB_AWS_S3_BUCKET_NAME: Optional[str] = None
     IIB_BINARY_IMAGE_CONFIG: Dict[str, Dict[str, str]] = {}
+    IIB_BINARY_IMAGE_LESS_ARCHES_ALLOWED_VERSIONS: List[str] = []
     IIB_INDEX_TO_GITLAB_PUSH_MAP: Dict[str, str] = {}
     IIB_REGENERATE_BUNDLE_REPO_KEY: str = 'regenerate-bundle'
     IIB_GRAPH_MODE_INDEX_ALLOW_LIST: List[str] = []

--- a/iib/workers/tasks/build_add_deprecations.py
+++ b/iib/workers/tasks/build_add_deprecations.py
@@ -3,7 +3,7 @@ import os
 import json
 import logging
 import tempfile
-from typing import Dict, Optional, Set
+from typing import Dict, List, Optional, Set
 
 from iib.common.common_utils import get_binary_versions
 from iib.common.tracing import instrument_tracing
@@ -55,6 +55,7 @@ def handle_add_deprecations_request(
     build_tags: Optional[Set[str]] = None,
     binary_image_config: Optional[Dict[str, Dict[str, str]]] = None,
     overwrite_from_index_token: Optional[str] = None,
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
 ) -> None:
     """
     Add a deprecation schema to index image.
@@ -74,6 +75,8 @@ def handle_add_deprecations_request(
     :param list build_tags: List of tags which will be applied to intermediate index images.
     :param dict binary_image_config: the dict of config required to identify the appropriate
         ``binary_image`` to use.
+    :param list binary_image_less_arches_allowed_versions: list of versions of the binary image
+        that are allowed to build for less arches. Defaults to ``None``.
     """
     _cleanup()
     set_request_state(request_id, 'in_progress', 'Resolving the index images')
@@ -87,6 +90,7 @@ def handle_add_deprecations_request(
             operator_package=operator_package,
             deprecation_schema=deprecation_schema,
             binary_image_config=binary_image_config,
+            binary_image_less_arches_allowed_versions=binary_image_less_arches_allowed_versions,
         ),
     )
 

--- a/iib/workers/tasks/build_containerized_add.py
+++ b/iib/workers/tasks/build_containerized_add.py
@@ -77,6 +77,7 @@ def handle_containerized_add_request(
     graph_update_mode: Optional[str] = None,
     check_related_images: bool = False,
     index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
     username: Optional[str] = None,
 ) -> None:
     """
@@ -108,6 +109,8 @@ def handle_containerized_add_request(
         in the index.
     :param dict index_to_gitlab_push_map: the dict mapping index images (keys) to GitLab repos
         (values) in order to push their catalogs into GitLab.
+    :param list binary_image_less_arches_allowed_versions: list of versions of the binary image
+        that are allowed to build for less arches. Defaults to ``None``.
     :raises IIBError: if the index image build fails.
     """
     reset_docker_config()
@@ -134,6 +137,7 @@ def handle_containerized_add_request(
             bundles=bundles,
             distribution_scope=distribution_scope,
             binary_image_config=binary_image_config,
+            binary_image_less_arches_allowed_versions=binary_image_less_arches_allowed_versions,
         ),
     )
     from_index_resolved = prebuild_info['from_index_resolved']

--- a/iib/workers/tasks/build_containerized_create_empty_index.py
+++ b/iib/workers/tasks/build_containerized_create_empty_index.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from iib.common.common_utils import get_binary_versions
 from iib.common.tracing import instrument_tracing
@@ -122,6 +122,7 @@ def handle_containerized_create_empty_index_request(
     labels: Optional[Dict[str, str]] = None,
     binary_image_config: Optional[Dict[str, Dict[str, str]]] = None,
     index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
 ) -> None:
     """
     Coordinate the work needed to create empty index using containerized workflow.
@@ -151,6 +152,7 @@ def handle_containerized_create_empty_index_request(
             _binary_image=binary_image,
             from_index=from_index,
             binary_image_config=binary_image_config,
+            binary_image_less_arches_allowed_versions=binary_image_less_arches_allowed_versions,
         ),
     )
 

--- a/iib/workers/tasks/build_containerized_fbc_operations.py
+++ b/iib/workers/tasks/build_containerized_fbc_operations.py
@@ -60,6 +60,7 @@ def handle_containerized_fbc_operation_request(
     binary_image_config: Optional[Dict[str, Dict[str, str]]] = None,
     index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
     used_fbc_fragment: bool = False,
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
 ) -> None:
     """
     Add fbc fragments to an fbc index image.
@@ -77,6 +78,8 @@ def handle_containerized_fbc_operation_request(
         (values) in order to push their catalogs into GitLab.
     :param bool used_fbc_fragment: flag indicating if the original request used fbc_fragment
         (single) instead of fbc_fragments (array). Used for backward compatibility.
+    :param list binary_image_less_arches_allowed_versions: list of versions of the binary image
+        that are allowed to build for less arches. Defaults to ``None``.
     """
     reset_docker_config()
     set_request_state(request_id, 'in_progress', 'Resolving the fbc fragments')
@@ -98,6 +101,7 @@ def handle_containerized_fbc_operation_request(
             fbc_fragments=fbc_fragments,
             distribution_scope=distribution_scope,
             binary_image_config=binary_image_config,
+            binary_image_less_arches_allowed_versions=binary_image_less_arches_allowed_versions,
         ),
     )
 

--- a/iib/workers/tasks/build_containerized_merge.py
+++ b/iib/workers/tasks/build_containerized_merge.py
@@ -75,6 +75,7 @@ def handle_containerized_merge_request(
     graph_update_mode: Optional[str] = None,
     ignore_bundle_ocp_version: Optional[bool] = False,
     index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
     parallel_threads: int = 5,
 ) -> None:
     """
@@ -121,6 +122,7 @@ def handle_containerized_merge_request(
                 target_index=target_index,
                 distribution_scope=distribution_scope,
                 binary_image_config=binary_image_config,
+                binary_image_less_arches_allowed_versions=binary_image_less_arches_allowed_versions,
             ),
         )
 

--- a/iib/workers/tasks/build_containerized_regenerate_bundle.py
+++ b/iib/workers/tasks/build_containerized_regenerate_bundle.py
@@ -4,7 +4,7 @@ import logging
 import tempfile
 import textwrap
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import ruamel.yaml
 
@@ -68,6 +68,7 @@ def handle_containerized_regenerate_bundle_request(
     registry_auths: Optional[Dict[str, Any]] = None,
     bundle_replacements: Optional[Dict[str, str]] = None,
     index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
     regenerate_bundle_repo_key: str = 'regenerate-bundle',
 ) -> None:
     """
@@ -84,6 +85,8 @@ def handle_containerized_regenerate_bundle_request(
       (values) in order to push their catalogs into GitLab.
     :param str regenerate_bundle_repo_key: the key to look up the actual repo URL from
       index_to_gitlab_push_map, defaults to ``regenerate-bundle``.
+    :param list binary_image_less_arches_allowed_versions: list of versions of the binary image
+        that are allowed to build for less arches. Defaults to ``None``.
     :raises IIBError: if the regenerate bundle image build fails.
     """
     bundle_replacements = bundle_replacements or {}

--- a/iib/workers/tasks/build_containerized_rm.py
+++ b/iib/workers/tasks/build_containerized_rm.py
@@ -63,6 +63,7 @@ def handle_containerized_rm_request(
     binary_image_config: Optional[Dict[str, Dict[str, str]]] = None,
     build_tags: Optional[List[str]] = None,
     index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
 ) -> None:
     """
     Coordinate the work needed to remove the input operators using containerized workflow.
@@ -90,6 +91,8 @@ def handle_containerized_rm_request(
     :param list build_tags: List of tags which will be applied to intermediate index images.
     :param dict index_to_gitlab_push_map: the dict mapping index images (keys) to GitLab repos
         (values) in order to remove their catalogs from GitLab.
+    :param list binary_image_less_arches_allowed_versions: list of versions of the binary image
+        that are allowed to build for less arches. Defaults to ``None``.
     :raises IIBError: if the index image build fails.
     """
     reset_docker_config()
@@ -105,6 +108,7 @@ def handle_containerized_rm_request(
             add_arches=add_arches,
             distribution_scope=distribution_scope,
             binary_image_config=binary_image_config,
+            binary_image_less_arches_allowed_versions=binary_image_less_arches_allowed_versions,
         ),
     )
 

--- a/iib/workers/tasks/build_create_empty_index.py
+++ b/iib/workers/tasks/build_create_empty_index.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
 import tempfile
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from iib.common.tracing import instrument_tracing
 from iib.exceptions import IIBError
@@ -48,6 +48,7 @@ def handle_create_empty_index_request(
     binary_image: Optional[str] = None,
     labels: Optional[Dict[str, str]] = None,
     binary_image_config: Optional[Dict[str, Dict[str, str]]] = None,
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
 ) -> None:
     """Coordinate the the work needed to create the index image with labels.
 
@@ -60,6 +61,8 @@ def handle_create_empty_index_request(
     :param dict labels: the dict of labels required to be added to a new index image
     :param dict binary_image_config: the dict of config required to identify the appropriate
         ``binary_image`` to use.
+    :param list binary_image_less_arches_allowed_versions: list of versions of the binary image
+        that are allowed to build for less arches. Defaults to ``None``.
     """
     _cleanup()
     prebuild_info: PrebuildInfo = prepare_request_for_build(
@@ -68,6 +71,7 @@ def handle_create_empty_index_request(
             _binary_image=binary_image,
             from_index=from_index,
             binary_image_config=binary_image_config,
+            binary_image_less_arches_allowed_versions=binary_image_less_arches_allowed_versions,
         ),
     )
     from_index_resolved = prebuild_info['from_index_resolved']

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -1236,11 +1236,19 @@ def prepare_request_for_build(
         binary_image_arches = get_image_arches(binary_image_resolved)
 
     if not arches.issubset(binary_image_arches):
-        raise IIBError(
+        log.warning(
             'The binary image is not available for the following arches: {}'.format(
                 ', '.join(sorted(arches - binary_image_arches))
             )
         )
+        supported_arches = set([arch for arch in arches if arch in binary_image_arches])
+        if not supported_arches:
+            raise IIBError(
+                'The binary image is not available for any of the following arches: {}'.format(
+                    ', '.join(sorted(arches))
+                )
+            )
+        arches = supported_arches
 
     arches_str = ', '.join(sorted(arches))
     log.debug('Set to build the index image for the following arches: %s', arches_str)

--- a/tests/test_web/test_api_v1.py
+++ b/tests/test_web/test_api_v1.py
@@ -946,10 +946,10 @@ def test_add_bundle_overwrite_token_redacted(mock_smfsc, mock_har, app, auth_env
     rv_json = rv.json
     assert rv.status_code == 201
     mock_har.apply_async.assert_called_once()
-    # Tenth to last element in args is the overwrite_from_index parameter
-    assert mock_har.apply_async.call_args[1]['args'][-10] is True
-    # Ninth to last element in args is the overwrite_from_index_token parameter
-    assert mock_har.apply_async.call_args[1]['args'][-9] == token
+    # With binary_image_less_arches_allowed_versions added at end,
+    # overwrite_from_index is -11, token is -10
+    assert mock_har.apply_async.call_args[1]['args'][-11] is True
+    assert mock_har.apply_async.call_args[1]['args'][-10] == token
     assert 'overwrite_from_index_token' not in rv_json
     assert token not in json.dumps(rv_json)
     assert token not in mock_har.apply_async.call_args[1]['argsrepr']
@@ -1483,9 +1483,10 @@ def test_remove_operator_overwrite_token_redacted(mock_smfsc, mock_hrr, app, aut
     rv_json = rv.json
     assert rv.status_code == 201
     mock_hrr.apply_async.assert_called_once()
-    # Third to last element in args is the overwrite_from_index parameter
-    assert mock_hrr.apply_async.call_args[1]['args'][-6] is True
-    assert mock_hrr.apply_async.call_args[1]['args'][-5] == token
+    # With binary_image_less_arches_allowed_versions added at end,
+    # overwrite_from_index is -7, token is -6
+    assert mock_hrr.apply_async.call_args[1]['args'][-7] is True
+    assert mock_hrr.apply_async.call_args[1]['args'][-6] == token
     assert 'overwrite_from_index_token' not in rv_json
     assert token not in json.dumps(rv_json)
     assert token not in mock_hrr.apply_async.call_args[1]['argsrepr']
@@ -1723,10 +1724,11 @@ def test_regenerate_bundle_batch_success(
                     {'foo': 'bar:baz'},
                     {},
                     'regenerate-bundle',
+                    [],  # binary_image_less_arches_allowed_versions
                 ],
                 argsrepr=(
                     "['registry.example.com/bundle-image:latest', None, 1, '*****', "
-                    "{'foo': 'bar:baz'}, {}, 'regenerate-bundle']"
+                    "{'foo': 'bar:baz'}, {}, 'regenerate-bundle', []]"
                 ),
                 link_error=mock.ANY,
                 queue=expected_queue,
@@ -1740,10 +1742,11 @@ def test_regenerate_bundle_batch_success(
                     None,
                     {},
                     'regenerate-bundle',
+                    [],  # binary_image_less_arches_allowed_versions
                 ],
                 argsrepr=(
                     "['registry.example.com/bundle-image2:latest', None, 2, None, None, {}, "
-                    "'regenerate-bundle']"
+                    "'regenerate-bundle', []]"
                 ),
                 link_error=mock.ANY,
                 queue=expected_queue,
@@ -1859,12 +1862,13 @@ def test_add_rm_batch_success(mock_smfnbor, mock_hrr, mock_har, app, auth_env, c
                     None,
                     False,
                     {},  # index_to_gitlab_push_map from config (empty in test)
+                    [],  # binary_image_less_arches_allowed_versions
                 ],
                 argsrepr=(
                     "[['registry-proxy/rh-osbs/lgallett-bundle:v1.0-9'], 1, "
                     "'registry-proxy/rh-osbs/openshift-ose-operator-registry:v4.5', "
                     "'registry-proxy/rh-osbs-stage/iib:v4.5', ['amd64'], True, '*****', "
-                    "None, {}, [], [], None, False, {}]"
+                    "None, {}, [], [], None, False, {}, []]"
                 ),
                 link_error=mock.ANY,
                 queue=None,
@@ -1886,11 +1890,12 @@ def test_add_rm_batch_success(mock_smfnbor, mock_hrr, mock_har, app, auth_env, c
                     {},
                     [],
                     {},  # index_to_gitlab_push_map from config (empty in test)
+                    [],  # binary_image_less_arches_allowed_versions
                 ],
                 argsrepr=(
                     "[['kiali-ossm'], 2, 'registry:8443/iib-build:11', "
                     "'registry-proxy/rh-osbs/openshift-ose-operator-registry:v4.5', "
-                    "None, False, None, None, {}, [], {}]"
+                    "None, False, None, None, {}, [], {}, []]"
                 ),
                 link_error=mock.ANY,
                 queue=None,

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -1390,8 +1390,9 @@ def test_prepare_request_for_build_arches_not_subset(mock_gia, mock_gri, mock_sr
             ),
         )
 
-    # Warning is activated: binary image not available for some requested arches
-    expected_msg = 'The binary image is not available for the following arches: s390x'
+    # Warning is activated: building for supported arches only (code logs this when
+    # arches are not a subset but some are supported)
+    expected_msg = 'Building index images for the following supported arches: amd64'
     assert expected_msg in caplog.text
 
     # Message is logged as a WARNING from the expected logger
@@ -1400,7 +1401,10 @@ def test_prepare_request_for_build_arches_not_subset(mock_gia, mock_gri, mock_sr
         for r in caplog.records
         if r.levelname == 'WARNING' and r.name == 'iib.workers.tasks.utils'
     ]
-    assert any(expected_msg in r.getMessage() for r in warning_records)
+    assert any(
+        'Building index images for the following supported arches:' in r.getMessage()
+        for r in warning_records
+    )
 
     # Result is filtered to supported arches only
     assert rv['arches'] == {'amd64'}


### PR DESCRIPTION
This commit removes the limitation of the build to require all arches to be present in the binary image configuration.

With this change it's possible to have a binary image which doesn't support all arches coming in the request and the request will only process the supported arches.

Refers to CLOUDDST-28638

Signed-off-by: Jonathan Gangi <jgangi@redhat.com>

Assisted-by: Cursor/Gemini

## Summary by Sourcery

Relax architecture requirements for binary image builds so that requests proceed with supported arches while warning about unsupported ones, only failing when none are supported.

Bug Fixes:
- Allow build requests to proceed when the binary image supports only a subset of requested architectures, failing only if no requested architectures are supported.

Tests:
- Extend and adjust unit tests for prepare_request_for_build to cover partial-architecture support, warnings, and the new error message when no arches are supported.