### PR TITLE
Fix Git FBC catalog divergence after bundle deprecation in containerized handlers

### DIFF
--- a/iib/workers/tasks/build_containerized_add.py
+++ b/iib/workers/tasks/build_containerized_add.py
@@ -45,11 +45,11 @@ from iib.workers.tasks.utils import (
     chmod_recursively,
     get_bundles_from_deprecation_list,
     get_resolved_bundles,
+    remove_deprecated_operators_from_git_catalog,
     request_logger,
     reset_docker_config,
     set_registry_token,
     RequestConfigAddRm,
-    get_image_label,
     verify_labels,
     prepare_request_for_build,
 )
@@ -243,22 +243,14 @@ def handle_containerized_add_request(
             generate_cache=False,
         )
 
-        # we have to remove all `deprecation_bundles` from `localized_git_catalog_path`
-        # before merging catalogs otherwise if catalog was deprecated and
-        # removed from `index.db` it stays on FBC (from_index)
-        # Therefore we have to remove the directory before merging
-        for deprecate_bundle_pull_spec in deprecation_bundles:
-            # remove deprecated operators from FBC stored in index image
-            deprecate_bundle_package = get_image_label(
-                deprecate_bundle_pull_spec, 'operators.operatorframework.io.bundle.package.v1'
+        # Remove stale operator directories from the from_index Git catalog before merging.
+        # merge_catalogs_dirs only copies from catalog_from_db; without this step, operators
+        # removed from index.db by deprecate_bundles_db would remain under configs/<package>/.
+        # Use the same bundle list as index.db deprecation.
+        if deprecation_bundles:
+            remove_deprecated_operators_from_git_catalog(
+                localized_git_catalog_path, deprecation_bundles
             )
-            bundle_from_index = Path(localized_git_catalog_path) / deprecate_bundle_package
-            if bundle_from_index.is_dir():
-                log.debug(
-                    "Removing deprecated bundle from catalog before merging: %s",
-                    deprecate_bundle_package,
-                )
-                shutil.rmtree(bundle_from_index)
         # overwrite data in `localized_git_catalog_path` by data from `catalog_from_db`
         # this adds changes on not opted in operators to final
         merge_catalogs_dirs(catalog_from_db, localized_git_catalog_path)

--- a/iib/workers/tasks/build_containerized_merge.py
+++ b/iib/workers/tasks/build_containerized_merge.py
@@ -46,6 +46,7 @@ from iib.workers.tasks.utils import (
     RequestConfigMerge,
     set_registry_token,
     get_bundles_from_deprecation_list,
+    remove_deprecated_operators_from_git_catalog,
 )
 from iib.workers.tasks.fbc_utils import merge_catalogs_dirs
 from iib.workers.tasks.iib_static_types import BundleImage
@@ -243,6 +244,7 @@ def handle_containerized_merge_request(
         deprecation_bundles = deprecation_bundles + [
             bundle['bundlePath'] for bundle in invalid_bundles
         ]
+        deprecation_bundles = list(dict.fromkeys(deprecation_bundles))
 
         # process the deprecation list into the intermediary index.db file
         if deprecation_bundles:
@@ -273,6 +275,16 @@ def handle_containerized_merge_request(
         # final destination of catalog (defined in Dockerfile)
         catalog_from_db = os.path.join(temp_dir, 'from_db')
         os.rename(fbc_dir, catalog_from_db)
+
+        # Remove stale operator directories from the target Git catalog before merging.
+        # This complements deprecate_bundles_db: merge_catalogs_dirs only copies from
+        # catalog_from_db and would leave existing configs/<package>/ dirs untouched, or
+        # re-add packages that were removed from index.db only when deprecate_bundles_db ran.
+        # Use the same bundle list as index.db deprecation (includes invalid_bundles).
+        if deprecation_bundles:
+            remove_deprecated_operators_from_git_catalog(
+                localized_git_catalog_path, deprecation_bundles
+            )
 
         # Merge migrated FBC with existing FBC in Git repo
         # overwrite data in `catalog_from_index` by data from `catalog_from_db`

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 
@@ -453,6 +454,127 @@ def get_bundles_from_deprecation_list(bundles: List[str], deprecation_list: List
             'Bundles that will be deprecated from the index image: %s', ', '.join(deprecate_bundles)
         )
     return deprecate_bundles
+
+
+# OLM package names (operators.operatorframework.io.bundle.package.v1) follow the DNS
+# subdomain rules: lowercase alphanumerics, hyphens, and periods only — no underscores
+# or uppercase. See RFC 1123 and OLM packaging docs.
+_OPERATOR_PACKAGE_NAME_PATTERN = re.compile(r'^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$')
+
+
+def _is_safe_operator_package_name(operator_package: str) -> bool:
+    """
+    Validate that an operator package name is safe to use as a catalog directory name.
+
+    Names must satisfy OLM DNS subdomain rules (lowercase alphanumerics, ``-``, ``.``)
+    in addition to path traversal checks. Underscores and uppercase are rejected because
+    they are invalid in ``operators.operatorframework.io.bundle.package.v1`` labels.
+
+    :param str operator_package: operator package name from a bundle image label
+    :return: whether the package name can be used without path traversal
+    :rtype: bool
+    """
+    if not operator_package or operator_package in {'.', '..'}:
+        return False
+
+    if '..' in operator_package:
+        return False
+
+    if operator_package != Path(operator_package).name:
+        return False
+
+    return _OPERATOR_PACKAGE_NAME_PATTERN.match(operator_package) is not None
+
+
+def _resolve_operator_catalog_dir(catalog_base: Path, operator_package: str) -> Optional[Path]:
+    """
+    Resolve the operator catalog directory and ensure it stays within the catalog base.
+
+    :param Path catalog_base: absolute path to the Git ``configs`` directory
+    :param str operator_package: validated operator package name (see
+        :func:`_is_safe_operator_package_name`)
+    :return: resolved operator catalog directory or ``None`` if resolution escapes
+        ``catalog_base`` (e.g. due to symlinks)
+    :rtype: Path | None
+    """
+    operator_catalog_dir = (catalog_base / operator_package).resolve()
+    if operator_catalog_dir == catalog_base or not operator_catalog_dir.is_relative_to(
+        catalog_base
+    ):
+        return None
+
+    return operator_catalog_dir
+
+
+def get_operator_packages_from_deprecation_list(deprecation_list: List[str]) -> List[str]:
+    """
+    Get operator package names declared in the deprecation list.
+
+    :param list deprecation_list: list of deprecated bundle pull specifications
+    :return: unique operator package names from the deprecation list
+    :rtype: list
+    """
+    operator_packages: List[str] = []
+    for pull_spec in deprecation_list:
+        operator_package = get_image_label(
+            pull_spec, 'operators.operatorframework.io.bundle.package.v1'
+        )
+        if operator_package:
+            if _is_safe_operator_package_name(operator_package):
+                operator_packages.append(operator_package)
+            else:
+                log.warning(
+                    'Skipping unsafe operator package name %r from deprecated bundle %s. '
+                    'The operator directory will not be removed from the Git catalog.',
+                    operator_package,
+                    pull_spec,
+                )
+        else:
+            log.warning(
+                'Could not determine operator package name for deprecated bundle %s. '
+                'The operator directory will not be removed from the Git catalog.',
+                pull_spec,
+            )
+    return list(dict.fromkeys(operator_packages))
+
+
+def remove_deprecated_operators_from_git_catalog(
+    localized_git_catalog_path: str, deprecated_bundle_pull_specs: List[str]
+) -> None:
+    """
+    Remove deprecated operator package directories from a Git-backed file-based catalog.
+
+    Removes the entire ``configs/<package>/`` tree for each operator package tied to a
+    deprecated bundle, not individual bundle versions. ``merge_catalogs_dirs`` uses
+    ``copytree(..., dirs_exist_ok=True)``, which overwrites files from the source but
+    does not delete extra files left in the Git catalog. Clearing the whole package
+    directory avoids stale channel or version entries. If the operator still exists in
+    ``index.db`` after deprecation, ``catalog_from_db`` (from ``opm_migrate``) restores
+    it on the subsequent merge.
+
+    :param str localized_git_catalog_path: path to the ``configs`` directory in the Git repository
+    :param list deprecated_bundle_pull_specs: bundle pull specifications deprecated in index.db
+    """
+    catalog_base = Path(localized_git_catalog_path).resolve()
+    for operator_package in get_operator_packages_from_deprecation_list(
+        deprecated_bundle_pull_specs
+    ):
+        operator_catalog_dir = _resolve_operator_catalog_dir(catalog_base, operator_package)
+        if not operator_catalog_dir:
+            log.warning(
+                'Resolved catalog path for operator package %r escapes %s; '
+                'skipping removal from the Git catalog',
+                operator_package,
+                catalog_base,
+            )
+            continue
+
+        if operator_catalog_dir.is_dir():
+            log.debug(
+                'Removing deprecated operator package directory from catalog: %s',
+                operator_package,
+            )
+            shutil.rmtree(operator_catalog_dir)
 
 
 def get_resolved_bundles(bundles: List[str]) -> List[str]:

--- a/tests/test_workers/test_tasks/test_build_containerized_add.py
+++ b/tests/test_workers/test_tasks/test_build_containerized_add.py
@@ -40,9 +40,10 @@ from iib.workers.tasks import build_containerized_add
 @mock.patch('iib.workers.tasks.build_containerized_add.write_build_metadata')
 @mock.patch('iib.workers.tasks.build_containerized_add.chmod_recursively')
 @mock.patch('iib.workers.tasks.build_containerized_add.merge_catalogs_dirs')
-@mock.patch('iib.workers.tasks.build_containerized_add.shutil.rmtree')
+@mock.patch(
+    'iib.workers.tasks.build_containerized_add.remove_deprecated_operators_from_git_catalog'
+)
 @mock.patch('iib.workers.tasks.build_containerized_add.Path.is_dir')
-@mock.patch('iib.workers.tasks.build_containerized_add.get_image_label')
 @mock.patch('iib.workers.tasks.build_containerized_add.opm_migrate')
 @mock.patch('iib.workers.tasks.build_containerized_add.deprecate_bundles_db')
 @mock.patch('iib.workers.tasks.build_containerized_add.get_bundles_from_deprecation_list')
@@ -78,9 +79,8 @@ def test_handle_containerized_add_request(
     mock_get_deprecations,
     mock_deprecate,
     mock_opm_migrate,
-    mock_get_image_label,
     mock_path_isdir,
-    mock_rmtree,
+    mock_remove_deprecated,
     mock_merge,
     mock_chmod,
     mock_write_meta,
@@ -149,9 +149,6 @@ def test_handle_containerized_add_request(
     deprecation_list = ['deprecated-bundle:1.0'] if with_deprecations else None
     if with_deprecations:
         mock_get_deprecations.return_value = ['deprecated-bundle@sha256:old']
-        mock_get_image_label.return_value = 'deprecated-operator-package'
-        package = Path(localized_git_catalog_path) / 'deprecated-operator-package'
-        package.mkdir(parents=True)
     else:
         mock_get_deprecations.return_value = []
 
@@ -246,12 +243,12 @@ def test_handle_containerized_add_request(
     if with_deprecations:
         mock_get_deprecations.assert_called_once()
         mock_deprecate.assert_called_once()
-        mock_rmtree.assert_called()
-        expected_path = Path(localized_git_catalog_path) / 'deprecated-operator-package'
-        mock_rmtree.assert_any_call(expected_path)
+        mock_remove_deprecated.assert_called_once_with(
+            localized_git_catalog_path, mock_get_deprecations.return_value
+        )
     else:
         mock_deprecate.assert_not_called()
-        mock_rmtree.assert_not_called()
+        mock_remove_deprecated.assert_not_called()
 
     # Verify makedirs and migrate
     assert mock_makedirs.call_count >= 2
@@ -299,9 +296,10 @@ def test_handle_containerized_add_request(
 @mock.patch('iib.workers.tasks.build_containerized_add.write_build_metadata')
 @mock.patch('iib.workers.tasks.build_containerized_add.chmod_recursively')
 @mock.patch('iib.workers.tasks.build_containerized_add.merge_catalogs_dirs')
-@mock.patch('iib.workers.tasks.build_containerized_add.shutil.rmtree')
+@mock.patch(
+    'iib.workers.tasks.build_containerized_add.remove_deprecated_operators_from_git_catalog'
+)
 @mock.patch('iib.workers.tasks.build_containerized_add.Path.is_dir')
-@mock.patch('iib.workers.tasks.build_containerized_add.get_image_label')
 @mock.patch('iib.workers.tasks.build_containerized_add.opm_migrate')
 @mock.patch('iib.workers.tasks.build_containerized_add.deprecate_bundles_db')
 @mock.patch('iib.workers.tasks.build_containerized_add.get_bundles_from_deprecation_list')
@@ -337,9 +335,8 @@ def test_handle_containerized_add_request_failure(
     mock_get_deprecations,
     mock_deprecate,
     mock_opm_migrate,
-    mock_get_image_label,
     mock_path_isdir,
-    mock_rmtree,
+    mock_remove_deprecated,
     mock_merge,
     mock_chmod,
     mock_write_meta,
@@ -420,9 +417,10 @@ def test_handle_containerized_add_request_failure(
 @mock.patch('iib.workers.tasks.build_containerized_add.write_build_metadata')
 @mock.patch('iib.workers.tasks.build_containerized_add.chmod_recursively')
 @mock.patch('iib.workers.tasks.build_containerized_add.merge_catalogs_dirs')
-@mock.patch('iib.workers.tasks.build_containerized_add.shutil.rmtree')
+@mock.patch(
+    'iib.workers.tasks.build_containerized_add.remove_deprecated_operators_from_git_catalog'
+)
 @mock.patch('iib.workers.tasks.build_containerized_add.Path.is_dir')
-@mock.patch('iib.workers.tasks.build_containerized_add.get_image_label')
 @mock.patch('iib.workers.tasks.build_containerized_add.opm_migrate')
 @mock.patch('iib.workers.tasks.build_containerized_add.deprecate_bundles_db')
 @mock.patch('iib.workers.tasks.build_containerized_add.get_bundles_from_deprecation_list')
@@ -460,9 +458,8 @@ def test_handle_containerized_add_request_overwrite(
     mock_get_deprecations,
     mock_deprecate,
     mock_opm_migrate,
-    mock_get_image_label,
     mock_path_isdir,
-    mock_rmtree,
+    mock_remove_deprecated,
     mock_merge,
     mock_chmod,
     mock_write_meta,

--- a/tests/test_workers/test_tasks/test_build_containerized_merge.py
+++ b/tests/test_workers/test_tasks/test_build_containerized_merge.py
@@ -49,6 +49,14 @@ def _mock_set_for_bundles(iterable=None):
     return _original_set(iterable)
 
 
+@pytest.fixture(autouse=True)
+def mock_remove_deprecated_operators_from_git_catalog():
+    with mock.patch(
+        'iib.workers.tasks.build_containerized_merge.remove_deprecated_operators_from_git_catalog'
+    ) as mock_remove:
+        yield mock_remove
+
+
 @mock.patch('iib.workers.tasks.build_containerized_merge.merge_mr_after_build')
 @mock.patch('iib.workers.tasks.build_containerized_merge.reset_docker_config')
 @mock.patch('iib.workers.tasks.build_containerized_merge.cleanup_on_failure')
@@ -417,6 +425,7 @@ def test_handle_containerized_merge_request_success_with_deprecations(
     mock_cof,
     mock_rdc,
     mock_merge_mr,
+    mock_remove_deprecated_operators_from_git_catalog,
 ):
     """Test successful merge request with deprecations executed correctly."""
     # Setup
@@ -611,6 +620,11 @@ def test_handle_containerized_merge_request_success_with_deprecations(
     assert 'bundle1@sha256:111' in dbd_call_args[1]['bundles']
     assert 'bundle2@sha256:222' in dbd_call_args[1]['bundles']
 
+    # Verify deprecated operator directories were removed from Git catalog before merge
+    mock_remove_deprecated_operators_from_git_catalog.assert_called_once_with(
+        localized_git_catalog_path, deprecation_bundles_latest
+    )
+
     # Verify FBC migration
     mock_om.assert_called_once()
 
@@ -646,6 +660,420 @@ def test_handle_containerized_merge_request_success_with_deprecations(
 
     # Verify reset_docker_config was called
     assert mock_rdc.call_count >= 1
+
+
+def _run_minimal_merge_handler(
+    mock_tempdir,
+    mock_get_request,
+    mock_prfb,
+    mock_opm,
+    mock_pgrfb,
+    mock_favida,
+    mock_gpb,
+    mock_gmbfts,
+    mock_gbfdl,
+    mock_gblv,
+    mock_om,
+    mock_glb,
+    mock_exists,
+    mock_gccmop,
+    mock_mpaei,
+    mock_ritd,
+    mock_pida,
+    temp_dir,
+    deprecation_list,
+    invalid_bundles=None,
+):
+    """Run merge handler with minimal mocks for focused deprecation tests."""
+    request_id = 10
+    source_from_index = 'quay.io/namespace/source-index:v4.14'
+    target_index = 'quay.io/namespace/target-index:v4.15'
+    index_git_repo = 'https://gitlab.com/repo'
+    local_git_repo_path = os.path.join(temp_dir, 'git_repo')
+    localized_git_catalog_path = os.path.join(local_git_repo_path, 'catalogs')
+
+    mock_tempdir.return_value.__enter__.return_value = temp_dir
+    mock_get_request.return_value = {'user': 'test-user'}
+    mock_prfb.return_value = {
+        'arches': {'amd64'},
+        'binary_image_resolved': 'registry.io/binary@sha256:abc123',
+        'source_from_index_resolved': 'quay.io/namespace/source-index@sha256:def456',
+        'target_index_resolved': 'quay.io/namespace/target-index@sha256:ghi789',
+        'ocp_version': 'v4.14',
+        'target_ocp_version': 'v4.15',
+        'distribution_scope': 'prod',
+    }
+    mock_opm.opm_version = 'v1.48.0'
+    mock_pgrfb.return_value = (index_git_repo, local_git_repo_path, localized_git_catalog_path)
+
+    source_index_db_path = os.path.join(temp_dir, 'source_index.db')
+    target_index_db_path = os.path.join(temp_dir, 'target_index.db')
+    mock_favida.side_effect = [source_index_db_path, target_index_db_path]
+
+    source_bundles = [
+        {'bundlePath': 'bundle1@sha256:111', 'csvName': 'bundle1-1.0', 'packageName': 'bundle1'},
+    ]
+    source_bundles_pull_spec = ['bundle1@sha256:111']
+    target_bundles = []
+    target_bundles_pull_spec = []
+    mock_gpb.side_effect = [
+        (source_bundles, source_bundles_pull_spec),
+        (target_bundles, target_bundles_pull_spec),
+    ]
+    mock_gmbfts.return_value = ([], invalid_bundles or [])
+    mock_gblv.side_effect = lambda bundles, all_bundles: bundles
+    mock_om.return_value = (os.path.join(temp_dir, 'fbc_catalog'), None)
+    mock_glb.return_value = [
+        {'bundlePath': 'bundle1@sha256:111', 'packageName': 'bundle1'},
+    ]
+    mock_exists.return_value = True
+    mr_details = {
+        'mr_id': str(request_id),
+        'mr_url': f'https://gitlab.com/repo/-/merge_requests/{request_id}',
+        'source_branch': f'iib-request-{request_id}-v4.15',
+    }
+    mock_gccmop.return_value = (mr_details, 'abc123commit')
+    mock_mpaei.return_value = 'quay.io/konflux/built-image@sha256:xyz789'
+    mock_ritd.return_value = ['quay.io/iib/iib-build:10']
+    mock_pida.return_value = 'sha256:original123'
+
+    build_containerized_merge.handle_containerized_merge_request(
+        source_from_index=source_from_index,
+        deprecation_list=deprecation_list,
+        request_id=request_id,
+        binary_image='registry.io/binary:latest',
+        target_index=target_index,
+        overwrite_target_index=True,
+        overwrite_target_index_token='user:token',
+    )
+    return localized_git_catalog_path
+
+
+@mock.patch('iib.workers.tasks.build_containerized_merge.merge_mr_after_build')
+@mock.patch('iib.workers.tasks.build_containerized_merge.reset_docker_config')
+@mock.patch('iib.workers.tasks.build_containerized_merge.cleanup_on_failure')
+@mock.patch('iib.workers.tasks.build_containerized_merge.cleanup_merge_request_if_exists')
+@mock.patch('iib.workers.tasks.build_containerized_merge.push_index_db_artifact')
+@mock.patch('iib.workers.tasks.build_containerized_merge._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_containerized_merge.replicate_image_to_tagged_destinations')
+@mock.patch('iib.workers.tasks.build_containerized_merge.monitor_pipeline_and_extract_image')
+@mock.patch('iib.workers.tasks.build_containerized_merge.git_commit_and_create_mr')
+@mock.patch('iib.workers.tasks.build_containerized_merge.write_build_metadata')
+@mock.patch('iib.workers.tasks.build_containerized_merge.opm_validate')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.copytree')
+@mock.patch('iib.workers.tasks.build_containerized_merge.merge_catalogs_dirs')
+@mock.patch('iib.workers.tasks.build_containerized_merge.opm_migrate')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_list_bundles')
+@mock.patch('iib.workers.tasks.build_containerized_merge.deprecate_bundles_db')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_bundles_latest_version')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_bundles_from_deprecation_list')
+@mock.patch('iib.workers.tasks.build_containerized_merge._opm_registry_add')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_missing_bundles_from_target_to_source')
+@mock.patch('iib.workers.tasks.build_containerized_merge.validate_bundles_in_parallel')
+@mock.patch('iib.workers.tasks.build_containerized_merge._get_present_bundles')
+@mock.patch('iib.workers.tasks.build_containerized_merge.fetch_and_verify_index_db_artifact')
+@mock.patch('iib.workers.tasks.build_containerized_merge.prepare_git_repository_for_build')
+@mock.patch('iib.workers.tasks.build_containerized_merge._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_containerized_merge.Opm')
+@mock.patch('iib.workers.tasks.build_containerized_merge.prepare_request_for_build')
+@mock.patch('iib.workers.api_utils.set_request_state')
+@mock.patch('iib.workers.api_utils.get_request')
+@mock.patch('iib.workers.tasks.build_containerized_merge.set_request_state')
+@mock.patch('iib.workers.tasks.build_containerized_merge.set_registry_token')
+@mock.patch('iib.workers.tasks.build_containerized_merge.tempfile.TemporaryDirectory')
+@mock.patch('iib.workers.tasks.build_containerized_merge.os.rename')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.rmtree')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.move')
+@mock.patch('iib.workers.tasks.build_containerized_merge.os.path.exists')
+@mock.patch('builtins.set', side_effect=_mock_set_for_bundles)
+def test_handle_containerized_merge_request_deduplicates_deprecation_bundles(
+    mock_set,
+    mock_exists,
+    mock_move,
+    mock_rmtree,
+    mock_rename,
+    mock_tempdir,
+    mock_set_registry_token,
+    mock_srs,
+    mock_srs_api,
+    mock_get_request,
+    mock_prfb,
+    mock_opm,
+    mock_uiibs,
+    mock_pgrfb,
+    mock_favida,
+    mock_gpb,
+    mock_vbip,
+    mock_gmbfts,
+    mock_ora,
+    mock_gbfdl,
+    mock_gblv,
+    mock_dbd,
+    mock_glb,
+    mock_om,
+    mock_mcd,
+    mock_copytree,
+    mock_ov,
+    mock_wbm,
+    mock_gccmop,
+    mock_mpaei,
+    mock_ritd,
+    mock_uiips,
+    mock_pida,
+    mock_cmrif,
+    mock_cof,
+    mock_rdc,
+    mock_merge_mr,
+    mock_remove_deprecated_operators_from_git_catalog,
+):
+    """Duplicate bundles from deprecation_list and invalid_bundles are deduplicated."""
+    duplicate_bundle = 'bundle1@sha256:111'
+    mock_gbfdl.return_value = [duplicate_bundle]
+    invalid_bundles = [
+        {'bundlePath': duplicate_bundle, 'csvName': 'bundle1-1.0', 'packageName': 'bundle1'},
+    ]
+
+    _run_minimal_merge_handler(
+        mock_tempdir,
+        mock_get_request,
+        mock_prfb,
+        mock_opm,
+        mock_pgrfb,
+        mock_favida,
+        mock_gpb,
+        mock_gmbfts,
+        mock_gbfdl,
+        mock_gblv,
+        mock_om,
+        mock_glb,
+        mock_exists,
+        mock_gccmop,
+        mock_mpaei,
+        mock_ritd,
+        mock_pida,
+        temp_dir='/tmp/iib-10-dedup',
+        deprecation_list=['bundle1:1.0'],
+        invalid_bundles=invalid_bundles,
+    )
+
+    mock_gblv.assert_called_once()
+    assert mock_gblv.call_args[0][0] == [duplicate_bundle]
+    mock_dbd.assert_called_once()
+    assert mock_dbd.call_args[1]['bundles'] == [duplicate_bundle]
+
+
+@mock.patch('iib.workers.tasks.build_containerized_merge.merge_mr_after_build')
+@mock.patch('iib.workers.tasks.build_containerized_merge.reset_docker_config')
+@mock.patch('iib.workers.tasks.build_containerized_merge.cleanup_on_failure')
+@mock.patch('iib.workers.tasks.build_containerized_merge.cleanup_merge_request_if_exists')
+@mock.patch('iib.workers.tasks.build_containerized_merge.push_index_db_artifact')
+@mock.patch('iib.workers.tasks.build_containerized_merge._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_containerized_merge.replicate_image_to_tagged_destinations')
+@mock.patch('iib.workers.tasks.build_containerized_merge.monitor_pipeline_and_extract_image')
+@mock.patch('iib.workers.tasks.build_containerized_merge.git_commit_and_create_mr')
+@mock.patch('iib.workers.tasks.build_containerized_merge.write_build_metadata')
+@mock.patch('iib.workers.tasks.build_containerized_merge.opm_validate')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.copytree')
+@mock.patch('iib.workers.tasks.build_containerized_merge.merge_catalogs_dirs')
+@mock.patch('iib.workers.tasks.build_containerized_merge.opm_migrate')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_list_bundles')
+@mock.patch('iib.workers.tasks.build_containerized_merge.deprecate_bundles_db')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_bundles_latest_version')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_bundles_from_deprecation_list')
+@mock.patch('iib.workers.tasks.build_containerized_merge._opm_registry_add')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_missing_bundles_from_target_to_source')
+@mock.patch('iib.workers.tasks.build_containerized_merge.validate_bundles_in_parallel')
+@mock.patch('iib.workers.tasks.build_containerized_merge._get_present_bundles')
+@mock.patch('iib.workers.tasks.build_containerized_merge.fetch_and_verify_index_db_artifact')
+@mock.patch('iib.workers.tasks.build_containerized_merge.prepare_git_repository_for_build')
+@mock.patch('iib.workers.tasks.build_containerized_merge._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_containerized_merge.Opm')
+@mock.patch('iib.workers.tasks.build_containerized_merge.prepare_request_for_build')
+@mock.patch('iib.workers.api_utils.set_request_state')
+@mock.patch('iib.workers.api_utils.get_request')
+@mock.patch('iib.workers.tasks.build_containerized_merge.set_request_state')
+@mock.patch('iib.workers.tasks.build_containerized_merge.set_registry_token')
+@mock.patch('iib.workers.tasks.build_containerized_merge.tempfile.TemporaryDirectory')
+@mock.patch('iib.workers.tasks.build_containerized_merge.os.rename')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.rmtree')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.move')
+@mock.patch('iib.workers.tasks.build_containerized_merge.os.path.exists')
+@mock.patch('builtins.set', side_effect=_mock_set_for_bundles)
+def test_handle_containerized_merge_request_skips_git_cleanup_without_deprecation_bundles(
+    mock_set,
+    mock_exists,
+    mock_move,
+    mock_rmtree,
+    mock_rename,
+    mock_tempdir,
+    mock_set_registry_token,
+    mock_srs,
+    mock_srs_api,
+    mock_get_request,
+    mock_prfb,
+    mock_opm,
+    mock_uiibs,
+    mock_pgrfb,
+    mock_favida,
+    mock_gpb,
+    mock_vbip,
+    mock_gmbfts,
+    mock_ora,
+    mock_gbfdl,
+    mock_gblv,
+    mock_dbd,
+    mock_glb,
+    mock_om,
+    mock_mcd,
+    mock_copytree,
+    mock_ov,
+    mock_wbm,
+    mock_gccmop,
+    mock_mpaei,
+    mock_ritd,
+    mock_uiips,
+    mock_pida,
+    mock_cmrif,
+    mock_cof,
+    mock_rdc,
+    mock_merge_mr,
+    mock_remove_deprecated_operators_from_git_catalog,
+):
+    """Git catalog cleanup is skipped when no bundles were deprecated in index.db."""
+    mock_gbfdl.return_value = []
+
+    _run_minimal_merge_handler(
+        mock_tempdir,
+        mock_get_request,
+        mock_prfb,
+        mock_opm,
+        mock_pgrfb,
+        mock_favida,
+        mock_gpb,
+        mock_gmbfts,
+        mock_gbfdl,
+        mock_gblv,
+        mock_om,
+        mock_glb,
+        mock_exists,
+        mock_gccmop,
+        mock_mpaei,
+        mock_ritd,
+        mock_pida,
+        temp_dir='/tmp/iib-10-no-deprecation',
+        deprecation_list=[],
+    )
+
+    mock_remove_deprecated_operators_from_git_catalog.assert_not_called()
+    mock_dbd.assert_not_called()
+    mock_gblv.assert_not_called()
+
+
+@mock.patch('iib.workers.tasks.build_containerized_merge.merge_mr_after_build')
+@mock.patch('iib.workers.tasks.build_containerized_merge.reset_docker_config')
+@mock.patch('iib.workers.tasks.build_containerized_merge.cleanup_on_failure')
+@mock.patch('iib.workers.tasks.build_containerized_merge.cleanup_merge_request_if_exists')
+@mock.patch('iib.workers.tasks.build_containerized_merge.push_index_db_artifact')
+@mock.patch('iib.workers.tasks.build_containerized_merge._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.build_containerized_merge.replicate_image_to_tagged_destinations')
+@mock.patch('iib.workers.tasks.build_containerized_merge.monitor_pipeline_and_extract_image')
+@mock.patch('iib.workers.tasks.build_containerized_merge.git_commit_and_create_mr')
+@mock.patch('iib.workers.tasks.build_containerized_merge.write_build_metadata')
+@mock.patch('iib.workers.tasks.build_containerized_merge.opm_validate')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.copytree')
+@mock.patch('iib.workers.tasks.build_containerized_merge.merge_catalogs_dirs')
+@mock.patch('iib.workers.tasks.build_containerized_merge.opm_migrate')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_list_bundles')
+@mock.patch('iib.workers.tasks.build_containerized_merge.deprecate_bundles_db')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_bundles_latest_version')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_bundles_from_deprecation_list')
+@mock.patch('iib.workers.tasks.build_containerized_merge._opm_registry_add')
+@mock.patch('iib.workers.tasks.build_containerized_merge.get_missing_bundles_from_target_to_source')
+@mock.patch('iib.workers.tasks.build_containerized_merge.validate_bundles_in_parallel')
+@mock.patch('iib.workers.tasks.build_containerized_merge._get_present_bundles')
+@mock.patch('iib.workers.tasks.build_containerized_merge.fetch_and_verify_index_db_artifact')
+@mock.patch('iib.workers.tasks.build_containerized_merge.prepare_git_repository_for_build')
+@mock.patch('iib.workers.tasks.build_containerized_merge._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build_containerized_merge.Opm')
+@mock.patch('iib.workers.tasks.build_containerized_merge.prepare_request_for_build')
+@mock.patch('iib.workers.api_utils.set_request_state')
+@mock.patch('iib.workers.api_utils.get_request')
+@mock.patch('iib.workers.tasks.build_containerized_merge.set_request_state')
+@mock.patch('iib.workers.tasks.build_containerized_merge.set_registry_token')
+@mock.patch('iib.workers.tasks.build_containerized_merge.tempfile.TemporaryDirectory')
+@mock.patch('iib.workers.tasks.build_containerized_merge.os.rename')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.rmtree')
+@mock.patch('iib.workers.tasks.build_containerized_merge.shutil.move')
+@mock.patch('iib.workers.tasks.build_containerized_merge.os.path.exists')
+@mock.patch('builtins.set', side_effect=_mock_set_for_bundles)
+def test_handle_containerized_merge_request_git_cleanup_without_db_deprecation_match(
+    mock_set,
+    mock_exists,
+    mock_move,
+    mock_rmtree,
+    mock_rename,
+    mock_tempdir,
+    mock_set_registry_token,
+    mock_srs,
+    mock_srs_api,
+    mock_get_request,
+    mock_prfb,
+    mock_opm,
+    mock_uiibs,
+    mock_pgrfb,
+    mock_favida,
+    mock_gpb,
+    mock_vbip,
+    mock_gmbfts,
+    mock_ora,
+    mock_gbfdl,
+    mock_gblv,
+    mock_dbd,
+    mock_glb,
+    mock_om,
+    mock_mcd,
+    mock_copytree,
+    mock_ov,
+    mock_wbm,
+    mock_gccmop,
+    mock_mpaei,
+    mock_ritd,
+    mock_uiips,
+    mock_pida,
+    mock_cmrif,
+    mock_cof,
+    mock_rdc,
+    mock_merge_mr,
+    mock_remove_deprecated_operators_from_git_catalog,
+):
+    """Git cleanup is skipped when deprecation_list matches no bundles in the index."""
+    mock_gbfdl.return_value = []
+
+    _run_minimal_merge_handler(
+        mock_tempdir,
+        mock_get_request,
+        mock_prfb,
+        mock_opm,
+        mock_pgrfb,
+        mock_favida,
+        mock_gpb,
+        mock_gmbfts,
+        mock_gbfdl,
+        mock_gblv,
+        mock_om,
+        mock_glb,
+        mock_exists,
+        mock_gccmop,
+        mock_mpaei,
+        mock_ritd,
+        mock_pida,
+        temp_dir='/tmp/iib-10-git-only',
+        deprecation_list=['bundle1:1.0'],
+    )
+
+    mock_dbd.assert_not_called()
+    mock_gblv.assert_not_called()
+    mock_remove_deprecated_operators_from_git_catalog.assert_not_called()
 
 
 @mock.patch('iib.workers.tasks.build_containerized_merge.reset_docker_config')

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -6,6 +6,7 @@ import os
 import stat
 import subprocess
 import textwrap
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -990,6 +991,107 @@ def testget_bundles_from_deprecation_list(mock_grb):
     deprecate_bundles = utils.get_bundles_from_deprecation_list(present_bundles, deprecation_list)
     assert deprecate_bundles == ['quay.io/bundle1@sha256:123456', 'quay.io/bundle2@sha256:987654']
     mock_grb.assert_called_once_with(deprecation_list)
+
+
+@mock.patch('iib.workers.tasks.utils.get_image_label')
+def test_get_operator_packages_from_deprecation_list(mock_get_image_label):
+    mock_get_image_label.side_effect = ['lgallett-bundle', 'serverless-operator']
+    deprecation_list = [
+        'registry.example.com/lgallett-bundle@sha256:abc',
+        'registry.example.com/serverless-operator@sha256:def',
+    ]
+
+    packages = utils.get_operator_packages_from_deprecation_list(deprecation_list)
+
+    assert packages == ['lgallett-bundle', 'serverless-operator']
+
+
+@mock.patch('iib.workers.tasks.utils.log')
+@mock.patch('iib.workers.tasks.utils.get_image_label', return_value='')
+def test_get_operator_packages_from_deprecation_list_missing_label(mock_get_image_label, mock_log):
+    pull_spec = 'registry.example.com/unknown-bundle@sha256:abc'
+
+    packages = utils.get_operator_packages_from_deprecation_list([pull_spec])
+
+    assert packages == []
+    mock_log.warning.assert_called_once()
+    assert pull_spec in mock_log.warning.call_args[0][1]
+
+
+@mock.patch('iib.workers.tasks.utils.get_operator_packages_from_deprecation_list')
+@mock.patch('iib.workers.tasks.utils.shutil.rmtree')
+def test_remove_deprecated_operators_from_git_catalog(mock_rmtree, mock_get_packages, tmpdir):
+    catalog_path = tmpdir.mkdir('configs')
+    package_dir = catalog_path.join('lgallett-bundle')
+    package_dir.mkdir()
+    mock_get_packages.return_value = ['lgallett-bundle']
+
+    utils.remove_deprecated_operators_from_git_catalog(str(catalog_path), ['bundle@sha256:abc'])
+
+    mock_rmtree.assert_called_once_with((Path(str(catalog_path)).resolve() / 'lgallett-bundle'))
+
+
+@mock.patch('iib.workers.tasks.utils.shutil.rmtree')
+@mock.patch('iib.workers.tasks.utils.get_image_label')
+def test_remove_deprecated_operators_from_git_catalog_missing_package_dir(
+    mock_get_image_label, mock_rmtree, tmpdir
+):
+    catalog_path = tmpdir.mkdir('configs')
+    mock_get_image_label.return_value = 'lgallett-bundle'
+
+    utils.remove_deprecated_operators_from_git_catalog(str(catalog_path), ['bundle@sha256:abc'])
+
+    mock_rmtree.assert_not_called()
+
+
+@mock.patch('iib.workers.tasks.utils.shutil.rmtree')
+@mock.patch('iib.workers.tasks.utils.get_image_label')
+def test_remove_deprecated_operators_from_git_catalog_rejects_path_traversal(
+    mock_get_image_label, mock_rmtree, tmpdir
+):
+    catalog_path = tmpdir.mkdir('configs')
+    outside_dir = tmpdir.mkdir('outside')
+    mock_get_image_label.return_value = '../outside'
+
+    utils.remove_deprecated_operators_from_git_catalog(str(catalog_path), ['bundle@sha256:abc'])
+
+    mock_rmtree.assert_not_called()
+    assert outside_dir.check(dir=True)
+
+
+@pytest.mark.parametrize(
+    'operator_package, expected',
+    (
+        ('lgallett-bundle', True),
+        ('serverless-operator', True),
+        ('amq7-amq-streams', True),
+        ('a', True),
+        ('', False),
+        ('.', False),
+        ('..', False),
+        ('../outside', False),
+        ('foo/bar', False),
+        ('foo\\bar', False),
+        ('foo..bar', False),
+        ('UPPERCASE', False),
+        ('foo_bar', False),
+    ),
+)
+def test_is_safe_operator_package_name(operator_package, expected):
+    assert utils._is_safe_operator_package_name(operator_package) is expected
+
+
+@mock.patch('iib.workers.tasks.utils.log')
+@mock.patch('iib.workers.tasks.utils.get_image_label')
+def test_get_operator_packages_from_deprecation_list_rejects_unsafe_name(
+    mock_get_image_label, mock_log
+):
+    mock_get_image_label.return_value = '../outside'
+
+    packages = utils.get_operator_packages_from_deprecation_list(['bundle@sha256:abc'])
+
+    assert packages == []
+    mock_log.warning.assert_called_once()
 
 
 def test_chmod_recursiverly(tmpdir):


### PR DESCRIPTION
## Summary

Fixes Git FBC catalog divergence after bundle deprecation in containerized **add** and **merge** handlers.

When `deprecate_bundles_db` updates `index.db`, `merge_catalogs_dirs` only copies files from the migrated catalog (`copytree` with `dirs_exist_ok=True`) and does not remove stale `configs/<package>/` directories left in the Git clone. Deprecated operators removed from `index.db` could therefore remain in the Git-backed FBC committed to Konflux.

This PR extracts Git cleanup into a shared utility and invokes it from both handlers before `merge_catalogs_dirs`.

## Problem

Containerized workflow:

1. `deprecate_bundles_db` mutates `index.db`
2. `opm_migrate` produces `catalog_from_db` without deprecated operators
3. `merge_catalogs_dirs(catalog_from_db, localized_git_catalog_path)` merges into the Git catalog

Step 3 overwrites matching files but **does not delete** extra files/directories already present under `configs/<package>/` in Git. The final committed FBC could still contain deprecated operator content even though `index.db` was updated correctly.

The containerized **add** handler already worked around this with inline cleanup; the **merge** handler did not.

## Solution

- Add `remove_deprecated_operators_from_git_catalog()` in `iib/workers/tasks/utils.py`
- Call it from containerized **add** and **merge** handlers after `opm_migrate` and before `merge_catalogs_dirs`
- Drive Git removal from the same `deprecation_bundles` list passed to `deprecate_bundles_db` (including `invalid_bundles` in merge)
- Deduplicate `deprecation_bundles` in the merge handler before DB deprecation and Git cleanup

### Implementation notes

- Removes the entire `configs/<package>/` directory per deprecated bundle’s operator package (not individual bundle versions). This matches prior add-handler behavior and is required because `merge_catalogs_dirs` cannot prune stale version/channel files on its own. If the operator remains in `index.db`, `catalog_from_db` restores it on merge.
- Package names are validated against OLM DNS subdomain rules with path traversal checks before `shutil.rmtree`
- Unsafe or missing package labels are skipped with warning logs (fail-safe)

## Test plan

- [x] Unit tests for `remove_deprecated_operators_from_git_catalog` and package name validation (`test_utils.py`)
- [x] Updated containerized add handler tests
- [x] New merge handler tests: deprecation flow, deduplication with `invalid_bundles`, skip when no bundles deprecated
- [x] `tox -e py312`
- [x] `tox -m static`
- [x] Manual: containerized add/merge request with `deprecation_list` and verify Git catalog no longer contains removed operators