### PR TITLE
Refactor set_registry_token to support repository-specific auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ The custom configuration options for the Celery workers are listed below:
 * `iib_docker_config_template` - the path to the Docker config.json file for IIB to use as a
   template. IIB will symlink this file to `~/.docker/config.json` at the beginning of every request.
   Additionally, it will use this file as a base and set the `overwrite_from_index_token` for the
-  registry of the `from_index` container image when applicable. IIB will never directly modify this
+  specific repository of the `from_index` container image when applicable. IIB will never directly modify this
   file though. This defaults to `~/.docker/config.json.template`.
 *  `iib_dogpile_backend` - the configuration for the dogpile.cache backend. The default value is
    `'dogpile.cache.null'`. In case you want to enable caching, set this to `'dogpile.cache.memcached'`.

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -574,23 +574,65 @@ def reset_docker_config() -> None:
         os.symlink(conf.iib_docker_config_template, docker_config_path)
 
 
+def _docker_auth_key_for_image(container_image: str) -> str:
+    """
+    Return the docker config ``auths`` key for ``container_image``.
+
+    Uses ``registry/namespace/repo`` when a namespace is present, since that is the most
+    specific key container runtimes reliably match. Without a namespace, only registry-level
+    keys are used because ``registry/repo`` matching is not consistent across runtimes.
+
+    :param str container_image: the pull specification of the container image
+    :return: the docker config ``auths`` key for ``container_image``
+    :rtype: str
+    :raises IIBError: if the pull specification does not contain a resolvable registry.
+    """
+    image_name = ImageName.parse(container_image)
+    registry = image_name.registry
+    if image_name.namespace and registry:
+        return f'{registry}/{image_name.namespace}/{image_name.repo}'
+    if registry:
+        return registry
+    raise IIBError(
+        f'Unable to determine the registry from the pull specification {container_image!r} '
+        'for Docker authentication'
+    )
+
+
 @contextmanager
 def set_registry_token(
     token: Optional[str], container_image: Optional[str], append: bool = False
 ) -> Generator:
     """
-    Configure authentication to the registry that ``container_image`` is from.
+    Configure authentication for the image identified by ``container_image``.
 
-    This context manager will reset the authentication to the way it was after it exits. If
-    ``token`` is falsy, this context manager will do nothing.
+    The token is written to ``~/.docker/config.json`` under the most specific ``auths`` key that
+    container runtimes reliably match for that pull specification:
+
+    * ``registry/namespace/repo`` when ``container_image`` includes a namespace
+    * ``registry`` when the image has no namespace (for example, ``localhost:5000/myimage:tag``)
+
+    If the pull specification does not contain a resolvable registry, :exc:`IIBError` is raised.
+
+    Broader credentials already present in the Docker configuration, such as registry- or
+    namespace-level entries for the same host, are not modified. Only the scoped ``auths`` key
+    derived from ``container_image`` is set or overwritten.
+
+    On exit, the Docker configuration is reset to its pre-request state via
+    :func:`reset_docker_config`. If ``token`` or ``container_image`` is falsy, this context
+    manager does nothing.
 
     :param str token: the token in the format of ``username:password``
-    :param str container_image: the pull specification of the container image to parse to determine
-        the registry this token is for.
-    :param bool append: When enabled new token is appended to current configuration.
-        Old token for the same registry is overwritten.
+    :param str container_image: the pull specification of the image to authenticate to. Used to
+        determine which ``auths`` entry receives ``token``.
+    :param bool append: when ``True``, start from the current ``~/.docker/config.json`` (if it
+        exists) before applying the scoped token. This preserves unrelated ``auths`` entries and
+        is the preferred mode for ``overwrite_from_index`` callers that must override credentials
+        for a single index image without disturbing other registry configuration. When ``False``,
+        only the scoped ``auths`` entry and the worker template are merged.
     :return: None
     :rtype: None
+    :raises IIBError: if the pull specification does not contain a resolvable registry.
     """
     if not token:
         log.debug(
@@ -606,8 +648,10 @@ def set_registry_token(
 
         return
 
-    registry = ImageName.parse(container_image).registry
     encoded_token = base64.b64encode(token.encode('utf-8')).decode('utf-8')
+    auth_entry = {'auth': encoded_token}
+    auth_key = _docker_auth_key_for_image(container_image)
+
     registry_auths: Dict[str, Any] = {'auths': {}}
     if append:
         docker_config_path = os.path.join(os.path.expanduser('~'), '.docker', 'config.json')
@@ -621,8 +665,8 @@ def set_registry_token(
 
                 log.debug('Docker config will be updated')
 
-    log.debug('Setting the override token for the registry %s ', registry)
-    registry_auths['auths'].update({registry: {'auth': encoded_token}})
+    log.debug('Setting the override token for the image %s', auth_key)
+    registry_auths['auths'].update({auth_key: auth_entry})
 
     with set_registry_auths(registry_auths):
         yield

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -1285,7 +1285,8 @@ def test_handle_rm_request_fbc(
     mock_voe.return_value = {'some-operator'}, '/tmp/xyz/database/index.db'
     mock_govn.return_value = '0.9.0'
     mock_iifbc.return_value = True
-    from_index_resolved = 'from-index@sha256:bcdefg'
+    from_index = 'quay.io/iib/from-index:latest'
+    from_index_resolved = 'quay.io/iib/from-index@sha256:bcdefg'
     mock_prfb.return_value = {
         'arches': {'amd64', 's390x'},
         'binary_image': 'binary-image:latest',
@@ -1306,7 +1307,7 @@ def test_handle_rm_request_fbc(
     build.handle_rm_request(
         operators=operators,
         request_id=5,
-        from_index='from-index:latest',
+        from_index=from_index,
         binary_image='binary-image:latest',
         binary_image_config={'prod': {'v4.6': 'some_image'}},
         overwrite_from_index=True,
@@ -1316,7 +1317,7 @@ def test_handle_rm_request_fbc(
         5,
         RequestConfigAddRm(
             _binary_image='binary-image:latest',
-            from_index='from-index:latest',
+            from_index=from_index,
             overwrite_from_index_token=None,
             add_arches=None,
             binary_image_config={'prod': {'v4.6': 'some_image'}},
@@ -1328,7 +1329,7 @@ def test_handle_rm_request_fbc(
     mock_gcl.assert_called_once()
     mock_mcd.assert_called_once_with(mock.ANY, configs_dir)
     mock_voe.assert_called_once_with(
-        from_index='from-index:latest',
+        from_index=from_index,
         base_dir=mock.ANY,
         operator_packages=operators,
         overwrite_from_index_token='token',
@@ -1346,7 +1347,7 @@ def test_handle_rm_request_fbc(
         output_pull_spec=mock_capml.return_value,
         request_id=5,
         arches={'amd64', 's390x'},
-        from_index='from-index:latest',
+        from_index=from_index,
         overwrite_from_index=True,
         overwrite_from_index_token="token",
         resolved_prebuild_from_index=from_index_resolved,

--- a/tests/test_workers/test_tasks/test_build_fbc_operations.py
+++ b/tests/test_workers/test_tasks/test_build_fbc_operations.py
@@ -272,13 +272,16 @@ def test_handle_fbc_operation_request_with_overwrite_token(
 ):
     """Test FBC operation with overwrite_from_index_token."""
     request_id = 10
-    from_index = 'from-index:latest'
+    from_index = 'quay.io/iib/from-index:latest'
     binary_image = 'binary-image:latest'
     binary_image_config = {'prod': {'v4.5': 'some_image'}}
-    fbc_fragments = ['fbc-fragment1:latest', 'fbc-fragment2:latest']
+    fbc_fragments = [
+        'quay.io/iib/fbc-fragment1:latest',
+        'quay.io/iib/fbc-fragment2:latest',
+    ]
     overwrite_from_index_token = 'user:password'
     arches = {'amd64', 's390x'}
-    from_index_resolved = 'from-index@sha256:bcdefg'
+    from_index_resolved = 'quay.io/iib/from-index@sha256:bcdefg'
 
     mock_prfb.return_value = {
         'arches': arches,

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -96,17 +96,108 @@ def test_set_registry_token(
                         '4gU2ltcHNvbgo='
                     )
                 },
-                'registry.redhat.io': {'auth': 'dXNlcjpwYXNz'},
+                'registry.redhat.io/ns/repo': {'auth': 'dXNlcjpwYXNz'},
             }
         }
     else:
         mock_open.assert_called_once_with('/home/iib-worker/.docker/config.json', 'w')
         assert mock_open.call_count == 1
         assert mock_json_dump.call_args[0][0] == {
-            'auths': {'registry.redhat.io': {'auth': 'dXNlcjpwYXNz'}}
+            'auths': {'registry.redhat.io/ns/repo': {'auth': 'dXNlcjpwYXNz'}}
         }
 
     mock_rdc.assert_called_once_with()
+
+
+@mock.patch('os.path.expanduser')
+@mock.patch('os.remove')
+@mock.patch('os.path.exists', return_value=True)
+@mock.patch('iib.workers.tasks.utils.open')
+@mock.patch('iib.workers.tasks.utils.json.dump')
+@mock.patch('iib.workers.tasks.utils.reset_docker_config')
+def test_set_registry_token_registry_only_auth_key(
+    mock_rdc,
+    mock_json_dump,
+    mock_open,
+    mock_exists,
+    mock_remove,
+    mock_expanduser,
+):
+    mock_expanduser.return_value = '/home/iib-worker'
+    mock_open.side_effect = mock.mock_open(
+        read_data=r'{"auths": {"quay.io": {"auth": "cXVheV90b2tlbg=="}}}'
+    )
+
+    with utils.set_registry_token('user:pass', 'localhost:5000/myimage:tag'):
+        pass
+
+    assert mock_json_dump.call_args[0][0]['auths'] == {
+        'quay.io': {'auth': 'cXVheV90b2tlbg=='},
+        'localhost:5000': {'auth': 'dXNlcjpwYXNz'},
+    }
+    mock_rdc.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    'container_image, expected_auth_key',
+    (
+        pytest.param(
+            'registry.redhat.io/ns/repo:latest',
+            'registry.redhat.io/ns/repo',
+            id='namespaced-with-tag',
+        ),
+        pytest.param(
+            'registry.redhat.io/ns/repo@sha256:abc123deadbeef',
+            'registry.redhat.io/ns/repo',
+            id='namespaced-with-digest',
+        ),
+        pytest.param(
+            'quay.io/org/index@sha256:deadbeef',
+            'quay.io/org/index',
+            id='namespaced-digest-only',
+        ),
+        pytest.param(
+            'localhost:5000/myimage:tag',
+            'localhost:5000',
+            id='registry-without-namespace-tag',
+        ),
+        pytest.param(
+            'localhost:5000/myimage@sha256:abc123',
+            'localhost:5000',
+            id='registry-without-namespace-digest',
+        ),
+        pytest.param(
+            'myregistry.io:5000/',
+            'myregistry.io:5000',
+            id='registry-only',
+        ),
+    ),
+)
+def test_docker_auth_key_for_image(container_image, expected_auth_key):
+    assert utils._docker_auth_key_for_image(container_image) == expected_auth_key
+
+
+@pytest.mark.parametrize(
+    'container_image',
+    (
+        pytest.param('ubuntu:latest', id='short-name-with-tag'),
+        pytest.param('ubuntu', id='short-name-no-tag'),
+        pytest.param('registry.redhat.io', id='bare-registry-host'),
+        pytest.param('from-index:latest', id='test-short-name-with-tag'),
+        pytest.param('from-index@sha256:bcdefg', id='test-short-name-with-digest'),
+    ),
+)
+def test_docker_auth_key_for_image_unresolvable_registry(container_image):
+    with pytest.raises(IIBError, match='Unable to determine the registry'):
+        utils._docker_auth_key_for_image(container_image)
+
+
+@mock.patch('iib.workers.tasks.utils.ImageName.parse')
+def test_docker_auth_key_for_image_namespace_without_registry(mock_parse):
+    mock_parse.return_value = mock.Mock(registry=None, namespace='ns', repo='repo')
+
+    with pytest.raises(IIBError, match='Unable to determine the registry'):
+        utils._docker_auth_key_for_image('ns/repo:latest')
 
 
 @pytest.mark.parametrize('config_exists', (True, False))
@@ -176,6 +267,40 @@ def test_set_registry_auths(
         assert mock_open.call_count == 1
         assert mock_json_dump.call_args[0][0] == registry_auths
 
+    mock_rdc.assert_called_once_with()
+
+
+@mock.patch('os.path.expanduser')
+@mock.patch('os.path.exists', return_value=True)
+@mock.patch('iib.workers.tasks.utils.open')
+@mock.patch('iib.workers.tasks.utils.json.dump')
+@mock.patch('iib.workers.tasks.utils.reset_docker_config')
+def test_set_registry_token_append_overwrites_repo_auth(
+    mock_rdc,
+    mock_json_dump,
+    mock_open,
+    mock_exists,
+    mock_expanduser,
+):
+    mock_expanduser.return_value = '/home/iib-worker'
+    mock_open.side_effect = mock.mock_open(
+        read_data=(
+            r'{"auths": {"registry.redhat.io": {"auth": "cmVnaXN0cnlfdG9rZW4="}, '
+            r'"registry.redhat.io/ns": {"auth": "bmFtZXNwYWNlX3Rva2Vu"}, '
+            r'"registry.redhat.io/ns/repo": {"auth": "b2xkX3Rva2Vu"}, '
+            r'"quay.io": {"auth": "cXVheV90b2tlbg=="}}}'
+        )
+    )
+
+    with utils.set_registry_token('user:pass', 'registry.redhat.io/ns/repo:latest', append=True):
+        pass
+
+    assert mock_json_dump.call_args[0][0]['auths'] == {
+        'quay.io': {'auth': 'cXVheV90b2tlbg=='},
+        'registry.redhat.io': {'auth': 'cmVnaXN0cnlfdG9rZW4='},
+        'registry.redhat.io/ns': {'auth': 'bmFtZXNwYWNlX3Rva2Vu'},
+        'registry.redhat.io/ns/repo': {'auth': 'dXNlcjpwYXNz'},
+    }
     mock_rdc.assert_called_once_with()
 
 


### PR DESCRIPTION
Updated the set_registry_token function to allow for appending tokens specific to a repository while leaving registry-level credentials intact. Adjusted related tests to verify the new behavior, ensuring proper handling of authentication entries for both repository and registry levels.