### PR TITLE
Dockerfiles and CI builds of main

### DIFF
--- a/.github/workflows/build_base_image.yml
+++ b/.github/workflows/build_base_image.yml
@@ -1,0 +1,54 @@
+---
+# Reusable workflow: build and push iib-base-image to Quay.
+#
+# Invoked by:
+#   - build_on_main.yml when docker/Dockerfile-base-image changed on merge to main
+#   - workflow_dispatch for manual rebuilds and one-time bootstrap (see docker/README.md)
+#
+# Bootstrap: run this workflow manually via workflow_dispatch BEFORE the first merge to main
+# that triggers build_on_main.yml, so iib-base-image:latest exists on Quay when Dockerfile-workers
+# is built. Without it, the worker build fails on FROM quay.io/.../iib-base-image:latest.
+#
+# Not triggered directly on push (orchestrated via build_on_main.yml to avoid racing
+# iib-worker against a stale base image on Quay).
+name: Build base image and push to quay.io
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    secrets:
+      REGISTRY_QUAY_IO_USER:
+        required: true
+      REGISTRY_QUAY_IO_PASSWORD:
+        required: true
+  workflow_dispatch:
+
+jobs:
+  deployments:
+    name: Build and Push iib-base-image to quay.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build iib-base-image
+        id: build-iib-base-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: iib-base-image
+          tags: latest
+          dockerfiles: |
+            ./docker/Dockerfile-base-image
+
+      - name: Push iib-base-image to quay.io
+        id: push-iib-base-image
+        uses: redhat-actions/push-to-registry@v2.7.1
+        with:
+          image: ${{ steps.build-iib-base-image.outputs.image }}
+          tags: ${{ steps.build-iib-base-image.outputs.tags }}
+          registry: quay.io/exd-guild-hello-operator
+          username: ${{ secrets.REGISTRY_QUAY_IO_USER }}
+          password: ${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}

