### PR TITLE
Add Hadolint for Dockerfiles

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,17 @@
+---
+# Hadolint config for IIB Dockerfiles (UBI-based).
+ignored:
+  # DL3003: `cd ...` in RUN — UBI build steps intentionally change dirs mid-RUN
+  #         where `WORKDIR` would leak state into later layers.
+  - DL3003
+  # DL3013: pin pip versions — pip is provided/managed by the UBI base image.
+  - DL3013
+  # DL3041: use `dnf install -y` with versions/no cache — UBI dnf handling and
+  #         module streams make strict version pinning impractical here.
+  - DL3041
+  # DL4006: require `SHELL -o pipefail` before a RUN that pipes commands — none of
+  #         these Dockerfiles use a pipe in RUN, so the pipefail SHELL is unnecessary.
+  - DL4006
+trustedRegistries:
+  - registry.access.redhat.com
+  - registry.redhat.io

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Additionally, `black` is used to enforce other coding standards with the followi
 
 * Single quotes are used instead of double quotes
 
-To verify that your code meets these standards, you may run `tox -e black,flake8`.
+To verify that your code meets these standards, you may run `tox -m static`, which runs all the
+static linters (`black`, `flake8`, `yamllint`, `mypy`, and `hadolint`).
 
 ## Running the Unit Tests
 

--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,4 +1,7 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+# Base layer pinned by digest (ubi8/ubi:latest as of this pin). Note the `dnf update -y`
+# below still pulls current packages, so the full image is not bit-for-bit reproducible.
+# Keep this digest in lockstep with the other Dockerfiles when bumping.
+FROM registry.access.redhat.com/ubi8/ubi@sha256:e39486422f729b5c5b7c007104d2f9c92a14273b1de01cdc28d4ac648fb6e1dd
 LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src
@@ -22,15 +25,15 @@ RUN dnf -y install \
     python3.12-setuptools \
     && dnf update -y \
     && dnf clean all
-RUN update-alternatives --set python3 $(which python3.12)
+RUN update-alternatives --set python3 "$(which python3.12)"
 
 COPY . .
 COPY ./docker/iib-httpd.conf /etc/httpd/conf/httpd.conf
 
 # default python3-pip version for rhel8 python3.8 is 19.3.1 and it can't be updated by dnf
 # we have to update it by pip to version above 21.0.0
-RUN pip3 install --upgrade pip
-RUN pip3 install -r requirements.txt --no-deps --require-hashes
-RUN pip3 install . --no-deps
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir -r requirements.txt --no-deps --require-hashes
+RUN pip3 install --no-cache-dir . --no-deps
 EXPOSE 8080
 CMD ["/usr/sbin/httpd", "-DFOREGROUND"]

--- a/docker/Dockerfile-workers
+++ b/docker/Dockerfile-workers
@@ -1,4 +1,7 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+# Base layer pinned by digest (ubi8/ubi:latest as of this pin). Note the `dnf update -y`
+# below still pulls current packages, so the full image is not bit-for-bit reproducible.
+# Keep this digest in lockstep with the other Dockerfiles when bumping.
+FROM registry.access.redhat.com/ubi8/ubi@sha256:e39486422f729b5c5b7c007104d2f9c92a14273b1de01cdc28d4ac648fb6e1dd
 LABEL maintainer="Red Hat - EXD"
 
 WORKDIR /src
@@ -37,7 +40,7 @@ RUN cd /usr/bin && tar -xf /src/grpcurl_1.8.5_linux_x86_64.tar.gz grpcurl && rm 
 ADD https://github.com/operator-framework/operator-sdk/releases/download/v1.15.0/operator-sdk_linux_amd64 /usr/bin/operator-sdk
 RUN chmod +x /usr/bin/operator-sdk
 
-RUN update-alternatives --set python3 $(which python3.12)
+RUN update-alternatives --set python3 "$(which python3.12)"
 
 # Adjust storage.conf to enable Fuse storage.
 RUN sed -i -e 's|^#mount_program|mount_program|g' /etc/containers/storage.conf
@@ -47,7 +50,7 @@ COPY . .
 
 # default python3-pip version for rhel8 python3.6 is 9.0.3 and it can't be updated by dnf
 # we have to update it by pip to version above 21.0.0
-RUN pip3 install --upgrade pip
-RUN pip3 install -r requirements.txt --no-deps --require-hashes
-RUN pip3 install . --no-deps
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 install --no-cache-dir -r requirements.txt --no-deps --require-hashes
+RUN pip3 install --no-cache-dir . --no-deps
 CMD ["/bin/celery-3", "-A", "iib.workers.tasks", "worker", "--loglevel=info"]

--- a/docker/message_broker/Dockerfile
+++ b/docker/message_broker/Dockerfile
@@ -1,11 +1,14 @@
 # Based from https://github.com/rmohr/docker-activemq
-FROM registry.access.redhat.com/ubi8/ubi:latest
+# Base layer pinned by digest (ubi8/ubi:latest as of this pin). Note the `dnf update -y`
+# below still pulls current packages, so the full image is not bit-for-bit reproducible.
+# Keep this digest in lockstep with the other Dockerfiles when bumping.
+FROM registry.access.redhat.com/ubi8/ubi@sha256:e39486422f729b5c5b7c007104d2f9c92a14273b1de01cdc28d4ac648fb6e1dd
 
 ENV ACTIVEMQ_VERSION 5.15.12
 ENV ACTIVEMQ_HOME /opt/activemq
 
 # keeping container image updated (security updates)
-RUN  dnf install java-1.8.0-openjdk maven -y && dnf update -y
+RUN  dnf install java-1.8.0-openjdk maven -y && dnf update -y && dnf clean all
 
 RUN curl "https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz" -o activemq-bin.tar.gz
 RUN tar xzf activemq-bin.tar.gz -C  /opt && \

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,18 @@
 [tox]
 min_version = 4.0
 skip_missing_interpreters = true
-envlist = black,docs,flake8,py312,py312,safety,yamllint,bandit, mypy
+envlist = black,docs,flake8,py312,py313,safety,yamllint,bandit,mypy,hadolint
 downloadcache = {toxworkdir}/_download/
 labels =
     test = unit_tests
-    static = black, flake8, yamllint, mypy
+    static = black, flake8, yamllint, mypy, hadolint
     security = bandit
     docs = docs
 
 [gh-actions]
 python =
-    3.12: py312, black, flake8, mypy, yamllint, bandit, safety, docs, unit_tests
-    3.13: py312, black, flake8, mypy, yamllint, bandit, safety, docs, unit_tests
+    3.12: py312, black, flake8, mypy, yamllint, bandit, safety, docs, unit_tests, hadolint
+    3.13: py313, black, flake8, mypy, yamllint, bandit, safety, docs, unit_tests, hadolint
 
 [testenv]
 usedevelop = true
@@ -107,6 +107,14 @@ deps =
     bandit
 commands =
     bandit -ll -r .
+
+[testenv:hadolint]
+description = Dockerfile linting [Mandatory]
+skip_install = true
+deps =
+    hadolint-py==2.15.1.2
+commands =
+    hadolint --failure-threshold warning docker/Dockerfile-api docker/Dockerfile-workers docker/message_broker/Dockerfile
 
 [testenv:mypy]
 description = type check iib


### PR DESCRIPTION
Add Hadolint for Dockerfiles and fix the errors
Removed the duplicate py12 entry in tox envlist
Corrected the gh-actions 3.13 mapping to run on 3.13

Assisted-by: Cursor