### PR TITLE
Disable registration of old handle_ functions

### DIFF
--- a/iib/workers/tasks/build.py
+++ b/iib/workers/tasks/build.py
@@ -22,7 +22,8 @@ from iib.common.tracing import instrument_tracing
 from iib.exceptions import IIBError, ExternalServiceError
 from iib.workers.api_utils import set_request_state, update_request
 from iib.workers.config import get_worker_config
-from iib.workers.tasks.celery import app
+
+# from iib.workers.tasks.celery import app
 from iib.workers.greenwave import gate_bundles
 from iib.workers.tasks.fbc_utils import (
     is_image_fbc,
@@ -777,7 +778,7 @@ def inspect_related_images(
         raise IIBError(f"IIB cannot access the following related images {invalid_related_images}")
 
 
-@app.task
+# @app.task
 @request_logger
 @instrument_tracing(span_name="workers.tasks.handle_add_request", attributes=get_binary_versions())
 def handle_add_request(
@@ -1078,7 +1079,7 @@ def handle_add_request(
     )
 
 
-@app.task
+# @app.task
 @request_logger
 @instrument_tracing(span_name="workers.tasks.handle_rm_request", attributes=get_binary_versions())
 def handle_rm_request(

--- a/iib/workers/tasks/build_create_empty_index.py
+++ b/iib/workers/tasks/build_create_empty_index.py
@@ -16,7 +16,8 @@ from iib.workers.tasks.build import (
     _update_index_image_build_state,
     _update_index_image_pull_spec,
 )
-from iib.workers.tasks.celery import app
+
+# from iib.workers.tasks.celery import app
 from iib.workers.tasks.fbc_utils import is_image_fbc
 from iib.workers.tasks.opm_operations import (
     opm_create_empty_fbc,
@@ -36,7 +37,7 @@ __all__ = ['handle_create_empty_index_request']
 log = logging.getLogger(__name__)
 
 
-@app.task
+# @app.task
 @request_logger
 @instrument_tracing(
     span_name="workers.tasks.handle_create_empty_index_request", attributes=get_binary_versions()

--- a/iib/workers/tasks/build_fbc_operations.py
+++ b/iib/workers/tasks/build_fbc_operations.py
@@ -15,7 +15,8 @@ from iib.workers.tasks.build import (
     _update_index_image_build_state,
     _update_index_image_pull_spec,
 )
-from iib.workers.tasks.celery import app
+
+# from iib.workers.tasks.celery import app
 from iib.workers.tasks.opm_operations import opm_registry_add_fbc_fragment, Opm
 from iib.workers.tasks.utils import (
     get_resolved_image,
@@ -30,7 +31,7 @@ __all__ = ['handle_fbc_operation_request']
 log = logging.getLogger(__name__)
 
 
-@app.task
+# @app.task
 @request_logger
 @instrument_tracing(
     span_name="workers.tasks.build.handle_fbc_operation_request", attributes=get_binary_versions()

--- a/iib/workers/tasks/build_merge_index_image.py
+++ b/iib/workers/tasks/build_merge_index_image.py
@@ -40,7 +40,8 @@ from iib.workers.tasks.build import (
     _update_index_image_build_state,
     _update_index_image_pull_spec,
 )
-from iib.workers.tasks.celery import app
+
+# from iib.workers.tasks.celery import app
 from iib.workers.tasks.fbc_utils import is_image_fbc
 from iib.workers.tasks.utils import (
     add_max_ocp_version_property,
@@ -273,7 +274,7 @@ def _add_bundles_missing_in_source(
     return missing_bundles, invalid_bundles
 
 
-@app.task
+# @app.task
 @request_logger
 @instrument_tracing(
     span_name="workers.tasks.build.handle_merge_request", attributes=get_binary_versions()

--- a/iib/workers/tasks/build_regenerate_bundle.py
+++ b/iib/workers/tasks/build_regenerate_bundle.py
@@ -23,7 +23,8 @@ from iib.workers.tasks.build import (
     _copy_files_from_image,
 )
 from iib.workers.config import get_worker_config
-from iib.workers.tasks.celery import app
+
+# from iib.workers.tasks.celery import app
 from iib.workers.tasks.utils import (
     get_image_labels,
     get_resolved_image,
@@ -51,7 +52,7 @@ yaml.preserve_quotes = True
 log = logging.getLogger(__name__)
 
 
-@app.task
+# @app.task
 @request_logger
 @instrument_tracing(
     span_name="workers.tasks.build.handle_regenerate_bundle_request",


### PR DESCRIPTION
Disable registration of old handle_ functions 

We should disable registration of old functions to Celery to prevent calling unsupported functions on OCP. 