### PR TITLE
Check for user in iib_no_ocp_label_allow_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,9 @@ The custom configuration options for the Celery workers are listed below:
 * `iib_log_level` - the Python log level for `iib.workers` logger. This defaults to `INFO`.
 * `iib_max_recursive_related_bundles` - the maximum number of recursive related bundles IIB will
   recurse through. This is to avoid DOS attacks.
-* `iib_no_ocp_label_allow_list` - list of index images to which we can add bundles 
-  without "com.redhat.openshift.versions" label
+* `iib_no_ocp_label_allow_list` - list of index images permited to add bundles 
+  without "com.redhat.openshift.versions" label. 
+* Can contain also specific users authorized to bypass this label requirement for any image.
 * `iib_organization_customizations` - this is used to customize aspects of the bundle being
   regenerated. The format is a dictionary where each key is an organization that requires
   customizations. Each value is a list of dictionaries with the ``type`` key set to one of the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,15 +9,15 @@ from datetime import datetime
 import os
 import sys
 
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version as get_version
 
 # -- Path setup --------------------------------------------------------------
 sys.path.append(os.path.abspath('../'))
 
 # -- Project information -----------------------------------------------------
 try:
-    version = pkg_resources.get_distribution('iib').version
-except pkg_resources.DistributionNotFound:
+    version = get_version('iib')
+except PackageNotFoundError:
     version = 'unknown'
 project = 'IIB Image Builder Service'
 copyright = datetime.today().strftime('%Y') + ', Red Hat Inc.'
@@ -44,7 +44,7 @@ htmlhelp_basename = 'IIBdoc'
 
 # -- Extension configuration -------------------------------------------------
 # This must be mocked because Read the Docs doesn't have krb5-devel installed
-autodoc_mock_imports = ["requests_kerberos"]
+autodoc_mock_imports = ["requests_kerberos", "operator_manifest"]
 
 # -- Options for intersphinx extension ---------------------------------------
 # Example configuration for intersphinx: refer to the Python standard library.

