### PR TITLE
Release v9.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 9.5.2
+
+* Update dependency urllib3 to v2.7.0 [SECURITY] by @renovate[bot] in https://github.com/release-engineering/iib/pull/1324
+* Update dependency mako to v1.3.12 [SECURITY] by @renovate[bot] in https://github.com/release-engineering/iib/pull/1323
+* Update dependency python-qpid-proton to v0.40.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1318
+* Update python Docker tag to v3.14.5 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1271
+* Update dependency coverage to v7.14.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1326
+* Update dependency googleapis-common-protos to v1.75.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1327
+* Update dependency requests to v2.34.1 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1329
+* Update dependency idna to v3.15 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1328
+
 ## 9.5.1
 
 * Check for user in iib_no_ocp_label_allow_list by @MichalZelenak in https://github.com/release-engineering/iib/pull/1304

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='iib',
-    version='9.5.1',
+    version='9.5.2',
     long_description=__doc__,
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,


### PR DESCRIPTION
Changes:

* Update dependency urllib3 to v2.7.0 [SECURITY] by @renovate[bot] in https://github.com/release-engineering/iib/pull/1324
* Update dependency mako to v1.3.12 [SECURITY] by @renovate[bot] in https://github.com/release-engineering/iib/pull/1323
* Update dependency python-qpid-proton to v0.40.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1318
* Update python Docker tag to v3.14.5 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1271
* Update dependency coverage to v7.14.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1326
* Update dependency googleapis-common-protos to v1.75.0 by @renovate[bot] in https://github.com/release-engineering/iib/pull/1327

Refers to CLOUDDST-32605

Signed-off-by: Jonathan Gangi <jgangi@redhat.com>
