### PR TITLE
Fix cache digest comparison by using oras manifest fetch instead of client-side hash

### DIFF
--- a/iib/workers/tasks/oras_utils.py
+++ b/iib/workers/tasks/oras_utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """This file contains functions for ORAS (OCI Registry As Storage) operations."""
+import json
 import logging
 import os
 import re
@@ -10,7 +11,7 @@ from typing import Any, Dict, Optional, Tuple
 from iib.common.tracing import instrument_tracing
 from iib.exceptions import IIBError
 from iib.workers.config import get_worker_config
-from iib.workers.tasks.utils import run_cmd, set_registry_auths, get_image_digest
+from iib.workers.tasks.utils import run_cmd, set_registry_auths, get_image_digest  # noqa: F401
 
 log = logging.getLogger(__name__)
 
@@ -265,7 +266,16 @@ def verify_indexdb_cache_sync(tag: str) -> bool:
         registry=conf['iib_index_db_artifact_registry'], tag=tag
     )
 
-    quay_digest = get_image_digest(artifact_pullspec)
+    oras_exclusive_auth_path = conf['iib_index_db_oras_auth_path']
+    cmd_args = []
+    if oras_exclusive_auth_path and os.path.exists(oras_exclusive_auth_path):
+        cmd_args = ['--registry-config', oras_exclusive_auth_path]
+
+    descriptor = run_cmd(
+        ['oras', 'manifest', 'fetch', '--descriptor', *cmd_args, artifact_pullspec],
+        exc_msg=f'Failed to fetch manifest descriptor for {artifact_pullspec}',
+    )
+    quay_digest = json.loads(descriptor)['digest']
     is_digest = get_image_stream_digest(tag)
 
     return quay_digest == is_digest

--- a/tests/test_workers/test_tasks/test_oras_utils.py
+++ b/tests/test_workers/test_tasks/test_oras_utils.py
@@ -432,42 +432,85 @@ def test_get_image_stream_digest_failure(mock_run_cmd):
 
 @mock.patch('iib.workers.tasks.oras_utils.get_worker_config')
 @mock.patch('iib.workers.tasks.oras_utils.get_image_stream_digest')
-@mock.patch('iib.workers.tasks.oras_utils.get_image_digest')
-def test_verify_indexdb_cache_sync_match(mock_get_image_digest, mock_get_is_digest, mock_gwc):
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_verify_indexdb_cache_sync_match(mock_run_cmd, mock_get_is_digest, mock_gwc):
     """Test successful verification when digests match."""
     mock_gwc.return_value = {
         'iib_index_db_artifact_registry': 'test-artifact-registry',
         'iib_index_db_artifact_template': '{registry}/index-db:{tag}',
+        'iib_index_db_oras_auth_path': '',
     }
-    mock_get_image_digest.return_value = 'sha256:abc'
+    mock_run_cmd.return_value = '{"digest": "sha256:abc"}'
     mock_get_is_digest.return_value = 'sha256:abc'
     tag = 'test-tag'
 
     result = verify_indexdb_cache_sync(tag)
 
     assert result is True
-    mock_get_image_digest.assert_called_once_with('test-artifact-registry/index-db:test-tag')
+    mock_run_cmd.assert_called_once_with(
+        ['oras', 'manifest', 'fetch', '--descriptor', 'test-artifact-registry/index-db:test-tag'],
+        exc_msg='Failed to fetch manifest descriptor for test-artifact-registry/index-db:test-tag',
+    )
     mock_get_is_digest.assert_called_once_with(tag)
 
 
 @mock.patch('iib.workers.tasks.oras_utils.get_worker_config')
 @mock.patch('iib.workers.tasks.oras_utils.get_image_stream_digest')
-@mock.patch('iib.workers.tasks.oras_utils.get_image_digest')
-def test_verify_indexdb_cache_sync_no_match(mock_get_image_digest, mock_get_is_digest, mock_gwc):
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_verify_indexdb_cache_sync_no_match(mock_run_cmd, mock_get_is_digest, mock_gwc):
     """Test successful verification when digests don't match."""
     mock_gwc.return_value = {
         'iib_index_db_artifact_registry': 'test-artifact-registry',
         'iib_index_db_artifact_template': '{registry}/index-db:{tag}',
+        'iib_index_db_oras_auth_path': '',
     }
-    mock_get_image_digest.return_value = 'sha256:abc'
+    mock_run_cmd.return_value = '{"digest": "sha256:abc"}'
     mock_get_is_digest.return_value = 'sha256:xyz'
     tag = 'test-tag'
 
     result = verify_indexdb_cache_sync(tag)
 
     assert result is False
-    mock_get_image_digest.assert_called_once_with('test-artifact-registry/index-db:test-tag')
+    mock_run_cmd.assert_called_once_with(
+        ['oras', 'manifest', 'fetch', '--descriptor', 'test-artifact-registry/index-db:test-tag'],
+        exc_msg='Failed to fetch manifest descriptor for test-artifact-registry/index-db:test-tag',
+    )
     mock_get_is_digest.assert_called_once_with(tag)
+
+
+@mock.patch('os.path.exists')
+@mock.patch('iib.workers.tasks.oras_utils.get_worker_config')
+@mock.patch('iib.workers.tasks.oras_utils.get_image_stream_digest')
+@mock.patch('iib.workers.tasks.oras_utils.run_cmd')
+def test_verify_indexdb_cache_sync_with_oras_auth(
+    mock_run_cmd, mock_get_is_digest, mock_gwc, mock_exists
+):
+    """Test that --registry-config is passed when oras auth path exists."""
+    mock_gwc.return_value = {
+        'iib_index_db_artifact_registry': 'test-artifact-registry',
+        'iib_index_db_artifact_template': '{registry}/index-db:{tag}',
+        'iib_index_db_oras_auth_path': '/path/to/oras/config.json',
+    }
+    mock_exists.return_value = True
+    mock_run_cmd.return_value = '{"digest": "sha256:abc"}'
+    mock_get_is_digest.return_value = 'sha256:abc'
+    tag = 'test-tag'
+
+    result = verify_indexdb_cache_sync(tag)
+
+    assert result is True
+    mock_run_cmd.assert_called_once_with(
+        [
+            'oras',
+            'manifest',
+            'fetch',
+            '--descriptor',
+            '--registry-config',
+            '/path/to/oras/config.json',
+            'test-artifact-registry/index-db:test-tag',
+        ],
+        exc_msg='Failed to fetch manifest descriptor for test-artifact-registry/index-db:test-tag',
+    )
 
 
 @mock.patch('iib.workers.tasks.oras_utils.get_worker_config')


### PR DESCRIPTION

get_image_digest computes a client-side sha256 of the raw manifest bytes from skopeo, which doesn't match the registry-assigned digest stored in the OpenShift ImageStream. Additionally, skopeo inspect without --raw fails entirely on ORAS artifacts.

Replace with oras manifest fetch --descriptor which returns the registry-assigned digest, matching what oc import-image stores in the ImageStream.