### PR TITLE
Pin GitHub Actions to commit digests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ jobs:
 
     steps:
       - name: Get latest tag
-        uses: oprypin/find-latest-tag@v1
+        # oprypin/find-latest-tag@v1.1.3
+        uses: oprypin/find-latest-tag@6957ac556fa6d349727ecabfcaaf9f8e5ee37124
         with:
           repository: release-engineering/iib
           releases-only: true
@@ -27,13 +28,15 @@ jobs:
         id: iibtag
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        # actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           ref: ${{ github.event.release.tag_name || steps.iibtag.outputs.tag }}
 
       - name: Build iib-worker
         id: build-iib-worker
-        uses: redhat-actions/buildah-build@v2
+        # redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4
         with:
           image: iib-worker
           tags: ${{ github.event.release.tag_name || steps.iibtag.outputs.tag }} latest
@@ -42,7 +45,8 @@ jobs:
 
       - name: Build iib-api
         id: build-iib-api
-        uses: redhat-actions/buildah-build@v2
+        # redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4
         with:
           image: iib-api
           tags: ${{ github.event.release.tag_name || steps.iibtag.outputs.tag }} latest
@@ -51,7 +55,8 @@ jobs:
 
       - name: Build iib-message-broker
         id: build-iib-message-broker
-        uses: redhat-actions/buildah-build@v2
+        # redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4
         with:
           image: iib-message-broker
           tags: ${{ github.event.release.tag_name || steps.iibtag.outputs.tag }} latest

--- a/.github/workflows/build_base_image.yml
+++ b/.github/workflows/build_base_image.yml
@@ -32,11 +32,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
       - name: Build iib-base-image
         id: build-iib-base-image
-        uses: redhat-actions/buildah-build@v2
+        # redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4
         with:
           image: iib-base-image
           tags: latest

--- a/.github/workflows/build_on_main.yml
+++ b/.github/workflows/build_on_main.yml
@@ -31,11 +31,13 @@ jobs:
     outputs:
       base_image: ${{ steps.filter.outputs.base_image }}
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout@v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           # Full history so paths-filter can diff against the previous commit on main.
           fetch-depth: 0
-      - uses: dorny/paths-filter@v3
+      # dorny/paths-filter@v3.0.4
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad
         id: filter
         with:
           filters: |
@@ -58,11 +60,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
       - name: Build iib-api
         id: build-iib-api
-        uses: redhat-actions/buildah-build@v2
+        # redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4
         with:
           image: iib-api
           tags: ocp-latest
@@ -91,11 +95,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
       - name: Build iib-worker
         id: build-iib-worker
-        uses: redhat-actions/buildah-build@v2
+        # redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4
         with:
           image: iib-worker
           tags: ocp-latest

--- a/.github/workflows/build_on_tag.api.yml
+++ b/.github/workflows/build_on_tag.api.yml
@@ -14,13 +14,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # actions/checkout@v6.1.0
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Build iib-api
         id: build-iib-api
-        uses: redhat-actions/buildah-build@v2
+        # redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4
         with:
           image: iib-api
           tags: qe

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -40,7 +40,8 @@ jobs:
     if: >-
       github.event_name != 'issue_comment'
       || github.event.comment.user.type != 'Bot'
-    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@v0
+    # fullsend-ai/fullsend@v0.35.1 (reusable-dispatch.yml)
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@19b3583154c39bed631455ca9e219dc512a16005
     with:
       event_action: ${{ github.event.action }}
       install_mode: per-repo

--- a/.github/workflows/run_tox.yml
+++ b/.github/workflows/run_tox.yml
@@ -17,9 +17,11 @@ jobs:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
+      # actions/checkout@v6.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        # actions/setup-python@v6.3.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Replace floating action tags (@v6, @v2, @v3, @v1, @v0) with resolved 40-character SHAs and add version comments above each uses: entry.


Assisted-by: Cursor, Composer 2.5