--- a/.github/workflows/build_on_main.yml
+++ b/.github/workflows/build_on_main.yml
@@ -1,0 +1,113 @@
+---
+# Build and push iib-api and iib-worker images after every merge to main.
+#
+# Job orchestration:
+#   - iib-api: always built (uses UBI9 directly, no base-image dependency).
+#   - iib-base-image: built only when docker/Dockerfile-base-image changed in the push.
+#   - iib-worker: always built, but waits for iib-base-image when that job ran so the
+#     worker image pulls the freshly pushed base image from Quay (not a stale :latest).
+#
+# Tags pushed to quay.io/exd-guild-hello-operator: iib-api:ocp-latest, iib-worker:ocp-latest.
+# For release-tagged images see .github/workflows/build.yml.
+#
+# Bootstrap: iib-base-image:latest must already exist on Quay before the first run (see
+# docker/README.md). Trigger build_base_image.yml manually via workflow_dispatch once.
+name: Build images on main merge
+
+permissions:
+  contents: read
+
+on:
+  # Runs on every push to main, including PR merges.
+  push:
+    branches:
+      - main
+
+jobs:
+  # Detect whether this push modified the base image Dockerfile.
+  # Output base_image=true triggers the reusable base-image workflow below.
+  detect_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      base_image: ${{ steps.filter.outputs.base_image }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so paths-filter can diff against the previous commit on main.
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            base_image:
+              - 'docker/Dockerfile-base-image'
+
+  # Runs only when docker/Dockerfile-base-image changed in this push.
+  # Skipped otherwise; iib-worker proceeds without waiting.
+  build_base_image:
+    needs: detect_changes
+    if: needs.detect_changes.outputs.base_image == 'true'
+    uses: ./.github/workflows/build_base_image.yml
+    secrets:
+      REGISTRY_QUAY_IO_USER: ${{ secrets.REGISTRY_QUAY_IO_USER }}
+      REGISTRY_QUAY_IO_PASSWORD: ${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}
+
+  # Always runs in parallel with detect_changes / build_base_image.
+  # Does not depend on iib-base-image (Dockerfile-api starts from UBI9).
+  build_iib_api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build iib-api
+        id: build-iib-api
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: iib-api
+          tags: ocp-latest
+          dockerfiles: |
+            ./docker/Dockerfile-api
+
+      - name: Push iib-api to quay.io
+        id: push-iib-api
+        uses: redhat-actions/push-to-registry@v2.7.1
+        with:
+          image: ${{ steps.build-iib-api.outputs.image }}
+          tags: ${{ steps.build-iib-api.outputs.tags }}
+          registry: quay.io/exd-guild-hello-operator
+          username: ${{ secrets.REGISTRY_QUAY_IO_USER }}
+          password: ${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}
+
+  # Always runs after build_base_image completes or is skipped.
+  # Waits when base image was rebuilt so Dockerfile-workers can FROM the new :latest on Quay.
+  # Skipped only if build_base_image failed (worker must not build against a failed base push).
+  build_iib_worker:
+    needs: [detect_changes, build_base_image]
+    if: |
+      always() &&
+      !cancelled() &&
+      (needs.build_base_image.result == 'success' || needs.build_base_image.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build iib-worker
+        id: build-iib-worker
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: iib-worker
+          tags: ocp-latest
+          dockerfiles: |
+            ./docker/Dockerfile-workers
+
+      - name: Push iib-worker to quay.io
+        id: push-iib-worker
+        uses: redhat-actions/push-to-registry@v2.7.1
+        with:
+          image: ${{ steps.build-iib-worker.outputs.image }}
+          tags: ${{ steps.build-iib-worker.outputs.tags }}
+          registry: quay.io/exd-guild-hello-operator
+          username: ${{ secrets.REGISTRY_QUAY_IO_USER }}
+          password: ${{ secrets.REGISTRY_QUAY_IO_PASSWORD }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Two components connected by RabbitMQ:
 Request types (each a `POST /builds/<type>` endpoint + celery task in `iib/workers/tasks/build_containerized*.py`): add, rm, merge-index-image, regenerate-bundle, fbc-operations, create-empty-index.
 
 ## Build
-Production: API and Worker images are built from Dockerfiles in `docker/containerized/` and deployed in OpenShift pods.
+Production images: `docker/Dockerfile-api`, `docker/Dockerfile-workers` (two-stage; base in `docker/Dockerfile-base-image`, published to Quay — see `docker/README.md`). Deployed in OpenShift pods.
 Local dev: (containerized workflow): See `docker/containerized/README.md` for full setup. Requires Konflux cluster credentials and GitLab tokens.
 Legacy local dev: `make up` / `make down` (docker-compose) spins up api, worker, db, rabbitmq, memcached, registry (TLS), jaeger.
 Entry points: WSGI `iib/web/wsgi.py`, CLI `iib` (e.g. `iib db upgrade`), worker `celery -A iib.workers.tasks worker`.

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ down:
 
 build:
 	@echo "Building the container images for the local development instance..."
-	${IIB_COMPOSE_RUNNER} build
+	${IIB_COMPOSE_RUNNER} build iib-base-image
+	${IIB_COMPOSE_RUNNER} build iib-worker iib-api message-broker
 
 test:
 	@tox

--- a/README.md
+++ b/README.md
@@ -83,6 +83,35 @@ development environment. This will automatically run the following containers:
 It's recommended to use the wrapper targets in the `Makefile` for pre-requisites. Simply run `make`
 to view available targets.
 
+### Container Images
+
+The worker image uses a two-stage Dockerfile layout. See **[docker/README.md](docker/README.md)**
+for the full architecture (registry dependencies, CI build order, and local vs production
+workflows).
+
+Summary:
+* **`docker/Dockerfile-base-image`** — shared tooling layer (opm, buildah, podman, oras, oc
+  client, Red Hat CA certificates, etc.). Published to Quay as
+  `quay.io/exd-guild-hello-operator/iib-base-image:latest` by CI when the file changes on merge
+  to `main`.
+* **`docker/Dockerfile-workers`** — worker-specific setup and Python dependencies. Starts from the
+  base image above (overridable via the `BASE_IMAGE` build argument).
+* **`docker/Dockerfile-api`** — standalone image built directly from UBI9; it does not use the
+  worker base image.
+
+For local development, `docker-compose` / `podman-compose` build the base image as
+`iib-base-image:local` and pass it to the worker build. Run `make build` before `make up` — the
+`build` target builds `iib-base-image` first, then the application images. Re-run `make build`
+after changing `docker/Dockerfile-base-image`.
+
+To build the worker against the Quay base image instead (e.g. when you have not changed the base
+Dockerfile locally), override the build argument:
+
+```bash
+docker compose -f compose-files/docker-compose.yml build \
+  --build-arg BASE_IMAGE=quay.io/exd-guild-hello-operator/iib-base-image:latest iib-worker
+```
+
 The Flask application will automatically reload if there is a change in the codebase. If invalid
 syntax is added in the code, the `iib-api` container may shutdown. The Celery worker will
 automatically restart if there is a change under the `iib/workers` directory.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ to view available targets.
 
 ### Container Images
 
-The worker image uses a two-stage Dockerfile layout. See **[docker/README.md](docker/README.md)**
+The worker image uses a two-stage Dockerfile layout. See
+**[docker/README.md](https://github.com/release-engineering/iib/blob/main/docker/README.md)**
 for the full architecture (registry dependencies, CI build order, and local vs production
 workflows).
 
@@ -103,6 +104,12 @@ For local development, `docker-compose` / `podman-compose` build the base image 
 `iib-base-image:local` and pass it to the worker build. Run `make build` before `make up` — the
 `build` target builds `iib-base-image` first, then the application images. Re-run `make build`
 after changing `docker/Dockerfile-base-image`.
+
+**CI bootstrap:** before the first merge to `main` that uses the two-stage worker build, run
+the [Build base image and push to quay.io](https://github.com/release-engineering/iib/actions/workflows/build_base_image.yml)
+workflow manually via GitHub Actions `workflow_dispatch` so `iib-base-image:latest` exists on Quay.
+Details in
+[docker/README.md#bootstrap-first-time-setup](https://github.com/release-engineering/iib/blob/main/docker/README.md#bootstrap-first-time-setup).
 
 To build the worker against the Quay base image instead (e.g. when you have not changed the base
 Dockerfile locally), override the build argument:

--- a/compose-files/docker-compose.yml
+++ b/compose-files/docker-compose.yml
@@ -111,10 +111,20 @@ services:
       - message-broker
       - jaeger
 
+  # Build-only service: shared worker base image (opm, buildah, podman, etc.).
+  # iib-worker builds FROM this image locally; run `make build` to build it first.
+  iib-base-image:
+    build:
+      context: ..
+      dockerfile: ./docker/Dockerfile-base-image
+    image: iib-base-image:local
+
   iib-worker:
     build:
       context: ..
       dockerfile: ./docker/Dockerfile-workers
+      args:
+        BASE_IMAGE: iib-base-image:local
     # Override the default command so that Celery auto-reloads on code changes.
     # This also adds the self-signed CA that was used to sign the Docker registry's certificate
     # to the trusted CA bundle. This will make podman trust the local Docker registry's certificate.

--- a/compose-files/podman-compose.yml
+++ b/compose-files/podman-compose.yml
@@ -109,10 +109,20 @@ services:
       - message-broker
       - jaeger
 
+  # Build-only service: shared worker base image (opm, buildah, podman, etc.).
+  # iib-worker builds FROM this image locally; run `make build` to build it first.
+  iib-base-image:
+    build:
+      context: ..
+      dockerfile: ./docker/Dockerfile-base-image
+    image: iib-base-image:local
+
   iib-worker:
     build:
       context: ..
       dockerfile: ./docker/Dockerfile-workers
+      args:
+        BASE_IMAGE: iib-base-image:local
     # Override the default command so that Celery auto-reloads on code changes.
     # This also adds the self-signed CA that was used to sign the Docker registry's certificate
     # to the trusted CA bundle. This will make podman trust the local Docker registry's certificate.

--- a/docker/Dockerfile-base-image
+++ b/docker/Dockerfile-base-image
@@ -1,0 +1,89 @@
+# iib-base-image — shared worker tooling layer (opm, buildah, podman, oras, oc, Kerberos, etc.).
+# Published to quay.io/exd-guild-hello-operator/iib-base-image:latest by CI.
+# Dockerfile-workers builds on top of this image; see docker/README.md for architecture.
+FROM registry.access.redhat.com/ubi9/ubi:latest
+LABEL maintainer="Red Hat - EXD"
+
+RUN dnf -y install \
+    --setopt=deltarpm=0 \
+    --setopt=install_weak_deps=false \
+    --setopt=tsflags=nodocs \
+    /etc/containers/storage.conf \
+    buildah \
+    fuse-overlayfs \
+    gcc \
+    tar \
+    gzip \
+    git \
+    krb5-devel \
+    krb5-workstation \
+    libffi-devel \
+    libpq-devel \
+    openssl-devel \
+    podman \
+    python3.12-devel \
+    python3.12-pip \
+    python3.12-wheel \
+    runc \
+    skopeo \
+    && dnf update -y \
+    && dnf clean all
+
+# Install all opm variants,
+# then expose the default opm via symlink.
+RUN set -eux; \
+    install_binary() { \
+      local name="$1"; local url="$2"; local sha="$3"; \
+      curl -fsSL "$url" -o "/usr/local/bin/${name}"; \
+      echo "${sha}  /usr/local/bin/${name}" | sha256sum -c -; \
+      chmod 0555 "/usr/local/bin/${name}"; \
+    }; \
+    install_binary "opm-v1.26.4" "https://github.com/operator-framework/operator-registry/releases/download/v1.26.4/linux-amd64-opm" "cf94e9dbd58c338e1eed03ca50af847d24724b99b40980812abbe540e8c7ff8e"; \
+    install_binary "opm-v1.28.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.28.0/linux-amd64-opm" "e18e5abc8febb63c9dc76db0f33475553d98495465bd2dca81c39dcdbc875c08"; \
+    install_binary "opm-v1.40.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.40.0/linux-amd64-opm" "33eb929264a69f31895e1973248b7e97e3b6a862d7ca27f6892e158f79ad6aeb"; \
+    install_binary "opm-v1.44.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.44.0/linux-amd64-opm" "21f0a423dfbfcddcffdde98266307a08d87b4db980be859b9e252a5a24df51bf"; \
+    install_binary "opm-v1.48.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.48.0/linux-amd64-opm" "0a301826baff730489162caff13e04f7dc16c1a79072cbcbdfc5379d95caef40"; \
+    install_binary "opm-v1.50.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.50.0/linux-amd64-opm" "d9bfdc08dd9640c1d9085d191f10f884f2ef29370db1ac097a73a0e23e803f95"; \
+    install_binary "opm-v1.57.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.57.0/linux-amd64-opm" "8d2f51f166f47f76eb6906c4de9af90462b7163cbacef6c932bda4829ec086c7"; \
+    install_binary "opm-v1.61.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.61.0/linux-amd64-opm" "c5701ef59e12c930337a9a9363cd44c2a4d9f64f6d4f96513d3511a36f81cf5d"; \
+    install_binary "operator-sdk" "https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/operator-sdk_linux_amd64" "d2065f1f7a0d03643ad71e396776dac0ee809ef33195e0f542773b377bab1b2a"; \
+    # set default opm \
+    ln -sfn /usr/local/bin/opm-v1.26.4 /usr/local/bin/opm
+
+RUN set -eux; \
+    install_archive() { \
+      local archive="$1"; local url="$2"; local sha="$3"; local dest="$4"; shift 4; \
+      curl -fsSL "$url" -o "/tmp/${archive}"; \
+      echo "${sha}  /tmp/${archive}" | sha256sum -c -; \
+      tar -xf "/tmp/${archive}" -C "${dest}" "$@"; \
+      rm -f "/tmp/${archive}"; \
+    }; \
+    install_archive "grpcurl_1.8.5_linux_x86_64.tar.gz" \
+      "https://github.com/fullstorydev/grpcurl/releases/download/v1.8.5/grpcurl_1.8.5_linux_x86_64.tar.gz" \
+      "20d1cca65dec077189472eb0f89290661e35d16892cfc9619e9e1fc6bb53dcac" \
+      "/usr/bin" grpcurl; \
+    install_archive "oc_client.tar.gz" \
+      "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.10/openshift-client-linux.tar.gz" \
+      "58179cea8f8458bcaa301b2923f0ee295c44ce454aeefb34662f8a4789593f76" \
+      "/usr/bin"; \
+    rm -f /usr/bin/README.md; \
+    install_archive "oras_1.3.0_linux_amd64.tar.gz" \
+      "https://github.com/oras-project/oras/releases/download/v1.3.0/oras_1.3.0_linux_amd64.tar.gz" \
+      "6cdc692f929100feb08aa8de584d02f7bcc30ec7d88bc2adc2054d782db57c64" \
+      "/usr/bin"; \
+    rm -f /usr/bin/LICENSE
+
+
+# UBI9 doesn't come with alternatives installed for python3 by default, so we need to set it manually
+RUN update-alternatives --install /usr/bin/python3 python3 $(which python3.12) 1
+RUN update-alternatives --install /usr/bin/pip3 pip3 $(which pip3.12) 1
+
+# Adjust storage.conf to enable Fuse storage.
+RUN sed -i -e 's|^#mount_program|mount_program|g' /etc/containers/storage.conf
+COPY docker/libpod.conf /usr/share/containers/libpod.conf
+
+RUN set -eux; \
+    curl -fsSL "https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem" \
+      -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem; \
+    echo "e9713aed04b4ef3003edd10fc9c4f8ab875436e4a44195f0cbafcdf95e9bad2c  /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem" | sha256sum -c -; \
+    update-ca-trust

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,76 +1,14 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+# iib-worker — Celery worker image built on iib-base-image.
+# Production default pulls the base from Quay; local compose overrides BASE_IMAGE to
+# iib-base-image:local. See docker/README.md for the two-stage build architecture.
+ARG BASE_IMAGE=quay.io/exd-guild-hello-operator/iib-base-image:latest
+FROM ${BASE_IMAGE}
 LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src
 
-RUN dnf -y install \
-    --setopt=deltarpm=0 \
-    --setopt=install_weak_deps=false \
-    --setopt=tsflags=nodocs \
-    /etc/containers/storage.conf \
-    buildah \
-    fuse-overlayfs \
-    gcc \
-    tar \
-    gzip \
-    git \
-    krb5-devel \
-    libffi-devel \
-    libpq-devel \
-    openssl-devel \
-    podman \
-    python3.12-devel \
-    python3.12-pip \
-    python3.12-wheel \
-    runc \
-    skopeo \
-    && dnf update -y \
-    && dnf clean all
-
-# Install all opm variants,
-# then expose the default opm via symlink.
-RUN set -eux; \
-    install_binary() { \
-      local name="$1"; local url="$2"; local sha="$3"; \
-      curl -fsSL "$url" -o "/usr/local/bin/${name}"; \
-      echo "${sha}  /usr/local/bin/${name}" | sha256sum -c -; \
-      chmod 0555 "/usr/local/bin/${name}"; \
-    }; \
-    install_binary "opm-v1.26.4" "https://github.com/operator-framework/operator-registry/releases/download/v1.26.4/linux-amd64-opm" "cf94e9dbd58c338e1eed03ca50af847d24724b99b40980812abbe540e8c7ff8e"; \
-    install_binary "opm-v1.28.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.28.0/linux-amd64-opm" "e18e5abc8febb63c9dc76db0f33475553d98495465bd2dca81c39dcdbc875c08"; \
-    install_binary "opm-v1.40.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.40.0/linux-amd64-opm" "33eb929264a69f31895e1973248b7e97e3b6a862d7ca27f6892e158f79ad6aeb"; \
-    install_binary "opm-v1.44.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.44.0/linux-amd64-opm" "21f0a423dfbfcddcffdde98266307a08d87b4db980be859b9e252a5a24df51bf"; \
-    install_binary "opm-v1.48.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.48.0/linux-amd64-opm" "0a301826baff730489162caff13e04f7dc16c1a79072cbcbdfc5379d95caef40"; \
-    install_binary "opm-v1.50.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.50.0/linux-amd64-opm" "d9bfdc08dd9640c1d9085d191f10f884f2ef29370db1ac097a73a0e23e803f95"; \
-    install_binary "opm-v1.57.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.57.0/linux-amd64-opm" "8d2f51f166f47f76eb6906c4de9af90462b7163cbacef6c932bda4829ec086c7"; \
-    install_binary "opm-v1.61.0" "https://github.com/operator-framework/operator-registry/releases/download/v1.61.0/linux-amd64-opm" "c5701ef59e12c930337a9a9363cd44c2a4d9f64f6d4f96513d3511a36f81cf5d"; \
-    install_binary "operator-sdk" "https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/operator-sdk_linux_amd64" "d2065f1f7a0d03643ad71e396776dac0ee809ef33195e0f542773b377bab1b2a"; \
-    # set default opm \
-    ln -sfn /usr/local/bin/opm-v1.26.4 /usr/local/bin/opm
-
-ADD https://github.com/fullstorydev/grpcurl/releases/download/v1.8.5/grpcurl_1.8.5_linux_x86_64.tar.gz /src/grpcurl_1.8.5_linux_x86_64.tar.gz
-RUN cd /usr/bin && tar -xf /src/grpcurl_1.8.5_linux_x86_64.tar.gz grpcurl && rm -f /src/grpcurl_1.8.5_linux_x86_64.tar.gz
-
-RUN curl -L "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.10/openshift-client-linux.tar.gz" -o /tmp/oc_client.tar.gz && \
-    tar -xvzf /tmp/oc_client.tar.gz -C /usr/bin/ && \
-    rm /tmp/oc_client.tar.gz /usr/bin/README.md
-
-RUN curl -L "https://github.com/oras-project/oras/releases/download/v1.3.0/oras_1.3.0_linux_amd64.tar.gz" -o /tmp/oras.tar.gz && \
-    tar -xvzf /tmp/oras.tar.gz -C /usr/bin/ && \
-    rm /tmp/oras.tar.gz /usr/bin/LICENSE
-
-RUN git config --global user.email "exd-guild-hello-operator+iib-dev-env@redhat.com"
-RUN git config --global user.name "IIB dev-env"
-
-# UBI9 doesn't come with alternatives installed for python3 by default, so we need to set it manually
-RUN update-alternatives --install /usr/bin/python3 python3 $(which python3.12) 1
-RUN update-alternatives --install /usr/bin/pip3 pip3 $(which pip3.12) 1
-
-# Adjust storage.conf to enable Fuse storage.
-RUN sed -i -e 's|^#mount_program|mount_program|g' /etc/containers/storage.conf
-COPY docker/libpod.conf /usr/share/containers/libpod.conf
-
-COPY . .
+RUN git config --global user.email "exd-guild-hello-operator+iib-worker@redhat.com"
+RUN git config --global user.name "iib worker"
 
 # Prepare writable HOME for OpenShift random UID runtime.
 RUN mkdir -p /home/iib-worker/.docker \
@@ -79,6 +17,13 @@ RUN mkdir -p /home/iib-worker/.docker \
 ENV HOME=/home/iib-worker
 ENV KRB5CCNAME=FILE:/home/iib-worker/krb5cc_iib_worker
 
+# Dependency layers: copy only lockfiles first so code edits reuse pip cache.
+COPY requirements.txt setup.py MANIFEST.in LICENSE ./
+RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt --no-deps --require-hashes
+
+# Must stay inside build context (no ``..``). Default ``iib`` = package dir at repo root.
+ARG IIB_PKG_SRC=iib
+COPY ${IIB_PKG_SRC} ./iib/
 RUN pip3 install . --no-deps
 CMD ["/usr/local/bin/celery", "-A", "iib.workers.tasks", "worker", "--loglevel=debug"]


### PR DESCRIPTION
Move tooling and runtime packages (opm, buildah, oras, oc client, etc.)
from docker/Dockerfile-workers into a new docker/Dockerfile-base-image.

Dockerfile-workers now builds FROM
quay.io/exd-guild-hello-operator/iib-base-image:latest, keeping only
worker-specific setup on top of the shared base layer.

Introduce .github/workflows/build_base_image.yml as a workflow_call
target (and workflow_dispatch for manual runs) that builds and pushes
iib-base-image:latest to quay.io/exd-guild-hello-operator.

The workflow is designed to be invoked from build_on_main.yml so worker
builds can wait for a fresh base image when Dockerfile-base-image changes.

Add build_on_main.yml to build and push iib-api:ocp-latest and
iib-worker:ocp-latest after each push to main. Rebuild iib-base-image
only when docker/Dockerfile-base-image changed; iib-worker waits for
that job so it does not pull a stale base image from Quay.