### PR TITLE
skip converting empty yaml objects to json

### DIFF
--- a/iib/workers/tasks/fbc_utils.py
+++ b/iib/workers/tasks/fbc_utils.py
@@ -154,12 +154,16 @@ def enforce_json_config_dir(config_dir: str) -> None:
     It will walk recursively and convert any YAML files to the JSON format.
 
     :param str config_dir: The config dir to walk recursively converting any YAML to JSON.
+    :raises IIBError: If the yaml content is empty.
     """
     log.info("Enforcing JSON content on config_dir: %s", config_dir)
     for dirpath, _, filenames in os.walk(config_dir):
         for file in filenames:
             in_file = os.path.join(dirpath, file)
-            if in_file.lower().endswith(".yaml"):
+            if in_file.lower().endswith(".yaml") or in_file.lower().endswith(".yml"):
+                if os.path.getsize(in_file) == 0:
+                    raise IIBError(f"Empty YAML file found: {in_file}")
+
                 out_file = os.path.join(dirpath, f"{Path(in_file).stem}.json")
                 log.debug(f"Converting {in_file} to {out_file}.")
                 # Make sure the output file doesn't exist before opening in append mode
@@ -169,5 +173,8 @@ def enforce_json_config_dir(config_dir: str) -> None:
                 with open(in_file, 'r') as yaml_in, open(out_file, 'a') as json_out:
                     data = yaml.load_all(yaml_in)
                     for chunk in data:
+                        # Ignore if it is an empty yaml object
+                        if chunk is None:
+                            continue
                         json.dump(chunk, json_out, default=_serialize_datetime)
                 os.remove(in_file)

--- a/tests/test_workers/test_tasks/test_fbc_utils.py
+++ b/tests/test_workers/test_tasks/test_fbc_utils.py
@@ -300,3 +300,53 @@ def test__serialize_datetime():
 def test__serialize_datetime_raise():
     with pytest.raises(TypeError, match="Type <class 'int'> is not serializable."):
         _serialize_datetime(2025)
+
+
+def test_enforce_json_config_dir_skips_empty_yaml_documents(tmpdir):
+    yaml_with_empty_doc = """\
+    ---
+    foo: bar
+    ---
+    ---
+    another: data
+    """
+
+    expected_result = '{"foo": "bar"}{"another": "data"}'
+
+    input_file = os.path.join(tmpdir, "test_file.yaml")
+    output_file = os.path.join(tmpdir, "test_file.json")
+    with open(input_file, 'w') as w:
+        w.write(dedent(yaml_with_empty_doc))
+
+    enforce_json_config_dir(tmpdir)
+
+    with open(output_file, 'r') as f:
+        assert f.read() == expected_result
+
+
+def test_enforce_json_config_dir_raises_on_empty_yaml(tmpdir):
+    """Ensure a 0-byte YAML file raises a IIBError."""
+    empty_yaml = os.path.join(tmpdir, "empty.yaml")
+
+    # Create a 0-byte file
+    open(empty_yaml, 'w').close()
+
+    with pytest.raises(IIBError) as exc_info:
+        enforce_json_config_dir(str(tmpdir))
+
+    assert "Empty YAML file found" in str(exc_info.value)
+    assert "empty.yaml" in str(exc_info.value)
+
+
+def test_enforce_json_config_dir_handles_yml_extension(tmpdir):
+    """Ensure files with the .yml extension are also processed."""
+    input_file = os.path.join(tmpdir, "test_file.yml")
+    output_file = os.path.join(tmpdir, "test_file.json")
+
+    with open(input_file, 'w') as w:
+        w.write("key: value")
+
+    enforce_json_config_dir(str(tmpdir))
+
+    assert os.path.exists(output_file)
+    assert not os.path.exists(input_file)


### PR DESCRIPTION
PTAL, this one skips empty YAML documents during FBC YAML→JSON conversion to prevent emitting null objects that breaks opm validate while performing add operations. 
Also fixes a bug for including conversion for .yml file too.