### PR TITLE
CLOUDDST-32368 : Fix FBC remove by only passing  DB-backed packages to opm registry rm

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -1166,7 +1166,7 @@ def handle_rm_request(
                 fbc_dir, _ = opm_registry_rm_fbc(
                     base_dir=temp_dir,
                     from_index=from_index_resolved,
-                    operators=operators,
+                    operators=operators_in_db,
                     index_db_path=index_db_path,
                 )
 

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -1256,6 +1256,10 @@ def test_handle_rm_request_fbc(
     tmpdir,
 ):
     configs_dir = tmpdir.mkdir('configs')
+    operators = ['hive-operator', 'some-operator']
+    configs_dir.mkdir('hive-operator')
+    configs_dir.mkdir('some-operator')
+
     deprecations_dir = configs_dir.mkdir(worker_config['operator_deprecations_dir'])
     operator_deprecation_dir = deprecations_dir.mkdir('some-operator')
     deprecation_template = textwrap.dedent(
@@ -1278,7 +1282,7 @@ def test_handle_rm_request_fbc(
     deprecation_file = operator_deprecation_dir.join('some-operator.json')
     deprecation_file.write(deprecation_template)
 
-    mock_voe.return_value = ['some-operator'], '/tmp/xyz/database/index.db'
+    mock_voe.return_value = {'some-operator'}, '/tmp/xyz/database/index.db'
     mock_govn.return_value = '0.9.0'
     mock_iifbc.return_value = True
     from_index_resolved = 'from-index@sha256:bcdefg'
@@ -1300,7 +1304,7 @@ def test_handle_rm_request_fbc(
     assert os.path.exists(deprecation_file)
 
     build.handle_rm_request(
-        operators=['some-operator'],
+        operators=operators,
         request_id=5,
         from_index='from-index:latest',
         binary_image='binary-image:latest',
@@ -1323,7 +1327,14 @@ def test_handle_rm_request_fbc(
     mock_gcd.assert_called_once()
     mock_gcl.assert_called_once()
     mock_mcd.assert_called_once_with(mock.ANY, configs_dir)
+    mock_voe.assert_called_once_with(
+        from_index='from-index:latest',
+        base_dir=mock.ANY,
+        operator_packages=operators,
+        overwrite_from_index_token='token',
+    )
     mock_orrf.assert_called_once()
+    assert mock_orrf.call_args.kwargs['operators'] == {'some-operator'}
     mock_opmvalidate.assert_called_once()
     assert mock_alti.call_count == 2
     assert mock_bi.call_count == 2
@@ -1342,7 +1353,7 @@ def test_handle_rm_request_fbc(
         add_or_rm=True,
         is_image_fbc=True,
         index_repo_map={},
-        rm_operators=['some-operator'],
+        rm_operators=operators,
     )
     assert mock_srs.call_args[0][1] == 'complete'
 


### PR DESCRIPTION
opm registry rm failed when the removal list included FBC-only packages
not present in the index.db.  This MR patches this bug by only passing operators which are present in DB when trying removing operators from db.

## Summary by Sourcery

Filter remove-operator requests so opm registry rm is invoked only with DB-backed packages when handling FBC removals.

Bug Fixes:
- Prevent failures in FBC removal when the operator list includes packages not present in the index database by passing only DB-backed operators to opm registry rm.

Tests:
- Extend FBC remove-request tests to cover mixed operator lists and verify only DB-backed operators are passed to the registry removal function.