### PR TITLE
feat(CLOUDDST-32565):Upgrade Dockerfiles to UBI9

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -22,7 +22,10 @@ RUN dnf -y install \
     python3.12-setuptools \
     && dnf update -y \
     && dnf clean all
-RUN update-alternatives --set python3 $(which python3.12)
+
+# UBI9 doesn't come with alternatives installed for python3 by default, so we need to set it manually
+RUN update-alternatives --install /usr/bin/python3 python3 $(which python3.12) 1
+RUN update-alternatives --install /usr/bin/pip3 pip3 $(which pip3.12) 1
 
 COPY . .
 COPY ./docker/iib-httpd.conf /etc/httpd/conf/httpd.conf

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -30,9 +30,6 @@ RUN update-alternatives --install /usr/bin/pip3 pip3 $(which pip3.12) 1
 COPY . .
 COPY ./docker/iib-httpd.conf /etc/httpd/conf/httpd.conf
 
-# default python3-pip version for rhel8 python3.8 is 19.3.1 and it can't be updated by dnf
-# we have to update it by pip to version above 21.0.0
-RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt --no-deps --require-hashes
 RUN pip3 install . --no-deps
 EXPOSE 8080

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -11,7 +11,6 @@ RUN dnf -y install \
     buildah \
     fuse-overlayfs \
     gcc \
-    curl \
     tar \
     gzip \
     git \

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -62,7 +62,9 @@ RUN curl -L "https://github.com/oras-project/oras/releases/download/v1.3.0/oras_
 RUN git config --global user.email "exd-guild-hello-operator+iib-dev-env@redhat.com"
 RUN git config --global user.name "IIB dev-env"
 
-RUN update-alternatives --set python3 $(which python3.12)
+# UBI9 doesn't come with alternatives installed for python3 by default, so we need to set it manually
+RUN update-alternatives --install /usr/bin/python3 python3 $(which python3.12) 1
+RUN update-alternatives --install /usr/bin/pip3 pip3 $(which pip3.12) 1
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' /etc/containers/storage.conf

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -79,9 +79,6 @@ RUN mkdir -p /home/iib-worker/.docker \
 ENV HOME=/home/iib-worker
 ENV KRB5CCNAME=FILE:/home/iib-worker/krb5cc_iib_worker
 
-# default python3-pip version for rhel8 python3.6 is 9.0.3 and it can't be updated by dnf
-# we have to update it by pip to version above 21.0.0
-RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt --no-deps --require-hashes
 RUN pip3 install . --no-deps
 CMD ["/usr/local/bin/celery", "-A", "iib.workers.tasks", "worker", "--loglevel=debug"]

--- a/docker/message_broker/Dockerfile
+++ b/docker/message_broker/Dockerfile
@@ -1,5 +1,5 @@
 # Based from https://github.com/rmohr/docker-activemq
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 ENV ACTIVEMQ_VERSION 5.15.12
 ENV ACTIVEMQ_HOME /opt/activemq


### PR DESCRIPTION
# Upgrade Dockerfiles to UBI9

This PR aims to upgrade the existing Dockerfiles for IIB's API and worker to the currently [latest version of UBI](https://catalog.redhat.com/en/software/base-images#base-images-get-images) which is the UBI9.

It also fix some issues in the existing Dockerfiles in order to make IIB work in the new UBI version.