### PR TITLE
Remove podman usage

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,7 +26,7 @@ requests
 ruamel.yaml
 semver
 setuptools
-sphinx
+sphinx==8.2.3
 sphinx_rtd_theme
 tenacity
 typing-extensions

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -277,9 +277,9 @@ class DevelopmentConfig(Config):
     iib_registry: str = 'registry:8443'
     iib_request_logs_dir: Optional[str] = '/var/log/iib/requests'
     iib_request_related_bundles_dir: Optional[str] = '/var/lib/requests/related_bundles'
-    iib_request_recursive_related_bundles_dir: Optional[str] = (
-        '/var/lib/requests/recursive_related_bundles'
-    )
+    iib_request_recursive_related_bundles_dir: Optional[
+        str
+    ] = '/var/lib/requests/recursive_related_bundles'
     iib_dogpile_backend: str = 'dogpile.cache.memcached'
     iib_ocp_opm_mapping: dict = {
         "v4.6": "opm-v1.26.4",

--- a/iib/workers/config.py
+++ b/iib/workers/config.py
@@ -67,7 +67,9 @@ class Config(object):
     # Default registry for index.db ImageStream
     iib_index_db_imagestream_registry: Optional[str] = None
     iib_index_db_artifact_registry: Optional[str] = None
-    iib_index_db_oras_auth_path: Optional[str] = None
+    iib_index_db_oras_auth_path: str = os.path.join(
+        os.path.expanduser('~'), '.docker', 'oras', 'config.json'
+    )
     iib_index_db_artifact_tag_template: str = '{image_name}-{tag}'
     iib_index_db_artifact_template: str = '{registry}/index-db:{tag}'
     # Whether to use OpenShift ImageStream cache for index.db artifacts
@@ -275,9 +277,9 @@ class DevelopmentConfig(Config):
     iib_registry: str = 'registry:8443'
     iib_request_logs_dir: Optional[str] = '/var/log/iib/requests'
     iib_request_related_bundles_dir: Optional[str] = '/var/lib/requests/related_bundles'
-    iib_request_recursive_related_bundles_dir: Optional[
-        str
-    ] = '/var/lib/requests/recursive_related_bundles'
+    iib_request_recursive_related_bundles_dir: Optional[str] = (
+        '/var/lib/requests/recursive_related_bundles'
+    )
     iib_dogpile_backend: str = 'dogpile.cache.memcached'
     iib_ocp_opm_mapping: dict = {
         "v4.6": "opm-v1.26.4",

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -24,7 +24,12 @@ from iib.workers.api_utils import set_request_state, update_request
 from iib.workers.config import get_worker_config
 from iib.workers.tasks.celery import app
 from iib.workers.greenwave import gate_bundles
-from iib.workers.tasks.fbc_utils import is_image_fbc, get_catalog_dir, merge_catalogs_dirs
+from iib.workers.tasks.fbc_utils import (
+    is_image_fbc,
+    get_catalog_dir,
+    merge_catalogs_dirs,
+    extract_directory_from_image_non_privileged,
+)
 from iib.workers.tasks.git_utils import push_configs_to_git, revert_last_commit
 from iib.workers.tasks.opm_operations import (
     opm_registry_add_fbc,
@@ -733,7 +738,9 @@ def inspect_related_images(
             bundle, "operators.operatorframework.io.bundle.manifests.v1"
         )
         with tempfile.TemporaryDirectory(prefix=f'iib-{request_id}-') as temp_dir:
-            _copy_files_from_image(bundle, manifest_location, temp_dir)
+            extract_directory_from_image_non_privileged(
+                image=bundle, src_path=manifest_location, dest_path=temp_dir
+            )
             manifest_path = os.path.join(temp_dir, manifest_location)
             try:
                 operator_manifest = OperatorManifest.from_directory(manifest_path)

--- a/iib/workers/tasks/fbc_utils.py
+++ b/iib/workers/tasks/fbc_utils.py
@@ -102,6 +102,83 @@ def merge_catalogs_dirs(src_config: str, dest_config: str):
     opm_validate(conf_dir)
 
 
+def extract_directory_from_image_non_privileged(image: str, src_path: str, dest_path: str) -> None:
+    """
+    Extract a directory from an image using 'oc image extract'.
+
+    'dest_path' is a directory path on the host to extract the contents to.
+    Non-existing directory will be created. A subdirectory named like
+    the last segment of 'src_path' (e.g. '/configs' -> 'configs') is created
+    under 'dest_path' and the image contents under 'src_path' are extracted there
+    via ``--path=<src_path>/*:<that_subdir>``.
+
+    :param str image: the pull specification of the container image
+    :param str src_path: absolute directory path inside the image; trailing slashes
+        and redundant '.' / '..' segments are normalized with :class:`pathlib.Path`
+        ('resolve(strict=False)'; logged when the result differs from the input).
+    :param str dest_path: directory path on the host to extract the contents to.
+        If the directory does not exist, it will be created.
+    :raises IIBError: if paths are invalid, 'dest_path' is missing, or 'oc' fails
+    """
+    from iib.workers.tasks.utils import run_cmd
+
+    # Image paths are POSIX-style absolute paths inside the container rootfs.
+    if not src_path.startswith('/'):
+        error_msg = f'src_path must be an absolute image path, got {src_path!r}'
+        log.error(error_msg)
+        raise IIBError(error_msg)
+
+    original_src_path = src_path
+
+    # 'oc' glob is '<dir>/*'; strip trailing slashes so we do not end up with '//' in paths.
+    stripped = src_path.rstrip('/')
+    if not stripped:
+        error_msg = f'src_path must name a directory under /, got {original_src_path!r}'
+        log.error(error_msg)
+        raise IIBError(error_msg)
+
+    # Collapse '.', '..', and repeated slashes
+    normalized_path = Path(stripped).resolve(strict=False)
+    normalized = normalized_path.as_posix()
+
+    if normalized != original_src_path.rstrip('/'):
+        log.info(
+            'Normalized src_path for oc image extract: %r -> %r',
+            original_src_path,
+            normalized,
+        )
+
+    # Host layout: 'dest_path/<basename(normalized)>/' receives image tree under 'normalized/'.
+    inner = normalized_path.name
+    if not inner:
+        error_msg = f'src_path must name a directory under /, got {original_src_path!r}'
+        log.error(error_msg)
+        raise IIBError(error_msg)
+
+    dest = Path(dest_path)
+    if not dest.exists():
+        dest.mkdir(parents=True, exist_ok=True)
+        log.info(f'dest_path did not exist, created {dest_path!r}')
+    elif not dest.is_dir():
+        raise IIBError(f'dest_path exists but is not a directory: {dest_path!r}')
+
+    target = dest / inner
+    target.mkdir(parents=True, exist_ok=True)
+    target_abs = target.resolve(strict=False).as_posix()
+
+    # '--path=<image_dir>/*:<abs_host_dir>' unpacks direct children of 'normalized' into target.
+    path_arg = f'{normalized}/*:{target_abs}'
+    cmd = ['oc', 'image', 'extract', '--confirm', f'--path={path_arg}', image]
+
+    log.info(
+        'Extracting image directory %s into %s (under existing %s)',
+        normalized,
+        target_abs,
+        str(dest),
+    )
+    run_cmd(cmd, exc_msg=f'Failed to extract {normalized} from {image}')
+
+
 def extract_fbc_fragment(
     temp_dir: str, fbc_fragment: str, fragment_index: int = 0
 ) -> Tuple[str, List[str]]:
@@ -115,15 +192,15 @@ def extract_fbc_fragment(
     :return: fbc_fragment path, fbc_operator_packages.
     :rtype: tuple
     """
-    from iib.workers.tasks.build import _copy_files_from_image
-
     log.info("Extracting the fbc_fragment's catalog from  %s", fbc_fragment)
     # store the fbc_fragment at /tmp/iib-**/fbc-fragment-{index} to prevent
     # cross-contamination
     conf = get_worker_config()
     fbc_fragment_path = os.path.join(temp_dir, f"{conf['temp_fbc_fragment_path']}-{fragment_index}")
     # Copy fbc_fragment's catalog to /tmp/iib-**/fbc-fragment-{index}
-    _copy_files_from_image(fbc_fragment, conf['fbc_fragment_catalog_path'], fbc_fragment_path)
+    extract_directory_from_image_non_privileged(
+        image=fbc_fragment, src_path=conf['fbc_fragment_catalog_path'], dest_path=fbc_fragment_path
+    )
 
     log.info("fbc_fragment extracted at %s", fbc_fragment_path)
     operator_packages = os.listdir(fbc_fragment_path)

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -1550,9 +1550,9 @@ def test_get_no_present_bundles(
 @mock.patch('iib.workers.tasks.build.skopeo_inspect')
 @mock.patch('iib.workers.tasks.build.get_bundle_metadata')
 @mock.patch('iib.workers.tasks.build.OperatorManifest.from_directory')
-@mock.patch('iib.workers.tasks.build._copy_files_from_image')
+@mock.patch('iib.workers.tasks.build.extract_directory_from_image_non_privileged')
 @mock.patch('iib.workers.tasks.build.get_image_label')
-def test_inspect_related_images(mock_gil, mock_cffi, mock_fd, mock_gbd, mock_si, tmpdir):
+def test_inspect_related_images(mock_gil, mock_edi, mock_fd, mock_gbd, mock_si, tmpdir):
     bundles = ['quay.io/repo/image@sha256:123', 'quay.io/repo2/image2@sha256:456']
     request_id = 5
     mock_gil.return_value = '/manifests'
@@ -1595,10 +1595,10 @@ def test_inspect_related_images(mock_gil, mock_cffi, mock_fd, mock_gbd, mock_si,
 @mock.patch('iib.workers.tasks.build.skopeo_inspect')
 @mock.patch('iib.workers.tasks.build.get_bundle_metadata')
 @mock.patch('iib.workers.tasks.build.OperatorManifest.from_directory')
-@mock.patch('iib.workers.tasks.build._copy_files_from_image')
+@mock.patch('iib.workers.tasks.build.extract_directory_from_image_non_privileged')
 @mock.patch('iib.workers.tasks.build.get_image_label')
 def test_inspect_related_images_stage_bundle(
-    mock_gil, mock_cffi, mock_fd, mock_gbd, mock_si, tmpdir
+    mock_gil, mock_edi, mock_fd, mock_gbd, mock_si, tmpdir
 ):
     bundles = ['quay.stage.io/repo/bundleimage@sha256:123']
     request_id = 5
@@ -1635,10 +1635,10 @@ def test_inspect_related_images_stage_bundle(
 @mock.patch('iib.workers.tasks.build.skopeo_inspect')
 @mock.patch('iib.workers.tasks.build.get_bundle_metadata')
 @mock.patch('iib.workers.tasks.build.OperatorManifest.from_directory')
-@mock.patch('iib.workers.tasks.build._copy_files_from_image')
+@mock.patch('iib.workers.tasks.build.extract_directory_from_image_non_privileged')
 @mock.patch('iib.workers.tasks.build.get_image_label')
 def test_inspect_related_images_stage_bundle_without_registry_replacement(
-    mock_gil, mock_cffi, mock_fd, mock_gbd, mock_si, tmpdir
+    mock_gil, mock_edi, mock_fd, mock_gbd, mock_si, tmpdir
 ):
     bundles = ['quay.stage.io/repo/bundleimage@sha256:123']
     request_id = 5
@@ -1675,9 +1675,9 @@ def test_inspect_related_images_stage_bundle_without_registry_replacement(
 @mock.patch('iib.workers.tasks.utils.run_cmd')
 @mock.patch('iib.workers.tasks.build.get_bundle_metadata')
 @mock.patch('iib.workers.tasks.build.OperatorManifest.from_directory')
-@mock.patch('iib.workers.tasks.build._copy_files_from_image')
+@mock.patch('iib.workers.tasks.build.extract_directory_from_image_non_privileged')
 @mock.patch('iib.workers.tasks.build.get_image_label')
-def test_inspect_related_images_fail(mock_gil, mock_cffi, mock_fd, mock_gbd, mock_rc, tmpdir):
+def test_inspect_related_images_fail(mock_gil, mock_edi, mock_fd, mock_gbd, mock_rc, tmpdir):
     bundles = ['quay.io/repo/image@sha256:123']
     request_id = 5
     mock_gil.return_value = '/manifests'

--- a/tests/test_workers/test_tasks/test_fbc_utils.py
+++ b/tests/test_workers/test_tasks/test_fbc_utils.py
@@ -15,6 +15,7 @@ from iib.workers.tasks.fbc_utils import (
     is_image_fbc,
     merge_catalogs_dirs,
     enforce_json_config_dir,
+    extract_directory_from_image_non_privileged,
     extract_fbc_fragment,
     _serialize_datetime,
 )
@@ -209,8 +210,8 @@ def test_enforce_json_config_dir_multiple_chunks_input(tmpdir):
 
 @pytest.mark.parametrize('ldr_output', [['testoperator'], ['test1', 'test2'], []])
 @mock.patch('os.listdir')
-@mock.patch('iib.workers.tasks.build._copy_files_from_image')
-def test_extract_fbc_fragment(mock_cffi, mock_osldr, ldr_output, tmpdir):
+@mock.patch('iib.workers.tasks.fbc_utils.extract_directory_from_image_non_privileged')
+def test_extract_fbc_fragment(mock_extract_dir, mock_osldr, ldr_output, tmpdir):
     test_fbc_fragment = "example.com/test/fbc_fragment:latest"
     mock_osldr.return_value = ldr_output
     # The function now adds -0 suffix by default when fragment_index is not provided
@@ -221,16 +222,18 @@ def test_extract_fbc_fragment(mock_cffi, mock_osldr, ldr_output, tmpdir):
             extract_fbc_fragment(tmpdir, test_fbc_fragment)
     else:
         extract_fbc_fragment(tmpdir, test_fbc_fragment)
-        mock_cffi.assert_called_once_with(
-            test_fbc_fragment, get_worker_config()['fbc_fragment_catalog_path'], fbc_fragment_path
+        mock_extract_dir.assert_called_once_with(
+            image=test_fbc_fragment,
+            src_path=get_worker_config()['fbc_fragment_catalog_path'],
+            dest_path=fbc_fragment_path,
         )
         mock_osldr.assert_called_once_with(fbc_fragment_path)
 
 
 @pytest.mark.parametrize('ldr_output', [['testoperator'], ['test1', 'test2']])
 @mock.patch('os.listdir')
-@mock.patch('iib.workers.tasks.build._copy_files_from_image')
-def test_extract_fbc_fragment_with_index(mock_cffi, mock_osldr, ldr_output, tmpdir):
+@mock.patch('iib.workers.tasks.fbc_utils.extract_directory_from_image_non_privileged')
+def test_extract_fbc_fragment_with_index(mock_extract_dir, mock_osldr, ldr_output, tmpdir):
     """Test extract_fbc_fragment with non-zero fragment_index values."""
     test_fbc_fragment = "example.com/test/fbc_fragment:latest"
     mock_osldr.return_value = ldr_output
@@ -251,15 +254,17 @@ def test_extract_fbc_fragment_with_index(mock_cffi, mock_osldr, ldr_output, tmpd
     assert result_operators == ldr_output
 
     # Verify the function was called with the correct path
-    mock_cffi.assert_called_once_with(
-        test_fbc_fragment, get_worker_config()['fbc_fragment_catalog_path'], fbc_fragment_path
+    mock_extract_dir.assert_called_once_with(
+        image=test_fbc_fragment,
+        src_path=get_worker_config()['fbc_fragment_catalog_path'],
+        dest_path=fbc_fragment_path,
     )
     mock_osldr.assert_called_once_with(fbc_fragment_path)
 
 
 @mock.patch('os.listdir')
-@mock.patch('iib.workers.tasks.build._copy_files_from_image')
-def test_extract_fbc_fragment_isolation(mock_cffi, mock_osldr, tmpdir):
+@mock.patch('iib.workers.tasks.fbc_utils.extract_directory_from_image_non_privileged')
+def test_extract_fbc_fragment_isolation(mock_extract_dir, mock_osldr, tmpdir):
     """Test that multiple fragments with different indices create isolated directories."""
     test_fbc_fragment1 = "example.com/test/fbc_fragment1:latest"
     test_fbc_fragment2 = "example.com/test/fbc_fragment2:latest"
@@ -283,12 +288,94 @@ def test_extract_fbc_fragment_isolation(mock_cffi, mock_osldr, tmpdir):
     assert operators2 == ['operator2']
     assert operators1 != operators2
 
-    # Verify _copy_files_from_image was called with different paths
     expected_calls = [
-        mock.call(test_fbc_fragment1, get_worker_config()['fbc_fragment_catalog_path'], path1),
-        mock.call(test_fbc_fragment2, get_worker_config()['fbc_fragment_catalog_path'], path2),
+        mock.call(
+            image=test_fbc_fragment1,
+            src_path=get_worker_config()['fbc_fragment_catalog_path'],
+            dest_path=path1,
+        ),
+        mock.call(
+            image=test_fbc_fragment2,
+            src_path=get_worker_config()['fbc_fragment_catalog_path'],
+            dest_path=path2,
+        ),
     ]
-    mock_cffi.assert_has_calls(expected_calls, any_order=True)
+    mock_extract_dir.assert_has_calls(expected_calls, any_order=True)
+
+
+def test_extract_directory_from_image_non_privileged_rejects_relative_src(tmp_path):
+    """Reject ``src_path`` without a leading ``/`` (not a valid absolute path in the image)."""
+    dest = tmp_path / 'dest'
+    dest.mkdir()
+    with pytest.raises(IIBError, match='absolute image path'):
+        extract_directory_from_image_non_privileged(
+            image='quay.io/ns/img@sha256:abc', src_path='configs', dest_path=str(dest)
+        )
+
+
+def test_extract_directory_from_image_non_privileged_rejects_slash_only(tmp_path):
+    """Reject ``src_path`` that is only ``/`` (no named directory segment after normalization)."""
+    dest = tmp_path / 'dest'
+    dest.mkdir()
+    with pytest.raises(IIBError, match='directory under /'):
+        extract_directory_from_image_non_privileged(
+            image='quay.io/ns/img@sha256:abc', src_path='/', dest_path=str(dest)
+        )
+
+
+@mock.patch('iib.workers.tasks.utils.run_cmd')
+def test_extract_directory_from_image_non_privileged_oc_command(mock_run_cmd, tmp_path):
+    """Test build with the expected parameters."""
+    dest = tmp_path / 'dest'
+    dest.mkdir()
+    image = 'quay.io/exd/hello@sha256:deadbeef'
+    extract_directory_from_image_non_privileged(
+        image=image, src_path='/configs', dest_path=str(dest)
+    )
+
+    mock_run_cmd.assert_called_once()
+    (cmd,) = mock_run_cmd.call_args[0]
+    assert cmd[:3] == ['oc', 'image', 'extract']
+    assert cmd[3] == '--confirm'
+    assert cmd[4].startswith('--path=/configs/*:')
+    assert str(dest / 'configs') in cmd[4]
+    assert cmd[5] == image
+
+
+@mock.patch('iib.workers.tasks.utils.run_cmd')
+def test_extract_directory_from_image_non_privileged_trailing_slash_on_src(mock_run_cmd, tmp_path):
+    """Test trailing slash on ``src_path`` is stripped."""
+    dest = tmp_path / 'dest'
+    dest.mkdir()
+    extract_directory_from_image_non_privileged(
+        image='quay.io/exd/hello@sha256:beef', src_path='/configs/', dest_path=str(dest)
+    )
+    path_arg = mock_run_cmd.call_args[0][0][4]
+    assert path_arg.startswith('--path=/configs/*:')
+
+
+@mock.patch('iib.workers.tasks.utils.run_cmd')
+def test_extract_directory_from_image_non_privileged_normpath_in_oc_path(mock_run_cmd, tmp_path):
+    """Test redundant segments in paths; uses the normalized directory."""
+    dest = tmp_path / 'dest'
+    dest.mkdir()
+    extract_directory_from_image_non_privileged(
+        image='quay.io/ns/i@sha256:1', src_path='/configs/./foo', dest_path=str(dest)
+    )
+    path_arg = mock_run_cmd.call_args[0][0][4]
+    assert path_arg.startswith('--path=/configs/foo/*:')
+
+
+@mock.patch('iib.workers.tasks.utils.run_cmd')
+def test_extract_directory_from_image_non_privileged_creates_dest(mock_run_cmd, tmp_path):
+    """If ``dest_path`` is missing, it is created before ``oc`` runs."""
+    dest = tmp_path / 'newdest'
+    assert not dest.exists()
+    extract_directory_from_image_non_privileged(
+        image='quay.io/ns/i@sha256:1', src_path='/manifests', dest_path=str(dest)
+    )
+    assert dest.is_dir()
+    mock_run_cmd.assert_called_once()
 
 
 def test__serialize_datetime():


### PR DESCRIPTION
Adding extraction of directory using oc command

We can't use podman inside container, and we need to extract data from index image. The best way for our purposes was to use `oc image extract`. 

This commit adds extract_directory_from_image_non_privileged used to extract data from image.

## Summary by Sourcery

Replace podman-based image directory extraction with a non-privileged `oc image extract` helper and wire it into FBC fragment and related image inspection workflows.

New Features:
- Add `extract_directory_from_image_non_privileged` helper to extract directories from container images using `oc image extract`.

Enhancements:
- Refactor FBC fragment extraction and related image inspection to use the new non-privileged image directory extraction helper instead of `_copy_files_from_image`.
- Set a default ORAS auth config path for index.db artifacts in the worker configuration.

Tests:
- Extend and update tests to cover the new extraction helper behavior and its integration into FBC fragment and related image inspection logic.