### PR TITLE
Fix containerized regenerate-bundle handler and related_images function for add

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -693,6 +693,9 @@ def _skopeo_copy(
     cmd = ['skopeo', '--command-timeout', skopeo_timeout, 'copy', '--format', 'v2s2']
     if copy_all:
         cmd.append('--all')
+    # OCI layout does not support signatures
+    if destination.startswith('oci:'):
+        cmd.append('--remove-signatures')
     cmd.extend([source, destination])
 
     run_cmd(cmd, exc_msg=exc_msg or f'Failed to copy {source} to {destination}')

--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -742,11 +742,13 @@ def inspect_related_images(
         manifest_location = get_image_label(
             bundle, "operators.operatorframework.io.bundle.manifests.v1"
         )
+        if not manifest_location.startswith('/'):
+            manifest_location = f'/{manifest_location}'
         with tempfile.TemporaryDirectory(prefix=f'iib-{request_id}-') as temp_dir:
             extract_directory_from_image_non_privileged(
                 image=bundle, src_path=manifest_location, dest_path=temp_dir
             )
-            manifest_path = os.path.join(temp_dir, manifest_location)
+            manifest_path = os.path.join(temp_dir, os.path.basename(manifest_location.rstrip('/')))
             try:
                 operator_manifest = OperatorManifest.from_directory(manifest_path)
             except (ruamel.yaml.YAMLError, ruamel.yaml.constructor.DuplicateKeyError) as e:

--- a/iib/workers/tasks/build_containerized_regenerate_bundle.py
+++ b/iib/workers/tasks/build_containerized_regenerate_bundle.py
@@ -68,8 +68,8 @@ def handle_containerized_regenerate_bundle_request(
     registry_auths: Optional[Dict[str, Any]] = None,
     bundle_replacements: Optional[Dict[str, str]] = None,
     index_to_gitlab_push_map: Optional[Dict[str, str]] = None,
-    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
     regenerate_bundle_repo_key: str = 'regenerate-bundle',
+    binary_image_less_arches_allowed_versions: Optional[List[str]] = None,
 ) -> None:
     """
     Coordinate the work needed to regenerate the operator bundle image using containerized workflow.
@@ -86,7 +86,7 @@ def handle_containerized_regenerate_bundle_request(
     :param str regenerate_bundle_repo_key: the key to look up the actual repo URL from
       index_to_gitlab_push_map, defaults to ``regenerate-bundle``.
     :param list binary_image_less_arches_allowed_versions: list of versions of the binary image
-        that are allowed to build for less arches. Defaults to ``None``.
+      that are allowed to build for less arches. Defaults to ``None``.
     :raises IIBError: if the regenerate bundle image build fails.
     """
     bundle_replacements = bundle_replacements or {}

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -1740,6 +1740,33 @@ def test_inspect_related_images_fail(mock_gil, mock_edi, mock_fd, mock_gbd, mock
     ]
 
 
+@mock.patch('iib.workers.tasks.build.skopeo_inspect')
+@mock.patch('iib.workers.tasks.build.get_bundle_metadata')
+@mock.patch('iib.workers.tasks.build.OperatorManifest.from_directory')
+@mock.patch('iib.workers.tasks.build.extract_directory_from_image_non_privileged')
+@mock.patch('iib.workers.tasks.build.get_image_label')
+def test_inspect_related_images_relative_manifest_path(
+    mock_gil, mock_edi, mock_fd, mock_gbd, mock_si, tmpdir
+):
+    bundles = ['quay.io/repo/image@sha256:123']
+    request_id = 5
+    mock_gil.return_value = 'manifests/'
+    mock_fd.return_value = mock.ANY
+
+    mock_gbd.return_value = {
+        'found_pullspecs': set(
+            [
+                ImageName.parse('quay.io/related/image@sha256:1'),
+            ]
+        )
+    }
+    build.inspect_related_images(bundles=bundles, request_id=request_id)
+
+    mock_edi.assert_called_once()
+    call_kwargs = mock_edi.call_args
+    assert call_kwargs[1]['src_path'] == '/manifests/'
+
+
 @mock.patch('iib.workers.tasks.build._cleanup')
 @mock.patch('iib.workers.tasks.build.set_request_state')
 @mock.patch('iib.workers.tasks.build.get_resolved_bundles')

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -683,6 +683,18 @@ def test_skopeo_copy(mock_run_cmd, copy_all):
     mock_run_cmd.assert_called_once()
 
 
+@pytest.mark.parametrize('copy_all', (False, True))
+@mock.patch('iib.workers.tasks.build.run_cmd')
+def test_skopeo_copy_to_oci_removes_signatures(mock_run_cmd, copy_all):
+    source = 'docker://registry.example.com/image:latest'
+    destination = 'oci:/tmp/some-oci-dir'
+    build._skopeo_copy(source, destination, copy_all=copy_all)
+    skopeo_args = mock_run_cmd.mock_calls[0][1][0]
+    assert '--remove-signatures' in skopeo_args
+    assert skopeo_args.index('--remove-signatures') < skopeo_args.index(source)
+    mock_run_cmd.assert_called_once()
+
+
 @mock.patch('iib.workers.tasks.build.run_cmd')
 def test_skopeo_copy_fail_max_retries(mock_run_cmd):
     match_str = 'Something went wrong'


### PR DESCRIPTION
- commit 1: The tests use keyword arguments but the call uses positional args. Hence, the bug wasn't caught.
- commit 2: Bundle images set the manifests.v1 label to 'manifests/' (relative),
but extract_directory_from_image_non_privileged requires an absolute
container path. Normalize the label value to absolute and use basename
for the local extraction path to avoid os.path.join discarding temp_dir