--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -25,7 +25,7 @@ from iib.workers.tasks.opm_operations import (
 from packaging.version import Version
 
 from iib.exceptions import IIBError
-from iib.workers.api_utils import set_request_state
+from iib.workers.api_utils import set_request_state, get_request
 from iib.workers.tasks.build import (
     _add_label_to_index,
     _build_image,
@@ -166,9 +166,12 @@ def _add_bundles_missing_in_source(
 
     if ignore_bundle_ocp_version:
         target_index_tmp = '' if target_index is None else target_index
+        user = get_request(request_id)['user']
         allow_no_ocp_version = any(
-            target_index_tmp.startswith(index) or source_from_index.startswith(index)
-            for index in get_worker_config()['iib_no_ocp_label_allow_list']
+            target_index_tmp.startswith(entry)
+            or source_from_index.startswith(entry)
+            or user == entry
+            for entry in get_worker_config()['iib_no_ocp_label_allow_list']
         )
     else:
         allow_no_ocp_version = False

--- a/tests/test_workers/test_tasks/test_build_merge_index_image.py
+++ b/tests/test_workers/test_tasks/test_build_merge_index_image.py
@@ -562,8 +562,18 @@ def test_handle_merge_request_no_deprecate(
 @mock.patch('iib.workers.tasks.build_merge_index_image._add_label_to_index')
 @mock.patch('iib.workers.tasks.build_merge_index_image.opm_index_add')
 @mock.patch('iib.workers.tasks.build_merge_index_image.set_request_state')
+@mock.patch('iib.workers.tasks.build_merge_index_image.get_request')
 def test_add_bundles_missing_in_source(
-    mock_srs, mock_oia, mock_aolti, mock_bi, mock_pi, mock_capml, mock_gil, mock_iifbc, mock_gwc
+    mock_gr,
+    mock_srs,
+    mock_oia,
+    mock_aolti,
+    mock_bi,
+    mock_pi,
+    mock_capml,
+    mock_gil,
+    mock_iifbc,
+    mock_gwc,
 ):
     source_bundles = [
         {
@@ -695,6 +705,169 @@ def test_add_bundles_missing_in_source(
     mock_bi.assert_called_once()
     mock_pi.assert_called_once()
     mock_capml.assert_not_called()
+
+
+@mock.patch('iib.workers.tasks.build_merge_index_image.get_worker_config')
+@mock.patch('iib.workers.tasks.build_merge_index_image.is_image_fbc')
+@mock.patch('iib.workers.tasks.build_merge_index_image.get_image_label')
+@mock.patch('iib.workers.tasks.build_merge_index_image._push_image')
+@mock.patch('iib.workers.tasks.build_merge_index_image._build_image')
+@mock.patch('iib.workers.tasks.build_merge_index_image._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_merge_index_image.opm_index_add')
+@mock.patch('iib.workers.tasks.build_merge_index_image.set_request_state')
+@mock.patch('iib.workers.tasks.build_merge_index_image.get_request')
+def test_add_bundles_missing_in_source_user_in_allow_list(
+    mock_gr,
+    mock_srs,
+    mock_oia,
+    mock_aolti,
+    mock_bi,
+    mock_pi,
+    mock_gil,
+    mock_iifbc,
+    mock_gwc,
+):
+    source_bundles = [
+        {
+            'packageName': 'bundle1',
+            'version': '1.0',
+            'bundlePath': 'quay.io/bundle1@sha256:123456',
+            'csvName': 'bundle1-1.0',
+        },
+    ]
+    target_bundles = [
+        {
+            'packageName': 'bundle1',
+            'version': '1.0',
+            'bundlePath': 'quay.io/bundle1@sha256:123456',
+            'csvName': 'bundle1-1.0',
+        },
+        {
+            'packageName': 'bundle2',
+            'version': '2.0',
+            'bundlePath': 'quay.io/bundle2@sha256:234567',
+            'csvName': 'bundle2-2.0',
+        },
+    ]
+
+    mock_gwc.return_value = {
+        'iib_no_ocp_label_allow_list': ['allowed_user'],
+    }
+    mock_gr.return_value = {'user': 'allowed_user'}
+
+    # side_effect order matches itertools.chain(missing_bundles, source_index_bundles)
+    # bundle2 (missing) gets '' (empty label), bundle1 (source) gets '=v4.6' (valid)
+    mock_gil.side_effect = ['', '=v4.6']
+    mock_iifbc.return_value = False
+    missing_bundles, invalid_bundles = build_merge_index_image._add_bundles_missing_in_source(
+        source_bundles,
+        target_bundles,
+        'some_dir',
+        'binary-image:4.5',
+        'index-image:4.6',
+        1,
+        'amd64',
+        '4.6',
+        'dev',
+        'replaces',
+        ignore_bundle_ocp_version=True,
+    )
+    assert missing_bundles == [
+        {
+            'packageName': 'bundle2',
+            'version': '2.0',
+            'bundlePath': 'quay.io/bundle2@sha256:234567',
+            'csvName': 'bundle2-2.0',
+        },
+    ]
+    # bundle2 has empty ocp version label but is allowed because user is in allow list
+    assert invalid_bundles == []
+    mock_gr.assert_called_once_with(1)
+
+
+@mock.patch('iib.workers.tasks.build_merge_index_image.get_worker_config')
+@mock.patch('iib.workers.tasks.build_merge_index_image.is_image_fbc')
+@mock.patch('iib.workers.tasks.build_merge_index_image.get_image_label')
+@mock.patch('iib.workers.tasks.build_merge_index_image._push_image')
+@mock.patch('iib.workers.tasks.build_merge_index_image._build_image')
+@mock.patch('iib.workers.tasks.build_merge_index_image._add_label_to_index')
+@mock.patch('iib.workers.tasks.build_merge_index_image.opm_index_add')
+@mock.patch('iib.workers.tasks.build_merge_index_image.set_request_state')
+@mock.patch('iib.workers.tasks.build_merge_index_image.get_request')
+def test_add_bundles_missing_in_source_user_not_in_allow_list(
+    mock_gr,
+    mock_srs,
+    mock_oia,
+    mock_aolti,
+    mock_bi,
+    mock_pi,
+    mock_gil,
+    mock_iifbc,
+    mock_gwc,
+):
+    source_bundles = [
+        {
+            'packageName': 'bundle1',
+            'version': '1.0',
+            'bundlePath': 'quay.io/bundle1@sha256:123456',
+            'csvName': 'bundle1-1.0',
+        },
+    ]
+    target_bundles = [
+        {
+            'packageName': 'bundle1',
+            'version': '1.0',
+            'bundlePath': 'quay.io/bundle1@sha256:123456',
+            'csvName': 'bundle1-1.0',
+        },
+        {
+            'packageName': 'bundle2',
+            'version': '2.0',
+            'bundlePath': 'quay.io/bundle2@sha256:234567',
+            'csvName': 'bundle2-2.0',
+        },
+    ]
+
+    mock_gwc.return_value = {
+        'iib_no_ocp_label_allow_list': ['allowed_user'],
+    }
+    mock_gr.return_value = {'user': 'unauthorized_user'}
+
+    # side_effect order matches itertools.chain(missing_bundles, source_index_bundles)
+    # bundle2 (missing) gets '' (empty label), bundle1 (source) gets '=v4.6' (valid)
+    mock_gil.side_effect = ['', '=v4.6']
+    mock_iifbc.return_value = False
+    missing_bundles, invalid_bundles = build_merge_index_image._add_bundles_missing_in_source(
+        source_bundles,
+        target_bundles,
+        'some_dir',
+        'binary-image:4.5',
+        'index-image:4.6',
+        1,
+        'amd64',
+        '4.6',
+        'dev',
+        'replaces',
+        ignore_bundle_ocp_version=True,
+    )
+    assert missing_bundles == [
+        {
+            'packageName': 'bundle2',
+            'version': '2.0',
+            'bundlePath': 'quay.io/bundle2@sha256:234567',
+            'csvName': 'bundle2-2.0',
+        },
+    ]
+    # bundle2 has empty ocp version label and user is NOT in allow list, so it's invalid
+    assert invalid_bundles == [
+        {
+            'packageName': 'bundle2',
+            'version': '2.0',
+            'bundlePath': 'quay.io/bundle2@sha256:234567',
+            'csvName': 'bundle2-2.0',
+        },
+    ]
+    mock_gr.assert_called_once_with(1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Allow bundle addition when the requesting user is configured to bypass missing OCP version labels.

Enhancements:
- Extend _add_bundles_missing_in_source to treat the requesting user as eligible for no-OCP-label allowances based on worker configuration.

Tests:
- Add tests covering behavior when the requesting user is and is not included in iib_no_ocp_label_allow_list with ignore_bundle_ocp_version enabled.