### PR TITLE
Setting default oras docker config path

### DIFF
--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -67,7 +67,9 @@ class Config(object):
     # Default registry for index.db ImageStream
     iib_index_db_imagestream_registry: Optional[str] = None
     iib_index_db_artifact_registry: Optional[str] = None
-    iib_index_db_oras_auth_path: Optional[str] = None
+    iib_index_db_oras_auth_path: str = os.path.join(
+        os.path.expanduser('~'), '.docker', 'oras', 'config.json'
+    )
     iib_index_db_artifact_tag_template: str = '{image_name}-{tag}'
     iib_index_db_artifact_template: str = '{registry}/index-db:{tag}'
     # Whether to use OpenShift ImageStream cache for index.db artifacts


### PR DESCRIPTION
Let's set default path for iib_index_db_oras_auth_path to $HOME/.docker/oras/config.json

[CLOUDDST-32383]

## Summary by Sourcery

Set a default path for the ORAS auth configuration used by index.db handling and perform a minor config formatting cleanup.

Enhancements:
- Default the ORAS auth config path to the user's $HOME/.docker/oras/config.json for index.db artifact handling.
- Tidy the development configuration by reformatting the recursive related bundles directory setting.