### PR TITLE
Fix removal of deprecated operators from Git catalog during ADD requests

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -46,6 +46,7 @@ from iib.workers.tasks.utils import (
     add_max_ocp_version_property,
     chmod_recursively,
     get_bundles_from_deprecation_list,
+    get_operator_packages_from_deprecation_list,
     get_resolved_bundles,
     get_resolved_image,
     podman_pull,
@@ -278,8 +279,8 @@ def _update_index_image_pull_spec(
     :param is_image_fbc: Set to True if the index image is an FBC (File-Based Catalog) image.
     :param dict(str) index_repo_map: The mapping between index images and git repositories. Only
         required if ``is_image_fbc`` is ``True``.
-    :param list(str) rm_operators: List of operators to remove from the index image. Only
-        required if ``add_or_rm`` is ``True`` and an RM operation is requested.
+    :param list(str) rm_operators: List of operator package names to remove from the Git
+        catalog during overwrite. Used by RM requests and ADD requests with deprecations.
     :raises IIBError: if the manifest list couldn't be created and pushed
     """
     conf = get_worker_config()
@@ -495,8 +496,8 @@ def _overwrite_from_index(
         ``from_index`` image. If this is not set, IIB's configured credentials will be used.
     :param dict(str) index_repo_map: The mapping between index images and git repositories. Only
         required if ``is_image_fbc`` is ``True``.
-    :param list(str) rm_operators: List of operators to remove from the index image. Only
-        required if ``add_or_rm`` is ``True`` and an RM operation is requested.
+    :param list(str) rm_operators: List of operator package names to remove from the Git
+        catalog during overwrite. Used by RM requests and ADD requests with deprecations.
     :raises IIBError: if one of the skopeo commands fails or if the index image has changed
         since IIB build started.
     """
@@ -1050,6 +1051,8 @@ def handle_add_request(
     set_request_state(request_id, 'in_progress', 'Creating the manifest list')
     output_pull_spec = _create_and_push_manifest_list(request_id, arches, build_tags)
 
+    deprecated_operator_packages = get_operator_packages_from_deprecation_list(deprecation_bundles)
+
     _update_index_image_pull_spec(
         output_pull_spec=output_pull_spec,
         request_id=request_id,
@@ -1061,6 +1064,7 @@ def handle_add_request(
         add_or_rm=True,
         is_image_fbc=is_fbc,
         index_repo_map=index_to_gitlab_push_map or {},
+        rm_operators=deprecated_operator_packages or None,
     )
     _cleanup()
     set_request_state(

--- a/iib/workers/tasks/git_utils.py
+++ b/iib/workers/tasks/git_utils.py
@@ -40,8 +40,12 @@ def push_configs_to_git(
                            files reside.
     :param dict(str) index_repo_map: The repo mapping to resolve the git URL.
     :param str commit_message: Custom commit message. If None, a default message is used.
-    :param list(str) rm_operators: List of operators to remove from the index image. Only
-        required if ``add_or_rm`` is ``True`` and an RM operation is requested.
+    :param list(str) rm_operators: List of operator package names to remove from the Git
+        catalog. When set, matching operator directories are removed from the cloned repo,
+        then any operators present in ``src_configs_path`` (the rebuilt index image) are
+        copied into the repo. For RM-only requests, ``src_configs_path`` reflects the
+        post-removal catalog, so copy keeps Git in sync with the index without restoring
+        removed operators.
     :raises IIBError: If src_configs_path is not found, remote branch does not exist,
                       or a Git operation fails.
     """
@@ -85,23 +89,25 @@ def push_configs_to_git(
                 repo_configs_dir,
             )
 
+            # ADD requests with deprecations may set both rm_operators and operator_packages.
+            # In that case both blocks run: remove deprecated operators first, then copy
+            # per-package content from the rebuilt index. The elif not rm_operators branch
+            # handles full-catalog copy for requests without removals.
             if rm_operators:
-                # Remove operators from the Git repo if an RM operation is requested
                 for operator_package in set(rm_operators):
                     operator_dir = os.path.join(repo_configs_dir, operator_package)
                     try:
                         shutil.rmtree(operator_dir)
                     except FileNotFoundError:
                         log.warning(f"Operator directory not found for removal: {operator_dir}")
-            elif operator_packages:
-                # Add content to the Git repo if an ADD or any other operation is requested
+
+            if operator_packages:
                 for operator_package in operator_packages:
                     src_pkg_dir = os.path.join(src_configs_path, operator_package)
                     dest_pkg_dir = os.path.join(repo_configs_dir, operator_package)
                     os.makedirs(dest_pkg_dir, exist_ok=True)
                     shutil.copytree(src_pkg_dir, dest_pkg_dir, dirs_exist_ok=True)
-            else:
-                # Add all content to the Git repo for ADD or any other operation
+            elif not rm_operators:
                 shutil.copytree(src_configs_path, repo_configs_dir)
 
             # Print git status to the logs

--- a/iib/workers/tasks/utils.py
+++ b/iib/workers/tasks/utils.py
@@ -447,6 +447,62 @@ def get_bundles_from_deprecation_list(bundles: List[str], deprecation_list: List
     return deprecate_bundles
 
 
+def _is_safe_operator_package_name(operator_package: str) -> bool:
+    """
+    Validate that an operator package name is safe to use as a catalog directory name.
+
+    :param str operator_package: operator package name from a bundle image label
+    :return: whether the package name can be used without path traversal
+    :rtype: bool
+    """
+    if not operator_package or operator_package in {'.', '..'}:
+        return False
+
+    if '..' in operator_package:
+        return False
+
+    if operator_package != Path(operator_package).name:
+        return False
+
+    # Operator package names become catalog directory names under configs/. Restrict to
+    # lowercase alphanumerics with optional internal dots/hyphens so the name cannot
+    # contain path separators or other filesystem-unsafe characters. Must start and
+    # end with alphanumeric to reject edge cases like ".foo" or "pkg." not caught above.
+    return re.match(r'^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$', operator_package) is not None
+
+
+def get_operator_packages_from_deprecation_list(deprecation_list: List[str]) -> List[str]:
+    """
+    Get operator package names declared in the deprecation list.
+
+    :param list deprecation_list: list of deprecated bundle pull specifications
+    :return: unique operator package names from the deprecation list
+    :rtype: list
+    """
+    operator_packages: List[str] = []
+    for pull_spec in deprecation_list:
+        operator_package = get_image_label(
+            pull_spec, 'operators.operatorframework.io.bundle.package.v1'
+        )
+        if operator_package:
+            if _is_safe_operator_package_name(operator_package):
+                operator_packages.append(operator_package)
+            else:
+                log.warning(
+                    'Skipping unsafe operator package name %r from deprecated bundle %s. '
+                    'The operator directory will not be removed from the Git catalog.',
+                    operator_package,
+                    pull_spec,
+                )
+        else:
+            log.warning(
+                'Could not determine operator package name for deprecated bundle %s. '
+                'The operator directory will not be removed from the Git catalog.',
+                pull_spec,
+            )
+    return list(dict.fromkeys(operator_packages))
+
+
 def get_resolved_bundles(bundles: List[str]) -> List[str]:
     """
     Get the pull specification of the bundle images using their digests.

--- a/tests/test_workers/test_tasks/test_build.py
+++ b/tests/test_workers/test_tasks/test_build.py
@@ -692,6 +692,8 @@ def test_buildah_fail_max_retries(mock_run_cmd: mock.MagicMock) -> None:
 )
 @pytest.mark.parametrize('distribution_scope', ('dev', 'stage', 'prod'))
 @pytest.mark.parametrize('deprecate_bundles', (True, False))
+@mock.patch('iib.workers.tasks.build.get_worker_config')
+@mock.patch('iib.workers.tasks.build.get_operator_packages_from_deprecation_list')
 @mock.patch('iib.workers.tasks.utils.get_list_bundles')
 @mock.patch('iib.workers.tasks.build.deprecate_bundles')
 @mock.patch('iib.workers.tasks.utils.get_resolved_bundles')
@@ -737,12 +739,18 @@ def test_handle_add_request(
     mock_ugrb,
     mock_dep_b,
     mock_glb,
+    mock_get_deprecated_ops,
+    mock_gwc,
     force_backport,
     binary_image,
     distribution_scope,
     deprecate_bundles,
 ):
     arches = {'amd64', 's390x'}
+    mock_gwc.return_value = {
+        'iib_registry': 'quay.io',
+        'iib_image_push_template': '{registry}/iib-build:{request_id}',
+    }
     binary_image_config = {'prod': {'v4.5': 'some_image'}}
     from_index_resolved = 'from-index@sha256:bcdefg'
     mock_iifbc.return_value = False
@@ -785,6 +793,7 @@ def test_handle_add_request(
         {"packageName": "test-operator", "version": "v1.2", "bundlePath": "bundle1"},
         {"packageName": "package2", "version": "v2.0", "bundlePath": "bundle2"},
     ]
+    mock_get_deprecated_ops.return_value = ['deprecated-operator'] if deprecate_bundles else []
 
     build.handle_add_request(
         bundles,
@@ -841,6 +850,16 @@ def test_handle_add_request(
         assert mock_pi.call_count == len(arches)
 
     mock_uiips.assert_called_once()
+    if deprecate_bundles:
+        expected_deprecation_bundles = [
+            'random_bundle@sha256:678',
+            'some-deprecation-bundle@sha256:456',
+        ]
+        mock_get_deprecated_ops.assert_called_once_with(expected_deprecation_bundles)
+        assert mock_uiips.call_args.kwargs['rm_operators'] == ['deprecated-operator']
+    else:
+        mock_get_deprecated_ops.assert_called_once_with([])
+        assert mock_uiips.call_args.kwargs['rm_operators'] is None
     mock_vii.assert_not_called()
     mock_sov.assert_called_once_with(from_index_resolved)
     mock_capml.assert_called_once_with(3, {'s390x', 'amd64'}, ["extra_tag1", "extra_tag2"])
@@ -850,11 +869,121 @@ def test_handle_add_request(
             bundles=['random_bundle@sha256:678', 'some-deprecation-bundle@sha256:456'],
             base_dir=mock.ANY,
             binary_image=binary_image or 'some_image',
-            from_index='registry:8443/iib-build:3-amd64',
+            from_index='quay.io/iib-build:3-amd64',
             container_tool='podman',
         )
     else:
         mock_dep_b.assert_not_called()
+
+
+@mock.patch('iib.workers.tasks.build.get_worker_config')
+@mock.patch('iib.workers.tasks.build.get_operator_packages_from_deprecation_list')
+@mock.patch('iib.workers.tasks.utils.get_list_bundles')
+@mock.patch('iib.workers.tasks.build.deprecate_bundles')
+@mock.patch('iib.workers.tasks.utils.get_resolved_bundles')
+@mock.patch('iib.workers.tasks.build._cleanup')
+@mock.patch('iib.workers.tasks.build.verify_labels')
+@mock.patch('iib.workers.tasks.build.prepare_request_for_build')
+@mock.patch('iib.workers.tasks.build._update_index_image_build_state')
+@mock.patch('iib.workers.tasks.build.opm_index_add')
+@mock.patch('iib.workers.tasks.build._build_image')
+@mock.patch('iib.workers.tasks.build._push_image')
+@mock.patch('iib.workers.tasks.build._verify_index_image')
+@mock.patch('iib.workers.tasks.build._update_index_image_pull_spec')
+@mock.patch('iib.workers.tasks.utils.set_request_state')
+@mock.patch('iib.workers.tasks.build.set_request_state')
+@mock.patch('iib.workers.tasks.build._create_and_push_manifest_list')
+@mock.patch('iib.workers.tasks.build.gate_bundles')
+@mock.patch('iib.workers.tasks.build.get_resolved_bundles')
+@mock.patch('iib.workers.tasks.build._add_label_to_index')
+@mock.patch('iib.workers.tasks.build._get_present_bundles')
+@mock.patch('iib.workers.tasks.build.set_registry_token')
+@mock.patch('iib.workers.tasks.build.is_image_fbc')
+@mock.patch('iib.workers.tasks.opm_operations.Opm.set_opm_version')
+def test_handle_add_request_passes_rm_operators_for_deprecation(
+    mock_sov,
+    mock_iifbc,
+    mock_srt,
+    mock_gpb,
+    mock_alti,
+    mock_grb,
+    mock_gb,
+    mock_capml,
+    mock_srs,
+    mock_srs2,
+    mock_uiips,
+    mock_vii,
+    mock_pi,
+    mock_bi,
+    mock_oia,
+    mock_uiibs,
+    mock_prfb,
+    mock_vl,
+    mock_cleanup,
+    mock_ugrb,
+    mock_dep_b,
+    mock_glb,
+    mock_get_deprecated_ops,
+    mock_gwc,
+):
+    arches = {'amd64'}
+    from_index_resolved = 'from-index@sha256:bcdefg'
+    deprecation_list = ['deprecated-bundle@sha256:456']
+    expected_deprecation_bundles = ['deprecated-bundle@sha256:456']
+    mock_gwc.return_value = {
+        'iib_registry': 'quay.io',
+        'iib_image_push_template': '{registry}/iib-build:{request_id}',
+    }
+    mock_iifbc.return_value = False
+    mock_prfb.return_value = {
+        'arches': arches,
+        'binary_image': 'binary-image:latest',
+        'binary_image_resolved': 'binary-image@sha256:abcdef',
+        'from_index_resolved': from_index_resolved,
+        'ocp_version': 'v4.5',
+        'distribution_scope': 'prod',
+    }
+    mock_grb.return_value = ['some-bundle@sha256:123']
+    mock_capml.return_value = 'quay.io/namespace/some-image:3'
+    mock_gpb.return_value = (
+        [{'bundlePath': 'deprecated-bundle@sha256:456'}],
+        ['deprecated-bundle@sha256:456'],
+    )
+    mock_ugrb.return_value = ['deprecated-bundle@sha256:456']
+    mock_get_deprecated_ops.return_value = ['deprecated-operator']
+    mock_glb.return_value = []
+
+    build.handle_add_request(
+        ['some-bundle:2.3-1'],
+        3,
+        'binary-image:latest',
+        'from-index:latest',
+        None,
+        'token',
+        'org',
+        False,
+        True,
+        'user:pass',
+        None,
+        {},
+        deprecation_list=deprecation_list,
+        index_to_gitlab_push_map={'from-index:latest': 'https://gitlab.example/repo.git'},
+    )
+
+    mock_get_deprecated_ops.assert_called_once_with(expected_deprecation_bundles)
+    mock_uiips.assert_called_once_with(
+        output_pull_spec=mock_capml.return_value,
+        request_id=3,
+        arches=arches,
+        from_index='from-index:latest',
+        overwrite_from_index=True,
+        overwrite_from_index_token='user:pass',
+        resolved_prebuild_from_index=from_index_resolved,
+        add_or_rm=True,
+        is_image_fbc=False,
+        index_repo_map={'from-index:latest': 'https://gitlab.example/repo.git'},
+        rm_operators=['deprecated-operator'],
+    )
 
 
 @mock.patch('iib.workers.tasks.build.update_request')
@@ -882,6 +1011,7 @@ def test_handle_add_request_raises(mock_iifbc, mock_runcmd, mock_c, mock_ur):
         )
 
 
+@mock.patch('iib.workers.tasks.build.get_operator_packages_from_deprecation_list')
 @mock.patch('iib.workers.tasks.build.get_worker_config')
 @mock.patch('iib.workers.tasks.utils.sqlite3.connect')
 @mock.patch('iib.workers.tasks.utils.run_cmd')
@@ -931,6 +1061,7 @@ def test_handle_add_request_check_index_label_behavior(
     mock_run_cmd,
     mock_sqlite,
     mock_gwc,
+    mock_get_deprecated_ops,
 ):
     arches = {'amd64', 's390x'}
     binary_image_config = {'prod': {'v4.5': 'some_image'}}
@@ -989,6 +1120,7 @@ def test_handle_add_request_check_index_label_behavior(
         }
     ]
     mock_sqlite.execute.return_value = 200
+    mock_get_deprecated_ops.return_value = ['deprecated-operator']
 
     build.handle_add_request(
         bundles,

--- a/tests/test_workers/test_tasks/test_git_utils.py
+++ b/tests/test_workers/test_tasks/test_git_utils.py
@@ -875,7 +875,11 @@ def test_push_configs_to_git_removing_content(
     mock_gwc,
     gitlab_url_mapping,
 ):
-    """Test push_configs_to_git when removing content (rm_operators provided)."""
+    """Test push_configs_to_git when removing content (rm_operators provided).
+
+    After removal, remaining operators from the rebuilt index image are copied into Git
+    so the repo stays aligned with the index catalog.
+    """
     mock_ggt.return_value = "foo", "bar"
     mock_cmd.return_value = "main"  # Mock git ls-remote output
     mock_clone.return_value = None
@@ -884,45 +888,27 @@ def test_push_configs_to_git_removing_content(
     # we don't want "finally" to be executed as it removes the temp repo
     mock_path_exists.return_value = False
 
-    # Mock the listdir calls for both source and repository configs
-    mock_listdir.side_effect = [
-        ["operator1", "operator2", "operator3"],  # Source configs (what's in the image)
-        [
-            "operator1",
-            "operator2",
-            "operator3",
-            "operator4",
-            "operator5",
-        ],  # Repo configs (what's in git)
-    ]
+    # Rebuilt index image retains only operators not removed by the RM request
+    mock_listdir.return_value = ["operator3"]
 
     with tempfile.TemporaryDirectory(prefix="test-push-configs-to-git") as temp_repo:
-        # Create source configs with some operators
         src_configs_dir = os.path.join(temp_repo, "src_configs")
         os.makedirs(src_configs_dir)
+        os.makedirs(os.path.join(src_configs_dir, "operator3"))
 
-        # Create operator directories in source
-        for op in ["operator1", "operator2", "operator3"]:
-            os.makedirs(os.path.join(src_configs_dir, op))
-
-        # Test removing content by providing rm_operators
         push_configs_to_git(
             request_id=1,
             from_index=PUB_INDEX_IMAGE,
             src_configs_path=src_configs_dir,
             index_repo_map=gitlab_url_mapping,
-            rm_operators=["operator1", "operator2"],  # This triggers removal mode
+            rm_operators=["operator1", "operator2"],
         )
 
-        # Verify the function was called with correct parameters
         mock_ggt.assert_called_once_with(PUB_GIT_REPO)
         mock_clone.assert_called_once_with(PUB_GIT_REPO, "latest", "foo", "bar", mock.ANY)
-        # configure_git_user is called with only one argument (local_repo_dir)
         mock_configure_git.assert_called_once_with(mock.ANY)
 
-        # Verify that commit_and_push was called with the correct parameters
         mock_commit_and_push.assert_called_once()
-        # commit_and_push is called with positional arguments, not keyword arguments
         call_args = mock_commit_and_push.call_args
         assert call_args[0][0] == 1  # request_id
         assert call_args[0][2] == PUB_GIT_REPO  # repo_url
@@ -932,6 +918,77 @@ def test_push_configs_to_git_removing_content(
             [
                 mock.call(RegexMatcher(r".*/configs/operator1$")),
                 mock.call(RegexMatcher(r".*/configs/operator2$")),
+            ],
+            any_order=True,
+        )
+        mock_shutil.copytree.assert_called_once_with(
+            os.path.join(src_configs_dir, "operator3"),
+            RegexMatcher(r".*/configs/operator3$"),
+            dirs_exist_ok=True,
+        )
+
+
+@mock.patch("iib.workers.tasks.git_utils.shutil")
+@mock.patch("iib.workers.tasks.git_utils.run_cmd")
+@mock.patch("iib.workers.tasks.git_utils.get_git_token")
+@mock.patch("iib.workers.tasks.git_utils.clone_git_repo")
+@mock.patch("iib.workers.tasks.git_utils.configure_git_user")
+@mock.patch("iib.workers.tasks.git_utils.commit_and_push")
+@mock.patch("iib.workers.tasks.git_utils.os.path.exists")
+@mock.patch("iib.workers.tasks.git_utils.os.listdir")
+def test_push_configs_to_git_add_and_remove(
+    mock_listdir,
+    mock_path_exists,
+    mock_commit_and_push,
+    mock_configure_git,
+    mock_clone,
+    mock_ggt,
+    mock_cmd,
+    mock_shutil,
+    mock_gwc,
+    gitlab_url_mapping,
+):
+    """Ensure add+deprecation removes stale operators and copies new catalog content."""
+    mock_ggt.return_value = "foo", "bar"
+    mock_cmd.return_value = "main"
+    mock_clone.return_value = None
+    mock_configure_git.return_value = None
+    mock_commit_and_push.return_value = None
+    mock_path_exists.return_value = False
+    mock_listdir.return_value = ["operator1", "operator2", "operator3"]
+
+    with tempfile.TemporaryDirectory(prefix="test-push-configs-to-git") as temp_repo:
+        src_configs_dir = os.path.join(temp_repo, "src_configs")
+        os.makedirs(src_configs_dir)
+        for op in ["operator1", "operator2", "operator3"]:
+            os.makedirs(os.path.join(src_configs_dir, op))
+
+        push_configs_to_git(
+            request_id=1,
+            from_index=PUB_INDEX_IMAGE,
+            src_configs_path=src_configs_dir,
+            index_repo_map=gitlab_url_mapping,
+            rm_operators=["operator4"],
+        )
+
+        mock_shutil.rmtree.assert_called_once_with(RegexMatcher(r".*/configs/operator4$"))
+        mock_shutil.copytree.assert_has_calls(
+            [
+                mock.call(
+                    os.path.join(src_configs_dir, "operator1"),
+                    RegexMatcher(r".*/configs/operator1$"),
+                    dirs_exist_ok=True,
+                ),
+                mock.call(
+                    os.path.join(src_configs_dir, "operator2"),
+                    RegexMatcher(r".*/configs/operator2$"),
+                    dirs_exist_ok=True,
+                ),
+                mock.call(
+                    os.path.join(src_configs_dir, "operator3"),
+                    RegexMatcher(r".*/configs/operator3$"),
+                    dirs_exist_ok=True,
+                ),
             ],
             any_order=True,
         )

--- a/tests/test_workers/test_tasks/test_utils.py
+++ b/tests/test_workers/test_tasks/test_utils.py
@@ -990,6 +990,21 @@ def testget_bundles_from_deprecation_list(mock_grb):
     mock_grb.assert_called_once_with(deprecation_list)
 
 
+@mock.patch('iib.workers.tasks.utils.get_image_label')
+def test_get_operator_packages_from_deprecation_list(mock_get_image_label):
+    mock_get_image_label.side_effect = ['safe-operator', 'unsafe/../op', '']
+    deprecation_list = [
+        'quay.io/bundle1@sha256:123',
+        'quay.io/bundle2@sha256:456',
+        'quay.io/bundle3@sha256:789',
+    ]
+
+    operator_packages = utils.get_operator_packages_from_deprecation_list(deprecation_list)
+
+    assert operator_packages == ['safe-operator']
+    assert mock_get_image_label.call_count == 3
+
+
 def test_chmod_recursiverly(tmpdir):
     # Create a directory structure like this:
     # spam-dir/


### PR DESCRIPTION
### Fix removal of deprecated operators from Git catalog during ADD requests

## Summary

When an ADD request includes a `deprecation_list`, deprecated operator directories were not removed from the linked Git catalog. The index image was updated correctly, but Git still contained stale operator content.

This PR fixes that in two parts:

- **`push_configs_to_git`**: Previously used mutually exclusive `if rm_operators` / `elif operator_packages` / `else` logic, so only one operation ran. It now removes operators listed in `rm_operators` and then copies operator packages from the rebuilt index image into Git. RM-only requests still work: the rebuilt catalog no longer contains removed operators, so they are not restored during copy.
- **`handle_add_request`**: Extracts operator package names from the user-provided `deprecation_list` via new helper `get_operator_packages_from_deprecation_list()` and passes them as `rm_operators` to `_update_index_image_pull_spec` during overwrite. Uses the original deprecation list (not resolved `deprecation_bundles`) to avoid manifest-list digest mismatches.

The new helper validates operator package names before using them as directory names (path traversal protection).

## Test plan

- [x] Unit tests for `get_operator_packages_from_deprecation_list` (safe names, unsafe names, missing labels)
- [x] Unit tests for `push_configs_to_git` with `rm_operators` only (remove + copy remaining operators)
- [x] Unit test for simultaneous add + remove in `push_configs_to_git`
- [x] Unit tests for `handle_add_request` verifying `rm_operators` is passed when deprecations are present
- [x] Manual verification: ADD request with `deprecation_list` on FBC index linked to Git — deprecated operator dir removed from Git repo, new/remaining operators synced
